### PR TITLE
Fix for CSP issue in base layout for gov frontend

### DIFF
--- a/src/config/helmet.ts
+++ b/src/config/helmet.ts
@@ -8,6 +8,7 @@ export const helmetConfiguration: Parameters<typeof helmet>[0] = {
       styleSrc: ["'self'"],
       scriptSrc: [
         "'self'",
+        "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='",
         "https://www.googletagmanager.com",
         "https://www.google-analytics.com",
         "https://ssl.google-analytics.com",


### PR DESCRIPTION
## What?

Add sha for inline script in helmet config.

## Why?

In the base template for gov.uk frontend there is a inline script which is not allowed with the CSP policy the app has in place. This has been fixed by adding the sha value to the helmet config.

For more info refer to https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-is-not-working-properly
