### PR TITLE
Redact phonenumber only for session

### DIFF
--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -13,10 +13,10 @@ export function enterPhoneNumberPost(
   service: EnterPhoneNumberServiceInterface = enterPhoneNumberService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const phoneNumber = (req.session.user.phoneNumber = redactPhoneNumber(
-      req.body.phoneNumber
-    ));
+    const phoneNumber = req.body.phoneNumber;
     const { email, id } = req.session.user;
+
+    req.session.user.phoneNumber = redactPhoneNumber(phoneNumber);
 
     if (await service.updateProfile(id, email, phoneNumber)) {
       await service.sendPhoneVerificationNotification(id, email, phoneNumber);

--- a/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
@@ -54,6 +54,7 @@ describe("enter phone number controller", () => {
       expect(fakeService.sendPhoneVerificationNotification).to.have.been
         .calledOnce;
       expect(res.redirect).to.have.calledWith("/check-your-phone");
+      expect(req.session.user.phoneNumber).to.be.eq("*******3990");
     });
 
     it("should throw error when API call to /update-profile throws error", async () => {


### PR DESCRIPTION
## What?

Only redact the phone number to be stored for the session.

## Why?

A bug was introduced where the redacted phone number was failing on the backend validation.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
