### PR TITLE
Update all cookies security options

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -27,5 +27,6 @@ jobs:
       - name: Run lint
         run: yarn lint
     env:
-      ENVIRONMENT: DEVELOPMENT
+      ENVIRONMENT: development
       API_BASE_URL: http://localhost:6000/api
+      SESSION_SECRET: secret

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -57,3 +57,8 @@ export const USER_STATE = {
 export enum NOTIFICATION_TYPE {
   VERIFY_EMAIL = "VERIFY_EMAIL",
 }
+
+export const ENVIRONMENT_NAME = {
+  PROD: "production",
+  DEV: "development",
+};

--- a/src/components/create-password/tests/create-password-integration.test.ts
+++ b/src/components/create-password/tests/create-password-integration.test.ts
@@ -43,6 +43,7 @@ describe("Integration::register create password", () => {
 
   after(() => {
     sandbox.restore();
+    app = undefined;
   });
 
   it("should return create password page", (done) => {

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -42,6 +42,7 @@ describe("Integration::enter email", () => {
 
   after(() => {
     sandbox.restore();
+    app = undefined;
   });
 
   it("should return enter email page", (done) => {

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -46,6 +46,7 @@ describe("Integration::enter password", () => {
 
   after(() => {
     sandbox.restore();
+    app = undefined;
   });
 
   it("should return enter password page", (done) => {

--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
-import { HTTP_STATUS_CODES, PATH_NAMES } from "../../app.constants";
+import { PATH_NAMES } from "../../app.constants";
 
 export function landingGet(req: Request, res: Response): void {
-  res.redirect(HTTP_STATUS_CODES.REDIRECT, PATH_NAMES.ENTER_EMAIL);
+  res.redirect(PATH_NAMES.ENTER_EMAIL);
 }

--- a/src/components/verify-email/tests/verify-email-integration.test.ts
+++ b/src/components/verify-email/tests/verify-email-integration.test.ts
@@ -43,6 +43,7 @@ describe("Integration:: verify email", () => {
 
   after(() => {
     sandbox.restore();
+    app = undefined;
   });
 
   it("should return verify email page", (done) => {

--- a/src/config/cookie.ts
+++ b/src/config/cookie.ts
@@ -1,0 +1,23 @@
+import CookieSessionOptions = CookieSessionInterfaces.CookieSessionOptions;
+import { CookieOptions } from "csurf";
+
+export function getSessionCookieOptions(
+  isProdEnv: boolean,
+  expiry: number,
+  secret: string
+): CookieSessionOptions {
+  return {
+    name: "aps",
+    secret: secret,
+    maxAge: expiry,
+    secure: isProdEnv,
+  };
+}
+
+export function getCSRFCookieOptions(isProdEnv: boolean): CookieOptions {
+  return {
+    httpOnly: isProdEnv,
+    secure: isProdEnv,
+    sameSite: isProdEnv ? "strict" : "none",
+  };
+}

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -26,6 +26,7 @@ export function validateSessionMiddleware(
   }
 
   res.clearCookie("aps");
+  res.clearCookie("aps.sig");
   res.status(401);
   next(new Error(ERROR_MESSAGES.INVALID_SESSION));
 }


### PR DESCRIPTION
## What?

Update cookie options for csurf, i18next and cookie session.

## Why?

The cookies did not have the correct settings set for httponly and secure so this has been updated.

