### PR TITLE
BAU: update signin frontend app url for acceptance tests

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -189,7 +189,7 @@ jobs:
             - name: di-authentication-acceptance-tests
           params:
             SELENIUM_URL: https://selenium-build.london.cloudapps.digital/wd/hub
-            IDP_URL: https://di-authentication-frontend.london.cloudapps.digital
+            IDP_URL: https://front.build.auth.ida.digital.cabinet-office.gov.uk
             RP_URL: https://di-auth-stub-relying-party-build.london.cloudapps.digital
           run:
             path: /bin/bash


### PR DESCRIPTION
## What?

Update signin frontend app url for acceptance tests

## Why?

We now have a new domain name for the frontend which should be reflected in the tests.