### PR TITLE
GOVSI-104: add cookie policy page and save preferences

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -56,14 +56,14 @@ window.govSigin = window.govSigin ?? {};
     });
   }
 
-  function setCookie(n, v) {
+  function setCookie(name, value) {
     var currentDate = new Date();
     var expiryDate = new Date(
       currentDate.setMonth(currentDate.getMonth() + 12),
     );
     document.cookie =
-      n + "=" +
-      JSON.stringify(v) +
+      name + "=" +
+      JSON.stringify(value) +
       "; expires=" +
       expiryDate +
       "; path=/; Secure";
@@ -82,7 +82,7 @@ window.govSigin = window.govSigin ?? {};
   }
 
   function cookiesPageInit() {
-    var cookie = getCookie(COOKIES_PREFERENCES_SET);
+    var cookie = getCookieValue(COOKIES_PREFERENCES_SET);
     var analyticsValue = false;
 
     if (!cookie) {
@@ -112,12 +112,12 @@ window.govSigin = window.govSigin ?? {};
     );
   }
 
-  function getCookie(n) {
-    var c = document.cookie
+  function getCookieValue(cookieName) {
+    var cookie = document.cookie
       .split("; ")
-      .find(row => row.startsWith(n + "="));
-    if (c) {
-      return c.split("=")[1];
+      .find(row => row.startsWith(cookieName + "="));
+    if (cookie) {
+      return cookie.split("=")[1];
     } else {
       return null;
     }

--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -13,10 +13,13 @@ window.govSigin = window.govSigin ?? {};
   var acceptCookies = document.querySelector("button[name=\"cookiesAccept\"]");
   var rejectCookies = document.querySelector("button[name=\"cookiesReject\"]");
   var cookiePreferencesExist =
-    document.cookie.indexOf(COOKIES_PREFERENCES_SET + '=') > -1;
+    document.cookie.indexOf(COOKIES_PREFERENCES_SET + "=") > -1;
 
   function init() {
-    if (cookiePreferencesExist || isOnCookiesPage()) {
+    if (isOnCookiesPage()) {
+      cookiesPageInit();
+      return;
+    } else if (cookiePreferencesExist) {
       return;
     }
 
@@ -26,7 +29,7 @@ window.govSigin = window.govSigin ?? {};
       "click",
       function(event) {
         event.preventDefault();
-        setCookie(COOKIES_PREFERENCES_SET, { "analytics": "true" });
+        setCookie(COOKIES_PREFERENCES_SET, { "analytics": true });
         showElement(cookiesAccepted);
         hideElement(cookieBanner);
       }.bind(this),
@@ -36,7 +39,7 @@ window.govSigin = window.govSigin ?? {};
       "click",
       function(event) {
         event.preventDefault();
-        setCookie(COOKIES_PREFERENCES_SET,{ "analytics": "false" });
+        setCookie(COOKIES_PREFERENCES_SET, { "analytics": false });
         showElement(cookiesRejected);
         hideElement(cookieBanner);
       }.bind(this),
@@ -76,6 +79,48 @@ window.govSigin = window.govSigin ?? {};
 
   function isOnCookiesPage() {
     return window.location.pathname === "/cookies";
+  }
+
+  function cookiesPageInit() {
+    var cookie = getCookie(COOKIES_PREFERENCES_SET);
+    var analyticsValue = false;
+
+    if (!cookie) {
+      setCookie(COOKIES_PREFERENCES_SET, { "analytics": false });
+    } else {
+      analyticsValue = JSON.parse(cookie).analytics;
+    }
+
+    document.querySelector("#policy-cookies-accepted").checked = analyticsValue;
+    document.querySelector("#policy-cookies-rejected").checked = !analyticsValue;
+    document.querySelector("#save-cookie-settings").addEventListener(
+      "click",
+      function(event) {
+        event.preventDefault();
+        var selectedPreference = document.querySelector("#radio-cookie-preferences input[type=\"radio\"]:checked").value;
+        setCookie(COOKIES_PREFERENCES_SET, { "analytics": selectedPreference === "true" });
+        showElement(document.querySelector("#save-success-banner"));
+        window.scrollTo(0, 0);
+      }.bind(this),
+    );
+    document.querySelector("#go-back-link").addEventListener(
+      "click",
+      function(event) {
+        event.preventDefault();
+        window.history.back();
+      }.bind(this),
+    );
+  }
+
+  function getCookie(n) {
+    var c = document.cookie
+      .split("; ")
+      .find(row => row.startsWith(n + "="));
+    if (c) {
+      return c.split("=")[1];
+    } else {
+      return null;
+    }
   }
 
   w.govSigin.CookieBanner = init;

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -2,13 +2,31 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
-{% set pageTitleName = 'general.footer.cookies.pageTitle' | translate %}
+{% set pageTitleName = 'pages.cookiePolicy.title' | translate %}
 
 {% block content %}
 
+{% set html %}
+<h3 class="govuk-notification-banner__heading">
+  {{ 'pages.cookiePolicy.successBanner.header' | translate }}
+</h3>
+<p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translate }}</p>
+<a class="govuk-notification-banner__link" id="go-back-link" href="#">{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
+{% endset %}
+
+{{ govukNotificationBanner({
+  html: html,
+  type: 'success',
+  attributes: {
+    "id": "save-success-banner",
+    "hidden": true
+  }
+}) }}
+
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'general.footer.cookies.pageTitle' | translate }}
+  {{ 'pages.cookiePolicy.header' | translate }}
 </h1>
 
 <p class="govuk-body">{{'pages.cookiePolicy.info.paragraph1' | translate}}</p>
@@ -176,6 +194,9 @@
 {{ govukRadios({
   idPrefix: "cookie-preferences",
   name: "cookie-preferences",
+  attributes: {
+    "id": "radio-cookie-preferences"
+  },
   fieldset: {
     legend: {
       text: 'pages.cookiePolicy.settings.header' | translate,
@@ -185,20 +206,25 @@
   },
   items: [
     {
-      value: "yes",
-      text: 'pages.cookiePolicy.settings.yesRadioButton' | translate
+      value: "true",
+      text: 'pages.cookiePolicy.settings.yesRadioButton' | translate,
+      id: "policy-cookies-accepted"
     },
     {
-      value: "no",
-      text: 'pages.cookiePolicy.settings.noRadioButton' | translate
+      value: "false",
+      text: 'pages.cookiePolicy.settings.noRadioButton' | translate,
+      id: "policy-cookies-rejected"
     }
   ]
 }) }}
 
 {{ govukButton({
   "text": 'pages.cookiePolicy.settings.saveButton' | translate,
-  "type": "Submit",
-  "preventDoubleClick": true
+  "type": "Button",
+  "preventDoubleClick": true,
+  attributes: {
+    "id": "save-cookie-settings"
+  }
 }) }}
 
 {% endblock %}

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -1,10 +1,204 @@
 {% extends "common/layout/base.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
 {% set pageTitleName = 'general.footer.cookies.pageTitle' | translate %}
 
 {% block content %}
 
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  Cookies
+  {{ 'general.footer.cookies.pageTitle' | translate }}
 </h1>
+
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph1' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph2' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph3' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph4' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph5' | translate}}
+  <a href="{{'pages.cookiePolicy.info.linkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">
+    {{'pages.cookiePolicy.info.linkText' | translate}}
+  </a>
+  {{'pages.cookiePolicy.info.paragraph6' | translate}}
+</p>
+
+<h2 class="govuk-heading-s">{{'pages.cookiePolicy.essential.header' | translate}}</h2>
+
+<p class="govuk-body">{{'pages.cookiePolicy.essential.info.paragraph1' | translate}}</p>
+
+{{ govukTable({
+  firstCellIsHeader: false,
+  head: [
+    {
+    text: 'pages.cookiePolicy.essential.info.table.headers.col1' | translate,
+    classes: 'govuk-body-s'
+    },
+    {
+    text: 'pages.cookiePolicy.essential.info.table.headers.col2' | translate,
+    classes: 'govuk-body-s'
+    },
+    {
+    text: 'pages.cookiePolicy.essential.info.table.headers.col3' | translate,
+    classes: 'govuk-body-s'
+    }
+  ],
+  rows: [
+    [
+      {
+      text: "lang",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row1.col2' | translate,
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row1.col3' | translate,
+      classes: 'govuk-body-s'
+      }
+    ],
+    [
+      {
+      text: "aps",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row2.col2' | translate,
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row2.col3' | translate,
+      classes: 'govuk-body-s'
+      }
+    ],
+    [
+      {
+      text: "aps.sig",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row3.col2' | translate,
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row3.col3' | translate,
+      classes: 'govuk-body-s'
+      }
+    ],
+    [
+      {
+      text: "_csrf",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row4.col2' | translate,
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row4.col3' | translate,
+      classes: 'govuk-body-s'
+      }
+    ],
+    [
+      {
+      text: "cookies_preferences_set",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row5.col2' | translate,
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row5.col3' | translate,
+      classes: 'govuk-body-s'
+      }
+    ]
+  ]
+}) }}
+
+<h2 class="govuk-heading-s">{{'pages.cookiePolicy.analytics.header' | translate}}</h2>
+<p class="govuk-body">{{'pages.cookiePolicy.analytics.info.paragraph1' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.analytics.info.paragraph2' | translate}}</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>{{'pages.cookiePolicy.analytics.info.bulletPoint1' | translate}}</li>
+  <li>{{'pages.cookiePolicy.analytics.info.bulletPoint2' | translate}}</li>
+  <li>{{'pages.cookiePolicy.analytics.info.bulletPoint3' | translate}}</li>
+</ul>
+
+{{ govukTable({
+  firstCellIsHeader: false,
+  head: [
+    {
+      text: 'pages.cookiePolicy.analytics.table.headers.col1' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.headers.col2' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.headers.col3' | translate,
+      classes: 'govuk-body-s'
+    }
+  ],
+  rows: [
+    [
+    {
+      text: "_ga",
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.rows.row1.col2' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.rows.row1.col3' | translate,
+      classes: 'govuk-body-s'
+    }
+    ],
+    [
+    {
+      text: "_gid",
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.rows.row2.col2' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.rows.row2.col3' | translate,
+      classes: 'govuk-body-s'
+    }
+    ]
+  ]
+}) }}
+
+{{ govukRadios({
+  idPrefix: "cookie-preferences",
+  name: "cookie-preferences",
+  fieldset: {
+    legend: {
+      text: 'pages.cookiePolicy.settings.header' | translate,
+      isPageHeading: false,
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  items: [
+    {
+      value: "yes",
+      text: 'pages.cookiePolicy.settings.yesRadioButton' | translate
+    },
+    {
+      value: "no",
+      text: 'pages.cookiePolicy.settings.noRadioButton' | translate
+    }
+  ]
+}) }}
+
+{{ govukButton({
+  "text": 'pages.cookiePolicy.settings.saveButton' | translate,
+  "type": "Submit",
+  "preventDoubleClick": true
+}) }}
 
 {% endblock %}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -217,7 +217,6 @@
         "listItem1": "didn't receive a code",
         "listItem2": "need a new code"
       },
-
       "code": {
         "label": "Enter the 6 digit security code",
         "validationError": {
@@ -236,6 +235,88 @@
         "paragraph1": "You entered the wrong security code too many times.",
         "paragraph2": "You need to wait 15 minutes.",
         "paragraph3": "You can then enter your phone number again and get a new code."
+      }
+    },
+    "cookiePolicy": {
+      "title": "Cookies",
+      "header": "Cookies",
+      "info": {
+        "paragraph1": "GOV.UK Sign in puts small files (known as ‘cookies’) on to your phone, tablet or computer when you use the service.",
+        "paragraph2": "We use these cookies to make the service work.",
+        "paragraph3": "We may also use analytics cookies to learn about how you use the service. Analytics cookies are optional.",
+        "paragraph4": "Cookies aren’t used to identify you personally.",
+        "paragraph5": "Find out more about",
+        "linkHref": "https://ico.org.uk/your-data-matters/online/cookies/",
+        "linkText": "how to manage cookies",
+        "paragraph6": " on the Information Commissioner’s Office (ICO) website."
+      },
+      "essential": {
+        "header": "Essential cookies",
+        "info": {
+          "paragraph1": "We use essential cookies to make the service work as it should.",
+          "table": {
+            "headers": {
+              "col1": "Name",
+              "col2": "Purpose",
+              "col3": "Expires"
+            },
+            "rows": {
+              "row1": {
+                "col2": "Remembers whether you chose to use the service in English or Welsh",
+                "col3": "1 year"
+              },
+              "row2": {
+                "col2": "Stores session data",
+                "col3": "24 hours"
+              },
+              "row3": {
+                "col2": "Stores session data",
+                "col3": "24 hours"
+              },
+              "row4": {
+                "col2": "To keep the service secure (security for pages that include forms)",
+                "col3": "When you close your browser"
+              },
+              "row5": {
+                "col2": "Saves your cookie consent settings",
+                "col3": "1 year"
+              }
+            }
+          }
+        }
+      },
+      "analytics": {
+        "header": "Analytics cookies (optional)",
+        "info": {
+          "paragraph1": "With your permission, we use Google Analytics to help us understand how you use the service. We do this to help us improve the services for our users.",
+          "paragraph2": "Google Analytics stores anonymised information about:",
+          "bulletPoint1": "how you got to GOV.UK Sign in",
+          "bulletPoint2": "the pages you visit and how long you spend on them",
+          "bulletPoint3": "any errors you see while using GOV.UK Sign in"
+        },
+        "table": {
+          "headers": {
+            "col1": "Name",
+            "col2": "Purpose",
+            "col3": "Expires"
+          },
+          "rows": {
+            "row1": {
+              "col2": "Helps us count how many people visit GOV.UK Account by checking if you’ve visited before",
+              "col3": "2 years"
+            },
+            "row2": {
+              "col2": "Helps us count how many people visit GOV.UK Account by checking if you’ve visited before",
+              "col3": "24 hours"
+            }
+          }
+        }
+      },
+      "settings": {
+        "header": "Do you want to accept analytics cookies?",
+        "yesRadioButton": "Yes",
+        "noRadioButton": "No",
+        "saveButton": "Save cookie settings"
       }
     }
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -317,6 +317,11 @@
         "yesRadioButton": "Yes",
         "noRadioButton": "No",
         "saveButton": "Save cookie settings"
+      },
+      "successBanner": {
+        "header": "Your cookie settings were saved",
+        "paragraph1": "Other government services may set additional cookies and, if so, will have their own cookie policy and banner.",
+        "linkText": "Go back to the page you were looking at"
       }
     }
   }


### PR DESCRIPTION
## What?

Update the cookie policy page with the latest content.
Add required UI components.
Save updated preferences when the user clicks the save button.

## Why?

As a user 
I want to know how the cookies will be used on the authentication service 
So that I can make an informed decision as to whether I want the service to use cookies 
