### PR TITLE
GOVSI-611: update content and use translations for 404, 500 and session expired error pages

### DIFF
--- a/src/components/common/errors/404.njk
+++ b/src/components/common/errors/404.njk
@@ -1,17 +1,18 @@
-{% extends "common/layout/base.njk" %} {% block content %}
+{% extends "common/layout/base.njk" %}
+{% set pageTitleName = 'error.error404.title' | translate %}
+
+{% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Page not found</h1>
-    <p class="govuk-body">If you typed the web address, check it is correct.</p>
+    <h1 class="govuk-heading-l">{{'error.error404.header' | translate }}</h1>
+    <p class="govuk-body">{{'error.error404.content.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{'error.error404.content.paragraph2' | translate }}</p>
     <p class="govuk-body">
-      If you pasted the web address, check you copied the entire address.
-    </p>
-    <p class="govuk-body">
-      If the web address is correct or you selected a link or button,
-      <a href="#" class="govuk-link">contact the GOV.UK sign in team</a> if you
-      need to speak to someone about this needs content.
+      {{'error.error404.content.paragraph3Start' | translate }}
+      <a href="{{'error.error404.content.yourAccountLink' | translate }}" class="govuk-link">{{'error.error404.content.yourAccountLinkText' | translate }}</a>
+      {{'error.error404.content.paragraph3Middle' | translate }}
+      <a href="{{'error.error404.content.govUKHomepageLink' | translate }}" class="govuk-link">{{'error.error404.content.govUKHomepageLinkText' | translate }}</a>
     </p>
   </div>
 </div>
 {% endblock %}
-

--- a/src/components/common/errors/500.njk
+++ b/src/components/common/errors/500.njk
@@ -1,12 +1,12 @@
-{% extends "common/layout/base.njk" %} {% block content %}
+{% extends "common/layout/base.njk" %}
+
+{% set pageTitleName = 'error.error500.title' | translate %}
+
+{% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
-    <p class="govuk-body">Try again later.</p>
-    <p class="govuk-body">PLACEHOLDER</p>
-    <p class="govuk-body">
-      <a class="govuk-link" href="#">PLACEHOLDER</a> PLACEHOLDER.
-    </p>
+    <h1 class="govuk-heading-l">{{ 'error.error500.header' | translate }}</h1>
+    <p class="govuk-body">{{ 'error.error500.content.paragraph1' | translate }}</p>
   </div>
 </div>
 {% endblock %}

--- a/src/components/common/errors/session-expired.njk
+++ b/src/components/common/errors/session-expired.njk
@@ -1,15 +1,25 @@
 {% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
 {% set pageTitleName = 'error.timeoutError.title' | translate %}
-{% set pageHeader = 'error.timeoutError.header' | translate %}
-{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% block content %}
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">{{ 'error.timeoutError.header' | translate }}</h1>
+        <h1 class="govuk-heading-l">{{ 'error.timeoutError.header' | translate }}</h1>
         <p class="govuk-body">{{ 'error.timeoutError.content.paragraph1' | translate }}</p>
         <p class="govuk-body">{{ 'error.timeoutError.content.paragraph2' | translate }}</p>
     </div>
 </div>
-{% endblock %}
 
+{{ govukButton({
+"text": button_text|default('error.timeoutError.content.signInButtonText' | translate, true),
+"type": "Submit",
+"href": 'error.timeoutError.content.signInButtonHRef' | translate
+}) }}
+
+<p class="govuk-body">
+    <a href="{{'error.timeoutError.content.govUKHomepageLink' | translate }}" class="govuk-link">{{'error.timeoutError.content.govUKHomepageLinkText' | translate }}</a>
+</p>
+
+{% endblock %}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -85,11 +85,15 @@
       "header": "Sorry, there is a problem with this service"
     },
     "timeoutError": {
-      "title": "Session timed out",
-      "header": "Session timed out",
+      "title": "You have been signed out",
+      "header": "You have been signed out",
       "content": {
-        "paragraph1": "Your session has timed out due to inactivity.",
-        "paragraph2": "add another line here"
+        "paragraph1": "You’ve been signed out because you did not use your account for 30 minutes or more.",
+        "paragraph2": "This is to keep your account and your information secure.",
+        "signInButtonText": "Sign in",
+        "signInButtonHRef": "#",
+        "govUKHomepageLink": "https://www.gov.uk/",
+        "govUKHomepageLinkText": "Go to the GOV.UK homepage"
       }
     }
   },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -68,7 +68,17 @@
   "error": {
     "error404": {
       "title": "Page not found",
-      "header": "Page not found"
+      "header": "Page not found",
+      "content": {
+        "paragraph1": "If you typed the web address, check it is correct.",
+        "paragraph2": "If you pasted the web address, check you copied the entire address.",
+        "paragraph3Start": "Go back to ",
+        "yourAccountLink": "#",
+        "yourAccountLinkText": "your account",
+        "paragraph3Middle": " or to the ",
+        "govUKHomepageLink": "https://www.gov.uk/",
+        "govUKHomepageLinkText": "GOV.UK homepage."
+      }
     },
     "error500": {
       "title": "Sorry, there is a problem with this service",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -81,8 +81,11 @@
       }
     },
     "error500": {
-      "title": "Sorry, there is a problem with this service",
-      "header": "Sorry, there is a problem with this service"
+      "title": "Sorry, there is a problem with the service",
+      "header": "Sorry, there is a problem with the service",
+      "content": {
+        "paragraph1": "Try again later."
+      }
     },
     "timeoutError": {
       "title": "You have been signed out",

--- a/startup.sh
+++ b/startup.sh
@@ -26,7 +26,7 @@ fi
 
 if [ $LOCAL == "1" ]; then
   echo "Starting di-auth-frontend-dev on local..."
-  yarn install && yarn run copy-build && yarn run dev
+  yarn install && yarn copy-assets && yarn dev
 else
   running_count=$(docker ps -a | grep "di-auth-frontend-dev" | wc -l | awk '{ print $1 }')
   if [ ${running_count} -ne 0 ]; then


### PR DESCRIPTION
## What?

Update content and use translations for 404, 500 and session expired error pages.

## Why?

Content has been refresh since the pages were first created.
Pages were not completely templated to read from translations.