### PR TITLE
Fix path to load translations

### DIFF
--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -8,7 +8,7 @@ export const i18nextConfigurationOptions = {
   preload: [LOCALE.EN],
   supportedLngs: [LOCALE.EN, LOCALE.CY],
   backend: {
-    loadPath: path.resolve(__dirname, "../../locales/{{lng}}/{{ns}}.json"),
+    loadPath: path.join(__dirname, "../../locales/{{lng}}/{{ns}}.json"),
     allowMultiLoading: true,
   },
   detection: {


### PR DESCRIPTION
## What?

The path to the translation files is broken when deployed.

## Why?

To allow pages to be translated properly.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
