### PR TITLE
LTG-35: add account created successfully page

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -12,8 +12,7 @@
     },
     "yes": "Yes",
     "no": "No",
-    "footer": {
-    },
+    "footer": {},
     "cookie": {
       "cookieText": "GOV.UK uses cookies to make the site simpler.",
       "cookieLink": "#",
@@ -59,14 +58,14 @@
           "email": "Enter an email address in the correct format, like name@example.com"
         }
       },
-      "details" : {
+      "details": {
         "summary": "A GOV.UK Account will:",
         "bulletPoint1": "let you reuse and share your data to ensure that government services are quicker to interact with",
         "bulletPoint2": "suggest GOV.UK guidance and information that is relevant to you",
         "bulletPoint3": "tell you when content you're interested in has been updated",
         "bulletPoint4": "help you set up reminders for tasks you may need to complete later"
       },
-      "whatYouNeed" : {
+      "whatYouNeed": {
         "summary": "What you need to create a GOV.UK Account",
         "bulletPoint1": "an email address",
         "bulletPoint2": "a working UK phone number with signal, so we can send you a security code"
@@ -82,7 +81,7 @@
           "required": "Enter your password"
         }
       },
-      "securePasswordDetails" : {
+      "securePasswordDetails": {
         "summary": "I've forgotten my password",
         "text": "Put something useful here"
       }
@@ -120,8 +119,8 @@
       "title": "Create a GOV.UK Account",
       "header": "Enter your phone number",
       "info": {
-          "paragraph1": "This is the number we will send 6-digit security codes to.",
-          "paragraph2": "It can be either a mobile or landline, but it needs to be a UK number, with signal."
+        "paragraph1": "This is the number we will send 6-digit security codes to.",
+        "paragraph2": "It can be either a mobile or landline, but it needs to be a UK number, with signal."
       },
       "phoneNumber": {
         "label": "UK phone number",
@@ -129,7 +128,17 @@
           "required": "Enter a UK phone number"
         }
       }
+    },
+    "registerAccountCreated": {
+      "title": "You have successfully created your GOV.UK Account",
+      "header": "You have successfully created your GOV.UK Account",
+      "info": {
+        "heading": "A GOV.UK Account will:",
+        "bulletPoint1": "let you reuse and share your data to ensure that government services are quicker to interact with",
+        "bulletPoint2": "suggest GOV.UK guidance and information that is relevant to you",
+        "bulletPoint3": "tell you when content you're interested in has been updated",
+        "bulletPoint4": "help you set up reminders for tasks you may need to complete later"
+      }
     }
   }
 }
-

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -8,6 +8,7 @@ export const PATH_NAMES = {
   CREATE_ACCOUNT_CHECK_EMAIL: "/check-email",
   CREATE_ACCOUNT_SET_PASSWORD: "/create-password",
   CREATE_ACCOUNT_ENTER_PHONE_NUMBER: "/enter-phone-number",
+  CREATE_ACCOUNT_SUCCESSFUL: "/account-created"
 };
 
 export const HTTP_STATUS_CODES = {

--- a/src/controllers/register-account-created-controller.ts
+++ b/src/controllers/register-account-created-controller.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from "express";
+
+const ACCOUNT_CREATED_TEMPLATE_NAME = "register-account-created.html";
+
+export function registerAccountCreatedGet(req: Request, res: Response): void {
+  res.render(ACCOUNT_CREATED_TEMPLATE_NAME);
+}
+
+export function registerAccountCreatedPost(req: Request, res: Response): void {
+  // TODO: redirect back to the service
+}

--- a/src/controllers/register-create-password-controller.ts
+++ b/src/controllers/register-create-password-controller.ts
@@ -73,9 +73,12 @@ export function createAccountPost(
           req.body["password"]
         )
       ) {
-        return res.redirect(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER);
+        if (req.session.user.email.includes("no2fa")) {
+          return res.redirect(PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL);
+        } else {
+          return res.redirect(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER);
+        }
       }
-
       return res.redirect(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD);
     } catch (err) {
       next(err);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -25,6 +25,7 @@ import {
   createSessionMiddleware,
   validateSessionMiddleware,
 } from "./middleware/session-middleware";
+import {registerAccountCreatedGet, registerAccountCreatedPost} from "./controllers/register-account-created-controller";
 
 const basicMiddlewarePipeline = [validateSessionMiddleware, csrfMiddleware];
 
@@ -74,6 +75,17 @@ router.get(
   PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
   csrfMiddleware,
   enterPhoneNumberGet
+);
+
+router.get(
+  PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL,
+  basicMiddlewarePipeline,
+  registerAccountCreatedGet
+);
+router.post(
+  PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL,
+  basicMiddlewarePipeline,
+  registerAccountCreatedPost
 );
 
 //footer pages

--- a/src/views/register-account-created.html
+++ b/src/views/register-account-created.html
@@ -1,0 +1,38 @@
+{% extends "base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% block content %}
+
+{% include "errors/errorSummary.njk" %}
+
+<form action="/account-created" method="post" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{csrfToken}}" />
+
+    {{ govukPanel({
+        titleText: 'pages.registerAccountCreated.header' | translate
+    }) }}
+
+    <br>
+
+    <p class="govuk-body">{{'pages.registerAccountCreated.info.heading' | translate}}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{'pages.registerAccountCreated.info.bulletPoint1' | translate}}</li>
+        <li>{{'pages.registerAccountCreated.info.bulletPoint2' | translate}}</li>
+        <li>{{'pages.registerAccountCreated.info.bulletPoint3' | translate}}</li>
+        <li>{{'pages.registerAccountCreated.info.bulletPoint4' | translate}}</li>
+    </ul>
+
+    <br>
+
+    {{ govukButton({
+        "text": button_text|default('general.continue.label' | translate, true),
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
+
+</form>
+
+{% endblock %}


### PR DESCRIPTION
## What

Add 'account created successfully' page.
When 2FA not required navigate to this page after 'enter password', otherwise navigate to 'enter phone number'.
In order to test the flow include 'no2fa' in the email to simulate a client not requiring 2FA.

## Why

- Given that the user has successfully created their password AND the service that the user requires only Email and Password for to access their service, When they select “Continue”, Then an account must be created for the user AND they should be directed to “You have successfully created your GOV.UK account” UI.