### PR TITLE
GOVSI-606: Add route to frontend

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -81,6 +81,8 @@ jobs:
       params:
         command: push
         manifest: di-authentication-frontend/manifest.yml
+        vars:
+          route_name: front.build.auth.ida.digital.cabinet-office.gov.uk
         path: di-authentication-frontend-zip/di-authentication-frontend.zip
         environment_variables:
           API_BASE_URL: ((build-api-base-url))

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,4 +8,5 @@ applications:
       - nodejs_buildpack
     env:
       NODE_ENV: "production"
-
+    routes:
+      - ((route_name))


### PR DESCRIPTION
## What?

Use the DNS route front.build.auth.ida.digital.cabinet-office.gov.uk to the front end.

## Why?

Required to allow cookies to be shared between front and backend endpoints.