### PR TITLE
BAU: add script to launch the app locally with a session id

### DIFF
--- a/session-start-local.sh
+++ b/session-start-local.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eu
+
+set -o allexport
+source .env
+set +o allexport
+
+redirect=$(curl -Ls -o /dev/null -w %{url_effective} $API_BASE_URL/authorize\?response_type\=code\&redirect_uri\=http%3A%2F%2Flocalhost%3A8080\&state\=T7HEWmyE8GS2LCClCgFzAEuESAtC5p2tf00Te_O5-4w\&client_id\=test-id\&client_name\=client-name\&scope\=openid+profile+email)
+
+query_params="$(cut -d'?' -f2 <<<"$redirect")"
+
+open "http://localhost:3000/?$query_params"


### PR DESCRIPTION
## What 

Add script to launch the app locally with a session id

## Why

If running a local node app against the remote API a session id is required from the API in order to run the flow.  This script retrieves the session id and passes it to the local app.
