### PR TITLE
remove next call in error handler

### DIFF
--- a/src/handlers/internal-server-error-handler.ts
+++ b/src/handlers/internal-server-error-handler.ts
@@ -17,6 +17,4 @@ export function serverErrorHandler(
 
   res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
   res.render("common/errors/500.njk");
-
-  next(err);
 }


### PR DESCRIPTION
## What?

In the global handler for errors there is no need to call the next middleware

## Why?

As this is the end of the middleware pipeline it doesn't need to call next.
