### PR TITLE
GOVSI-126: add cookie banner and save cookie preferences

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,5 @@ dist
 # don't lint nyc coverage output
 functional-output
 coverage
+# ignore front-end js
+src/assets/javascript

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/style.css",
     "dev": "concurrently -k -p \"[{name}]\" -n \"Sass,TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-sass\" \"npm run watch-ts\" \"npm run watch-node\"",
     "test:audit": "yarn audit",
-    "copy-build": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ && copyfiles -a static/*",
+    "copy-build": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ && copyfiles -a static/* && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts",
     "start": "node dist/server.js",
     "watch-node": "nodemon -r dotenv/config dist/server.js",
     "watch-ts": "tsc -w",

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -1,17 +1,9 @@
 (function (w) {
   "use strict";
   function appInit() {
-    //TODO implement
-    // if (w.GOVUKFrontend) {
-    //     w.GOVUKFrontend.initAll();
-    // }
-    //
-    // w.GOVUK.CookieSettings.init();
-    //
-    // w.GOVUK.Analytics.init(gaTrackingId);
-    // w.GOVUK.Analytics.start();
-    //
-    // w.GOVUK.Modules.CookieBanner.init(document.querySelector('[data-module="cookie-banner"]'));
+    window.govSigin.CookieBanner();
   }
   w.appInit = appInit;
-})();
+})(window);
+
+window.appInit();

--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -1,0 +1,82 @@
+window.govSigin = window.govSigin ?? {};
+
+(function(w) {
+  "use strict";
+
+  var COOKIES_PREFERENCES_SET = "cookies_preferences_set";
+
+  var cookiesAccepted = document.querySelector("#cookies-accepted");
+  var cookiesRejected = document.querySelector("#cookies-rejected");
+  var hideCookieBanner = document.querySelectorAll(".cookie-hide-button");
+  var cookieBannerContainer = document.querySelector(".govuk-cookie-banner");
+  var cookieBanner = document.querySelector("#cookies-banner-main");
+  var acceptCookies = document.querySelector("button[name=\"cookiesAccept\"]");
+  var rejectCookies = document.querySelector("button[name=\"cookiesReject\"]");
+  var cookiePreferencesExist =
+    document.cookie.indexOf(COOKIES_PREFERENCES_SET + '=') > -1;
+
+  function init() {
+    if (cookiePreferencesExist || isOnCookiesPage()) {
+      return;
+    }
+
+    showElement(cookieBannerContainer);
+
+    acceptCookies.addEventListener(
+      "click",
+      function(event) {
+        event.preventDefault();
+        setCookie(COOKIES_PREFERENCES_SET, { "analytics": "true" });
+        showElement(cookiesAccepted);
+        hideElement(cookieBanner);
+      }.bind(this),
+    );
+
+    rejectCookies.addEventListener(
+      "click",
+      function(event) {
+        event.preventDefault();
+        setCookie(COOKIES_PREFERENCES_SET,{ "analytics": "false" });
+        showElement(cookiesRejected);
+        hideElement(cookieBanner);
+      }.bind(this),
+    );
+
+    hideCookieBanner.forEach((element) => {
+      element.addEventListener(
+        "click",
+        function(event) {
+          event.preventDefault();
+          hideElement(cookieBannerContainer);
+        }.bind(this),
+      );
+    });
+  }
+
+  function setCookie(n, v) {
+    var currentDate = new Date();
+    var expiryDate = new Date(
+      currentDate.setMonth(currentDate.getMonth() + 12),
+    );
+    document.cookie =
+      n + "=" +
+      JSON.stringify(v) +
+      "; expires=" +
+      expiryDate +
+      "; path=/; Secure";
+  }
+
+  function hideElement(el) {
+    el.style.display = "none";
+  }
+
+  function showElement(el) {
+    el.style.display = "block";
+  }
+
+  function isOnCookiesPage() {
+    return window.location.pathname === "/cookies";
+  }
+
+  w.govSigin.CookieBanner = init;
+})(window);

--- a/src/components/common/layout/banner.njk
+++ b/src/components/common/layout/banner.njk
@@ -1,0 +1,79 @@
+{% set html %}
+<p>{{ 'general.cookie.cookieBanner.paragraph1' | translate }}</p>
+<p>{{ 'general.cookie.cookieBanner.paragraph2' | translate }}</p>
+{% endset %}
+
+{% set html %}
+  <p>We use some essential cookies to make this service work.</p>
+  <p>We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
+{% endset %}
+
+{% set acceptHtml %}
+  <p>{{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph2' | translate }}</p>
+{% endset %}
+
+{% set rejectedHtml %}
+  <p>{{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph1' | translate }}<a class="govuk-link" href="/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph2' | translate }}.</p>
+{% endset %}
+
+{{ govukCookieBanner({
+  ariaLabel: 'general.cookie.cookieBanner.title' | translate,
+  name: "gov-uk-cookie-banner",
+  messages: [
+    {
+      headingText: 'general.cookie.cookieBanner.heading' | translate,
+      html: html,
+      attributes: {
+                  "id": "cookies-banner-main"
+                },
+      actions: [
+        {
+          text: 'general.cookie.cookieBanner.buttonAcceptText' | translate,
+          type: "button",
+          name: "cookiesAccept",
+          value: "accept"
+        },
+        {
+          text: 'general.cookie.cookieBanner.buttonRejectText' | translate,
+          type: "button",
+          name: "cookiesReject",
+          value: "reject"
+        },
+        {
+          text: "View cookies",
+          href: "/cookies"
+        }
+      ]
+    },
+    {
+      html: acceptHtml,
+      attributes: {
+            "id": "cookies-accepted"
+          },
+      actions: [
+        {
+          text: 'general.cookie.cookieBanner.cookieBannerHideLink' | translate,
+          href: "#",
+          type: "button",
+          classes:"cookie-hide-button"
+        }
+      ],
+      hidden: true
+    },
+    {
+      html: rejectedHtml,
+      attributes: {
+                  "id": "cookies-rejected"
+                },
+      actions: [
+        {
+          text: 'general.cookie.cookieBanner.cookieBannerHideLink' | translate,
+          href: "#",
+          type: "button",
+          classes:"cookie-hide-button"
+        }
+      ],
+      hidden: true
+    }
+  ],  hidden: true
+}) }}

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -1,4 +1,5 @@
 {% extends "govuk/template.njk" %}
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
 
 {% block head %}
@@ -16,6 +17,7 @@
   <!--[if lt IE 9]>
     <script src="/html5-shiv/html5shiv.js"></script>
   <![endif]-->
+
 {% endblock %}
 
 {% block pageTitle %}
@@ -30,6 +32,9 @@
     {{ 'general.serviceNameTitle' | translate }}
 {% endblock %}
 
+{% block bodyStart %}
+ {% include 'common/layout/banner.njk' %}
+{% endblock %}
 
 {% block header %}
   {{ govukHeader({
@@ -83,5 +88,7 @@
     {% endblock %}
 
 {% block bodyEnd %}
-  {# Run JavaScript at end of the <body>, to avoid blocking the initial render. #}
+
+  <script type="text/javascript" src="/public/scripts/cookies.js"></script>
+  <script type="text/javascript" src="/public/scripts/application.js"></script>
 {% endblock %}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -16,6 +16,25 @@
     "no": "No",
     "footer": {},
     "cookie": {
+      "cookieBanner": {
+        "title": "Cookies on GOV.UK Account",
+        "heading": "Cookies on GOV.UK Account",
+        "paragraph1": "We use some essential cookies to make this service work.",
+        "paragraph2": "We’d also like to use analytics cookies so we can understand how you use the service and make improvements.",
+        "buttonAcceptText": "Accept analytics cookies",
+        "buttonRejectText": "Reject analytics cookies",
+        "linkViewCookiesText": "View cookies",
+        "cookieBannerHideLink": "Hide this message",
+        "cookeBannerAccept": {
+          "paragraph1": "You’ve accepted additional cookies. You can",
+          "paragraph2": " at any time."
+        },
+        "cookeBannerReject": {
+          "paragraph1": "You’ve rejected additional cookies. You can",
+          "paragraph2": " at any time."
+        },
+        "changeCookiePreferencesLink": "change your cookie settings"
+      },
       "cookieText": "GOV.UK uses cookies to make the site simpler.",
       "cookieLink": "#",
       "cookieLinkText": "Find out more about cookies"


### PR DESCRIPTION
## What?

Add cookie banner and save cookie preferences.

## Why?

User must be prompted to save their cookie preferences.