### PR TITLE
Fix path for views for deployment

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -34,7 +34,7 @@ import { serverErrorHandler } from "./handlers/internal-server-error-handler";
 dotenv.config();
 
 const APP_VIEWS = [
-  "src/components",
+  path.join(__dirname, "components"),
   path.resolve("node_modules/govuk-frontend/"),
 ];
 


### PR DESCRIPTION
The deployment of the app to paas can't find the path to where the views live so throws an error. This PR fixes that.