### PR TITLE
GOVSI-281: updated content for 'share-info' page

### DIFF
--- a/src/components/share-info/index.njk
+++ b/src/components/share-info/index.njk
@@ -52,18 +52,19 @@
   },
   items: [
     {
-      checked: "false",
       text: 'pages.shareInfo.radios.radioText.agree' | translate,
       id: "share-info-accepted",
       value: "true"
     },
     {
-      checked: "true",
       text: 'pages.shareInfo.radios.radioText.doNotAgree' | translate,
       id: "share-info-rejected",
       value: "false"
     }
-  ]
+  ],
+  errorMessage: {
+  text: errors['consentValue'].text
+  } if (errors['consentValue'])
 }) }}
 
 {{ govukButton({

--- a/src/components/share-info/share-info-routes.ts
+++ b/src/components/share-info/share-info-routes.ts
@@ -4,14 +4,20 @@ import * as express from "express";
 import { shareInfoGet, shareInfoPost } from "./share-info-controller";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { asyncHandler } from "../../utils/async";
+import { validateShareInfoRequest } from "./share-info-validation";
 
 const router = express.Router();
 
-router.get(PATH_NAMES.SHARE_INFO, asyncHandler(shareInfoGet()));
+router.get(
+  PATH_NAMES.SHARE_INFO,
+  validateSessionMiddleware,
+  asyncHandler(shareInfoGet())
+);
 
 router.post(
   PATH_NAMES.SHARE_INFO,
   validateSessionMiddleware,
+  validateShareInfoRequest(),
   asyncHandler(shareInfoPost())
 );
 

--- a/src/components/share-info/share-info-validation.ts
+++ b/src/components/share-info/share-info-validation.ts
@@ -1,0 +1,16 @@
+import { body } from "express-validator";
+import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
+import { ValidationChainFunc } from "../../types";
+
+export function validateShareInfoRequest(): ValidationChainFunc {
+  return [
+    body("consentValue")
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t("pages.shareInfo.radios.radioText.errorMessage", {
+          value,
+        });
+      }),
+    validateBodyMiddleware("share-info/index.njk"),
+  ];
+}

--- a/src/components/share-info/tests/share-info-integration.test.ts
+++ b/src/components/share-info/tests/share-info-integration.test.ts
@@ -1,0 +1,145 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { expect, sinon } from "../../../../test/utils/test-utils";
+import nock = require("nock");
+import * as cheerio from "cheerio";
+import decache from "decache";
+
+describe("Integration::share info", () => {
+  let sandbox: sinon.SinonSandbox;
+  let token: string | string[];
+  let cookies: string;
+  let app: any;
+  let baseApi: string;
+
+  before(() => {
+    decache("../../../app");
+    decache("../../../middleware/session-middleware");
+    const sessionMiddleware = require("../../../middleware/session-middleware");
+    sandbox = sinon.createSandbox();
+    sandbox
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+        res.locals.clientSessionId = "csy103saszhcxbQq0-mjdzU854";
+        req.session.user = {
+          email: "test@test.com",
+        };
+        next();
+      });
+
+    app = require("../../../app").createApp();
+    baseApi = process.env.API_BASE_URL;
+
+    nock(baseApi)
+      .get("/client-info")
+      .once()
+      .reply(200, {
+        clientId: "client_test",
+        clientName: "client_test_name",
+        scopes: ["email", "phone"],
+      });
+
+    request(app)
+      .get("/share-info")
+      .end((err, res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sandbox.restore();
+    app = undefined;
+  });
+
+  it("should return share info page", (done) => {
+    nock(baseApi)
+      .get("/client-info")
+      .once()
+      .reply(200, {
+        clientId: "client_test",
+        clientName: "client_test_name",
+        scopes: ["email", "phone"],
+      });
+    request(app).get("/share-info").expect(200, done);
+  });
+
+  it("should return error when csrf not present", (done) => {
+    request(app)
+      .post("/share-info")
+      .type("form")
+      .send({
+        consentValue: "true",
+      })
+      .expect(500, done);
+  });
+
+  it("should return validation error when consentValue not selected", (done) => {
+    request(app)
+      .post("/share-info")
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        consentValue: undefined,
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#share-info-error").text()).to.contains(
+          "Select if you want to share your email address and phone number or not"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should redirect to /auth-code page when consentValue valid", (done) => {
+    nock(baseApi)
+      .post("/update-profile")
+      .once()
+      .reply(200, {
+        sessionState: "ADDED_CONSENT",
+      });
+
+    request(app)
+      .post("/share-info")
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        consentValue: "true",
+      })
+      .expect("Location", "/auth-code")
+      .expect(302, done);
+  });
+
+  it("should return internal server error when /update-profile API call response is 500", (done) => {
+    nock(baseApi)
+      .post("/update-profile")
+      .once()
+      .reply(500, {});
+
+    request(app)
+      .post("/share-info")
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        consentValue: "true",
+      })
+      .expect(500, done);
+  });
+
+  it("should return internal server error when /client-info API call response is 500", (done) => {
+    nock(baseApi)
+      .get("/client-info")
+      .once()
+      .reply(500, {});
+    request(app).get("/share-info").expect(500, done);
+  });
+});

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -291,18 +291,18 @@
     "shareInfo": {
       "title": "Share information from your GOV.UK account",
       "header": "Share information from your GOV.UK account",
-      "continue": "Continue",
-      "bulletPointSectionHeader": "This service needs to use your:",
-      "paragraph1": "You added this information to your GOV.UK Account when you created the account. You can choose to share it with the service instead of entering it when you use the service.",
-      "paragraph2": "The service will only use this information to contact you about the service. It won't share your information with anyone else. It will keep your information for as long as it needs to or the law requires it to.",
-      "paragraph3": "If you choose not to share information from your GOV.UK Account, you may still be asked for that information as you use the service. For example if you choose not to share your email address or phone number and the service needs a way to contact you.",
-      "essentialHeader": "Do you want to share information from your GOV.UK account?",
-      "radios": {
-        "shareMy": "Do you consent to sharing your email address and phone number:",
-        "radioText": {
-          "agree": "I agree",
-          "doNotAgree": "I do not agree",
-          "error": "You must select an option"
+      "continue" : "Continue",
+      "bulletPointSectionHeader" : "This service needs to use your:",
+      "paragraph1" : "You added this information to your GOV.UK account when you created the account. You can choose to share it with the service instead of entering it when you use the service.",
+      "paragraph2" : "The service will only use this information to contact you about the service. It won't share your information with anyone else. It will keep your information for as long as it needs to or the law requires it to.",
+      "paragraph3" : "If you choose not to share information from your GOV.UK account, you may still be asked for that information as you use the service. For example if you choose not to share your email address and phone number and the service needs a way to contact you.",
+      "essentialHeader" : "Do you want to share information from your GOV.UK account?",
+      "radios" : {
+        "shareMy" : "Do you want to share information from your GOV.UK account?",
+        "radioText" : {
+          "agree" : "Share my email address and phone number",
+          "doNotAgree" : "Do not share my email address and phone number",
+          "errorMessage" : "Select if you want to share your email address and phone number or not"
         }
       }
     },


### PR DESCRIPTION

## What?

By default no option will be selected.
On clicking continue an error message will be displayed if no option is selected.

## Why?

Page content has been updated in the Figma and there is new default behaviour and an error message for when no option is selected by the user for sharing.

## Related PRs

#155 
#267
#265
#261
