### PR TITLE
GOVSI-126: add missing spaces to cookie banner text

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -26,11 +26,11 @@
         "linkViewCookiesText": "View cookies",
         "cookieBannerHideLink": "Hide this message",
         "cookeBannerAccept": {
-          "paragraph1": "You’ve accepted additional cookies. You can",
+          "paragraph1": "You’ve accepted additional cookies. You can ",
           "paragraph2": " at any time."
         },
         "cookeBannerReject": {
-          "paragraph1": "You’ve rejected additional cookies. You can",
+          "paragraph1": "You’ve rejected additional cookies. You can ",
           "paragraph2": " at any time."
         },
         "changeCookiePreferencesLink": "change your cookie settings"


### PR DESCRIPTION
## What?

Add missing spaces to cookie banner text.

## Why?

Spaces are missing.
