### PR TITLE
GOVSI-281: create share-info page and api calls to capture user consent

### DIFF
--- a/dev-app.js
+++ b/dev-app.js
@@ -2,21 +2,31 @@
 
 const express = require("express");
 const axios = require("axios").default;
+const dotenv = require("dotenv").config();
 const app = express();
 const port = 2000;
 
-app.get("/", (req, res) => {
+const AUTHORIZE_REQUEST =
+  process.env.API_BASE_URL + '/authorize?' +
+  'scope=openid+phone+email&' +
+  'response_type=code&' +
+  'redirect_uri=https%3A%2F%2Fdi-auth-stub-relying-party-build.london.cloudapps.digital%2Foidc%2Fauthorization-code%2Fcallback&' +
+  'state=sEazICy8jKFFlt-NLSw5yqYRA2r4q5BZGcAf9sYeWRg&' +
+  'nonce=gyRdMfQGsQS9BvhU-lBwENOZ0UU&' +
+  'client_id=' + process.env.TEST_CLIENT_ID;
+
+  app.get("/", (req, res) => {
   axios
     .get(
-      `https://api.build.auth.ida.digital.cabinet-office.gov.uk/authorize?scope=openid+phone+email&response_type=code&redirect_uri=https%3A%2F%2Fdi-auth-stub-relying-party-build.london.cloudapps.digital%2Foidc%2Fauthorization-code%2Fcallback&state=sEazICy8jKFFlt-NLSw5yqYRA2r4q5BZGcAf9sYeWRg&nonce=gyRdMfQGsQS9BvhU-lBwENOZ0UU&client_id=SR-pLhOKIbJ6bFKq9VJPebIjsEY`,
+      AUTHORIZE_REQUEST,
       {
         validateStatus: (status) => {
           return status >= 200 && status <= 304;
         },
         maxRedirects: 0,
-      }
+      },
     )
-    .then(function (response) {
+    .then(function(response) {
       const cookies = response.headers["set-cookie"][0].split(";");
       let cookeValue;
       cookies.forEach((item) => {
@@ -25,14 +35,11 @@ app.get("/", (req, res) => {
           cookeValue = item.split("=")[1];
         }
       });
-      res.cookie("gs", cookeValue, {
-        httpOnly: true,
-        maxAge: 1800,
-      });
+      res.cookie("gs", cookeValue);
       console.log("Session is:" + cookeValue);
       res.redirect("http://localhost:3000/");
     })
-    .catch(function (error) {
+    .catch(function(error) {
       console.error(error);
     });
 });

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -12,6 +12,7 @@ export const PATH_NAMES = {
   CREATE_ACCOUNT_SUCCESSFUL: "/account-created",
   LOG_IN_ENTER_PHONE_NUMBER: "/enter-phone-number",
   CHECK_YOUR_PHONE: "/check-your-phone",
+  SHARE_INFO: "/share-info",
   ENTER_MFA: "/enter-code",
   SECURITY_CODE_EXPIRED: "/security-code-expired",
   AUTH_CODE: "/auth-code",
@@ -43,6 +44,7 @@ export const API_ENDPOINTS = {
   UPDATE_PROFILE: "/update-profile",
   MFA: "/mfa",
   AUTH_CODE: "/auth-code",
+  CLIENT_INFO: "/client-info",
 };
 
 export const ERROR_MESSAGES = {
@@ -67,6 +69,7 @@ export const USER_STATE = {
   PHONE_NUMBER_CODE_MAX_RETRIES_REACHED:
     "PHONE_NUMBER_CODE_MAX_RETRIES_REACHED",
   MFA_CODE_SENT: "MFA_CODE_SENT",
+  ADDED_CONSENT: "ADDED_CONSENT",
 };
 
 export enum NOTIFICATION_TYPE {

--- a/src/app.ts
+++ b/src/app.ts
@@ -41,6 +41,7 @@ import { authCodeRouter } from "./components/auth-code/auth-code-routes";
 import { resendMfaCodeRouter } from "./components/resend-mfa-code/resend-mfa-code-routes";
 import { signedOutRouter } from "./components/signed-out/signed-out-routes";
 import { getSessionIdMiddleware } from "./middleware/session-middleware";
+import { shareInfoRouter } from "./components/share-info/share-info-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -63,6 +64,7 @@ function registerRoutes(app: express.Application) {
   app.use(authCodeRouter);
   app.use(resendMfaCodeRouter);
   app.use(signedOutRouter);
+  app.use(shareInfoRouter);
 }
 
 function createApp(): express.Application {

--- a/src/components/share-info/index.njk
+++ b/src/components/share-info/index.njk
@@ -1,0 +1,77 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+
+{% set pageTitleName = 'pages.shareInfo.title' | translate %}
+
+{% block content %}
+
+{% set html %}
+<p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translate }}</p>
+<a class="govuk-notification-banner__link" id="go-back-link" href="#">{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
+{% endset %}
+
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+  {{ 'pages.shareInfo.header' | translate }}
+</h1>
+
+<h2 class="govuk-body-l">{{ clientInfo.client_name }}</h2>
+<p class="govuk-body">{{'pages.shareInfo.bulletPointSectionHeader' | translate}}</p>
+
+<ul class="govuk-list govuk-list--bullet">
+    {% for scope in prettyScopes %}
+        <li>
+            {{ scope }}
+        </li>
+    {% endfor %}
+</ul>
+
+<p class="govuk-body">{{'pages.shareInfo.paragraph1' | translate}}</p>
+<p class="govuk-body">{{'pages.shareInfo.paragraph2' | translate}}</p>
+<p class="govuk-body">{{'pages.shareInfo.paragraph3' | translate}}</p>
+
+<h2 class="govuk-heading-s">{{'pages.shareInfo.essentialHeader' | translate}}</h2>
+
+<form action="/share-info" method="post" novalidate>
+
+<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+{{ govukRadios({
+  idPrefix: "share-info",
+  name: "consentValue",
+  attributes: {
+    "id": "radio-share-info-preferences"
+  },
+  fieldset: {
+    legend: {
+      text: 'pages.shareInfo.radios.shareMy' | translate,
+      isPageHeading: false,
+      classes: "govuk-body"
+    }
+  },
+  items: [
+    {
+      checked: "false",
+      text: 'pages.shareInfo.radios.radioText.agree' | translate,
+      id: "share-info-accepted",
+      value: "true"
+    },
+    {
+      checked: "true",
+      text: 'pages.shareInfo.radios.radioText.doNotAgree' | translate,
+      id: "share-info-rejected",
+      value: "false"
+    }
+  ]
+}) }}
+
+{{ govukButton({
+  "text": 'pages.shareInfo.continue' | translate,
+  "type": "Submit",
+  "preventDoubleClick": true
+}) }}
+
+</form>
+
+{% endblock %}

--- a/src/components/share-info/share-info-controller.ts
+++ b/src/components/share-info/share-info-controller.ts
@@ -1,0 +1,44 @@
+import { Request, Response } from "express";
+import { ExpressRouteFunc } from "../../types";
+import { shareInfoService } from "./share-info-service";
+import { PATH_NAMES } from "../../app.constants";
+import { ShareInfoServiceInterface } from "./types";
+
+export function shareInfoGet(
+  service: ShareInfoServiceInterface = shareInfoService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const sessionId = res.locals.sessionId;
+    const clientSessionId = res.locals.clientSessionId;
+    const clientInfo = await service.clientInfo(sessionId, clientSessionId);
+    const prettyScopes = mapScopes(clientInfo.scopes);
+
+    res.render("share-info/index.njk", { clientInfo, prettyScopes });
+  };
+}
+
+export function shareInfoPost(
+  service: ShareInfoServiceInterface = shareInfoService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const consentValue = req.body.consentValue;
+    const { email } = req.session.user;
+    const sessionId = res.locals.sessionId;
+    const clientSessionId = res.locals.clientSessionId;
+
+    if (await service.updateProfile(sessionId, clientSessionId, email, consentValue)) {
+      res.redirect(PATH_NAMES.AUTH_CODE);
+    } else {
+      throw new Error("Unable to update user profile");
+    }
+  };
+}
+
+function mapScopes(scopes: string[]) {
+  const returnScopes: any[] = [];
+  scopes.forEach(function (item) {
+    if (item === "email") { returnScopes.push("email address"); }
+    if (item === "phone") { returnScopes.push("phone number"); }
+  });
+  return returnScopes;
+}

--- a/src/components/share-info/share-info-routes.ts
+++ b/src/components/share-info/share-info-routes.ts
@@ -1,0 +1,18 @@
+import { PATH_NAMES } from "../../app.constants";
+
+import * as express from "express";
+import {shareInfoGet, shareInfoPost} from "./share-info-controller";
+import {validateSessionMiddleware} from "../../middleware/session-middleware";
+import {asyncHandler} from "../../utils/async";
+
+const router = express.Router();
+
+router.get(PATH_NAMES.SHARE_INFO, asyncHandler(shareInfoGet()));
+
+router.post(
+    PATH_NAMES.SHARE_INFO,
+    validateSessionMiddleware,
+    asyncHandler(shareInfoPost())
+);
+
+export { router as shareInfoRouter };

--- a/src/components/share-info/share-info-service.ts
+++ b/src/components/share-info/share-info-service.ts
@@ -1,0 +1,50 @@
+import { getBaseRequestConfigWithClientSession, Http, http } from "../../utils/http";
+import { API_ENDPOINTS, USER_STATE } from "../../app.constants";
+
+import {
+  ClientInfoResponse,
+  ShareInfoServiceInterface,
+  UpdateUserProfile,
+} from "./types";
+
+const UPDATE_TYPE_CAPTURE_CONSENT = "CAPTURE_CONSENT";
+
+export function shareInfoService(
+  axios: Http = http
+): ShareInfoServiceInterface {
+  const updateProfile = async function (
+    sessionId: string,
+    clientSessionId: string,
+    email: string,
+    consent: boolean
+  ): Promise<boolean> {
+    const { data } = await axios.client.post<UpdateUserProfile>(
+      API_ENDPOINTS.UPDATE_PROFILE,
+      {
+        email,
+        profileInformation: consent,
+        updateProfileType: UPDATE_TYPE_CAPTURE_CONSENT,
+      },
+      getBaseRequestConfigWithClientSession(sessionId, clientSessionId)
+    );
+
+    return data.sessionState === USER_STATE.ADDED_CONSENT;
+  };
+
+  const clientInfo = async function (
+    sessionId: string,
+    clientSessionId: string,
+  ): Promise<ClientInfoResponse> {
+    const { data } = await axios.client.get<ClientInfoResponse>(
+      API_ENDPOINTS.CLIENT_INFO,
+      getBaseRequestConfigWithClientSession(sessionId, clientSessionId)
+    );
+    return data;
+  };
+
+  return {
+    updateProfile,
+    clientInfo,
+  };
+}
+

--- a/src/components/share-info/tests/share-info-controller.test.ts
+++ b/src/components/share-info/tests/share-info-controller.test.ts
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import { shareInfoGet, shareInfoPost } from "../share-info-controller";
+import { UserSession } from "../../../types";
+import { ShareInfoServiceInterface } from "../types";
+
+describe("share-info controller", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    req = {
+      body: {},
+      session: { user: {} as UserSession },
+      i18n: { language: "en" },
+    };
+    res = {
+      render: sandbox.fake(),
+      redirect: sandbox.fake(),
+      status: sandbox.fake(),
+      locals: {},
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("shareInfoGet", () => {
+    it("should render share-info page", async () => {
+      const fakeService: ShareInfoServiceInterface = {
+        updateProfile: sandbox.fake(),
+        clientInfo: sandbox.fake.returns({ scopes: ["openid", "profile"] }),
+      };
+
+      res.locals.sessionId = "s-123456-djjad";
+      res.locals.clientSessionId = "c-123456-djjad";
+
+      await shareInfoGet(fakeService)(req as Request, res as Response);
+
+      expect(fakeService.clientInfo).to.be.calledOnce;
+      expect(res.render).to.have.calledWith("share-info/index.njk");
+    });
+  });
+
+  describe("shareInfoPost", () => {
+    it("should redirect to /auth-code when succesfully", async () => {
+      const fakeService: ShareInfoServiceInterface = {
+        updateProfile: sandbox.fake.returns(true),
+        clientInfo: sandbox.fake.returns({ scopes: ["openid", "profile"] }),
+      };
+
+      req.body.consentValue = true;
+      res.locals.sessionId = "s-123456-djjad";
+      res.locals.clientSessionId = "c-123456-djjad";
+      req.session.user = {
+        email: "test@test.com",
+      };
+
+      await shareInfoPost(fakeService)(req as Request, res as Response);
+
+      expect(fakeService.updateProfile).to.have.been.calledOnce;
+      expect(res.redirect).to.have.calledWith("/auth-code");
+    });
+  });
+
+  describe("shareInfoPostError", () => {
+    it("should throw error when update profile returns false", async () => {
+      const fakeService: ShareInfoServiceInterface = {
+        updateProfile: sandbox.fake.returns(false),
+        clientInfo: sandbox.fake.returns({ scopes: ["openid", "profile"] }),
+      };
+
+      req.body.consentValue = true;
+      res.locals.sessionId = "s-123456-djjad";
+      res.locals.clientSessionId = "c-123456-djjad";
+      req.session.user = {
+        email: "test@test.com",
+      };
+
+      await expect(
+          shareInfoPost(fakeService)(req as Request, res as Response
+      )).to.be.rejectedWith(Error, "Unable to update user profile");
+
+      expect(fakeService.updateProfile).to.have.been.calledOnce;
+    });
+  });
+});

--- a/src/components/share-info/types.ts
+++ b/src/components/share-info/types.ts
@@ -1,0 +1,19 @@
+export interface ShareInfoServiceInterface {
+  updateProfile: (
+    sessionId: string,
+    clientSessionId: string,
+    email: string,
+    consentValue: boolean
+  ) => Promise<boolean>;
+  clientInfo: (sessionId: string, clientSessionId: string) => Promise<ClientInfoResponse>;
+}
+
+export interface UpdateUserProfile {
+  sessionState: string;
+}
+
+export interface ClientInfoResponse {
+  clientId: string;
+  clientName: string;
+  scopes: string[];
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -273,6 +273,24 @@
       "buttonHref": "https://www.gov.uk/",
       "buttonText": "Return to the GOV.UK homepage"
     },
+    "shareInfo": {
+      "title": "Share information from your GOV.UK account",
+      "header": "Share information from your GOV.UK account",
+      "continue" : "Continue",
+      "bulletPointSectionHeader" : "This service needs to use your:",
+      "paragraph1" : "You added this information to your GOV.UK Account when you created the account. You can choose to share it with the service instead of entering it when you use the service.",
+      "paragraph2" : "The service will only use this information to contact you about the service. It won't share your information with anyone else. It will keep your information for as long as it needs to or the law requires it to.",
+      "paragraph3" : "If you choose not to share information from your GOV.UK Account, you may still be asked for that information as you use the service. For example if you choose not to share your email address or phone number and the service needs a way to contact you.",
+      "essentialHeader" : "Do you want to share information from your GOV.UK account?",
+      "radios" : {
+        "shareMy" : "Do you consent to sharing your email address and phone number:",
+        "radioText" : {
+          "agree" : "I agree",
+          "doNotAgree" : "I do not agree",
+          "error" : "You must select an option"
+        }
+      }
+    },
     "cookiePolicy": {
       "title": "Cookies",
       "header": "Cookies",

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -17,6 +17,7 @@ export function getSessionIdMiddleware(
 ): void {
   if (req.cookies && req.cookies["gs"]) {
     res.locals.sessionId = req.cookies["gs"].split(".")[0];
+    res.locals.clientSessionId = req.cookies["gs"].split(".")[1];
   }
   next();
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -21,6 +21,16 @@ export function getBaseRequestConfig(sessionId: string): AxiosRequestConfig {
   };
 }
 
+export function getBaseRequestConfigWithClientSession(sessionId: string, clientSessionId: string): AxiosRequestConfig {
+  return {
+    headers: {
+      "Session-Id": sessionId,
+      "Client-Session-Id": clientSessionId,
+    },
+    proxy: false,
+  };
+}
+
 export class Http {
   private instance: AxiosInstance;
 


### PR DESCRIPTION
## What?

Create share-info page and api calls to capture user consent.

- Add new page which calls 'client-info' on GET to retrieve the client name and list of supported scopes for displaying on the page.
- On submit (POST) call 'update-profile' to store the user consent against the client in the user profile.

Includes additional local node app by @sanisc that starts a session and run the flow locally.

## Why?

The application must capture the user's consent to share data with the service.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/261
https://github.com/alphagov/di-authentication-api/pull/265
https://github.com/alphagov/di-authentication-api/pull/267