### PR TITLE
LTG-371: tweak 'check your email' to look like prototype

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -18,6 +18,21 @@
   <![endif]-->
 {% endblock %}
 
+{% block pageTitle %}
+    {% if error or errors %}
+        {{ 'general.errorTitlePrefix' | translate }}
+        -
+    {% endif %}
+    {% if pageTitleName %}
+        {{ pageTitleName }}
+        -
+    {% endif %}
+    {{ 'general.serviceName' | translate }}
+    -
+    {{ 'general.provider' | translate }}
+{% endblock %}
+
+
 {% block header %}
   {{ govukHeader({
   homepageUrl: "#",

--- a/src/components/register-verify-email/index.njk
+++ b/src/components/register-verify-email/index.njk
@@ -12,12 +12,13 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.verifyEmail.header' | translate}}</h1>
 
 {{ govukInsetText({
-    text: 'pages.verifyEmail.text' | translate
+    html: 'pages.verifyEmail.text' | translate + '<span class="govuk-body govuk-!-font-weight-bold">' + email + '</span>'
   }) }}
 
 <p class="govuk-body">{{'pages.verifyEmail.info.paragraph1' | translate}}</p>
 <p class="govuk-body">{{'pages.verifyEmail.info.paragraph2' | translate}}</p>
 <p class="govuk-body">{{'pages.verifyEmail.info.paragraph3' | translate}}</p>
+<p class="govuk-body">{{'pages.verifyEmail.info.paragraph4' | translate | replace("#SOMETHING", '<a class="govuk-link" href="enter-email" rel="noreferrer noopener" target="_blank">enter your email address again</a>') | safe }}</p>
 
 <form action="/check-your-email" method="post" novalidate>
 

--- a/src/components/register-verify-email/index.njk
+++ b/src/components/register-verify-email/index.njk
@@ -5,6 +5,8 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
+{% set pageTitleName = 'pages.verifyEmail.title' | translate %}
+
 {% block content %}
 
 {% include "common/errors/errorSummary.njk" %}
@@ -18,7 +20,10 @@
 <p class="govuk-body">{{'pages.verifyEmail.info.paragraph1' | translate}}</p>
 <p class="govuk-body">{{'pages.verifyEmail.info.paragraph2' | translate}}</p>
 <p class="govuk-body">{{'pages.verifyEmail.info.paragraph3' | translate}}</p>
-<p class="govuk-body">{{'pages.verifyEmail.info.paragraph4' | translate | replace("#SOMETHING", '<a class="govuk-link" href="enter-email" rel="noreferrer noopener" target="_blank">enter your email address again</a>') | safe }}</p>
+<p class="govuk-body">{{'pages.verifyEmail.info.paragraph4Start' | translate }}
+    <a href="/enter-email" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.verifyEmail.info.enterEmailLink' | translate }}</a>
+    {{'pages.verifyEmail.info.paragraph4End' | translate }}
+</p>
 
 <form action="/check-your-email" method="post" novalidate>
 

--- a/src/components/register-verify-email/index.njk
+++ b/src/components/register-verify-email/index.njk
@@ -19,10 +19,9 @@
 
 <p class="govuk-body">{{'pages.verifyEmail.info.paragraph1' | translate}}</p>
 <p class="govuk-body">{{'pages.verifyEmail.info.paragraph2' | translate}}</p>
-<p class="govuk-body">{{'pages.verifyEmail.info.paragraph3' | translate}}</p>
-<p class="govuk-body">{{'pages.verifyEmail.info.paragraph4Start' | translate }}
+<p class="govuk-body">{{'pages.verifyEmail.info.paragraph3Start' | translate }}
     <a href="/enter-email" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.verifyEmail.info.enterEmailLink' | translate }}</a>
-    {{'pages.verifyEmail.info.paragraph4End' | translate }}
+    {{'pages.verifyEmail.info.paragraph3End' | translate }}
 </p>
 
 <form action="/check-your-email" method="post" novalidate>

--- a/src/components/register-verify-email/register-verify-email-controller.ts
+++ b/src/components/register-verify-email/register-verify-email-controller.ts
@@ -1,7 +1,9 @@
 import { Request, Response } from "express";
 
 export function registerVerifyEmailGet(req: Request, res: Response): void {
-  res.render("register-verify-email/index.njk");
+  res.render("register-verify-email/index.njk", {
+    email: req.session.user.email,
+  });
 }
 
 export function registerVerifyEmailPost(req: Request, res: Response): void {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,8 +1,10 @@
 {
   "general": {
+    "provider": "GOV.UK",
+    "serviceName": "GOV.UK Sign in",
     "pageTitle": "GOV.UK Sign in",
     "serviceName": "Sign in to or create your GOV.UK Account",
-    "errorPrefix": "Error",
+    "errorTitlePrefix": "Error",
     "back": "Back",
     "warning": "Warning",
     "errorSummaryTitle": "There is a problem",
@@ -149,7 +151,9 @@
         "paragraph1": "The email contains a 6-digit security code.",
         "paragraph2": "Once you have opened the email and retrieved the code, return to this page and enter the security code sent below to activate your account.",
         "paragraph3": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
-        "paragraph4": "You can <a href=\"/enter-email\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">enter your email address again</a> if you got it wrong."
+        "paragraph4Start": "You can ",
+        "enterEmailLink": "enter your email address again",
+        "paragraph4End": " if you got it wrong."
       },
       "code": {
         "label": "Enter the 6 digit security code",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -148,12 +148,11 @@
       "header": "Check your email",
       "text": "We have sent an email to: ",
       "info": {
-        "paragraph1": "The email contains a 6-digit security code.",
-        "paragraph2": "Once you have opened the email and retrieved the code, return to this page and enter the security code sent below to activate your account.",
-        "paragraph3": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
-        "paragraph4Start": "You can ",
+        "paragraph1": "Once you have opened the email and got the code, come back to this page and enter the security code below.",
+        "paragraph2": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
+        "paragraph3Start": "You can ",
         "enterEmailLink": "enter your email address again",
-        "paragraph4End": " if you got it wrong."
+        "paragraph3End": " if you got it wrong."
       },
       "code": {
         "label": "Enter the 6 digit security code",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -146,9 +146,10 @@
       "header": "Check your email",
       "text": "We have sent an email to: ",
       "info": {
-        "paragraph1": "Follow the link in the email to activate your GOV.UK account. You will need to create a password for your account.",
-        "paragraph2": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
-        "paragraph3": "You can enter your email address again if you got it wrong."
+        "paragraph1": "The email contains a 6-digit security code.",
+        "paragraph2": "Once you have opened the email and retrieved the code, return to this page and enter the security code sent below to activate your account.",
+        "paragraph3": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
+        "paragraph4": "You can <a href=\"/enter-email\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">enter your email address again</a> if you got it wrong."
       },
       "code": {
         "label": "Enter the 6 digit security code",


### PR DESCRIPTION
## What?

Tweak 'check your email' to look like prototype.
Make sure all text and fonts are correct.
Include the email address entered on the previous page.

## Why?

Page must conform to the design.
