### PR TITLE
BAU: Change 'userexists' endpoint to user-exists.

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -26,7 +26,7 @@ export enum LOCALE {
 }
 
 export const API_ENDPOINTS = {
-  USER_EXISTS: "/userexists",
+  USER_EXISTS: "/user-exists",
   SIGNUP_USER: "/signup",
   SEND_NOTIFICATION: "/send-notification",
 };

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -95,7 +95,7 @@ describe("Integration::enter email", () => {
   });
 
   it("should redirect to enter password page when email address exists", (done) => {
-    nock(baseApi).post("/userexists").once().reply(200, {
+    nock(baseApi).post("/user-exists").once().reply(200, {
       email: "test@test.com",
       doesUserExist: true,
       sessionState: "USER_FOUND",
@@ -115,7 +115,7 @@ describe("Integration::enter email", () => {
 
   it("should redirect to check your email when email address not found", (done) => {
     nock(baseApi)
-      .post("/userexists")
+      .post("/user-exists")
       .once()
       .reply(200, {
         email: "test@test.com",


### PR DESCRIPTION
## What?

Change 'userexists' endpoint to user-exists.

## Why?

Keep API resource path names consistent.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/109