### PR TITLE
GOVSI-606: Fix manifest error

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,4 +9,4 @@ applications:
     env:
       NODE_ENV: "production"
     routes:
-      - ((route_name))
+      - route: ((route_name))


### PR DESCRIPTION
## What?

We had included a badly formed `routes` section in the `manifest.yml` file.


## Why?

Deployment is failing.

## Related PRs

#133 