### PR TITLE
GOVSI-611: error page content updates to match the figma

### DIFF
--- a/src/components/common/errors/404.njk
+++ b/src/components/common/errors/404.njk
@@ -1,4 +1,5 @@
 {% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {% set pageTitleName = 'error.error404.title' | translate %}
 
 {% block content %}
@@ -7,10 +8,14 @@
     <h1 class="govuk-heading-l">{{'error.error404.header' | translate }}</h1>
     <p class="govuk-body">{{'error.error404.content.paragraph1' | translate }}</p>
     <p class="govuk-body">{{'error.error404.content.paragraph2' | translate }}</p>
+
+    {{ govukButton({
+    "text": button_text|default('error.error404.content.backToYourAccountButtonText' | translate, true),
+    "type": "Submit",
+    "href": 'error.error404.content.backToYourAccountButtonLink' | translate
+    }) }}
+
     <p class="govuk-body">
-      {{'error.error404.content.paragraph3Start' | translate }}
-      <a href="{{'error.error404.content.yourAccountLink' | translate }}" class="govuk-link">{{'error.error404.content.yourAccountLinkText' | translate }}</a>
-      {{'error.error404.content.paragraph3Middle' | translate }}
       <a href="{{'error.error404.content.govUKHomepageLink' | translate }}" class="govuk-link">{{'error.error404.content.govUKHomepageLinkText' | translate }}</a>
     </p>
   </div>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -72,23 +72,21 @@
       "content": {
         "paragraph1": "If you typed the web address, check it is correct.",
         "paragraph2": "If you pasted the web address, check you copied the entire address.",
-        "paragraph3Start": "Go back to ",
-        "yourAccountLink": "#",
-        "yourAccountLinkText": "your account",
-        "paragraph3Middle": " or to the ",
+        "backToYourAccountButtonLink": "#",
+        "backToYourAccountButtonText": "Go back to your account",
         "govUKHomepageLink": "https://www.gov.uk/",
-        "govUKHomepageLinkText": "GOV.UK homepage."
+        "govUKHomepageLinkText": "Go to the GOV.UK homepage"
       }
     },
     "error500": {
-      "title": "Sorry, there is a problem with the service",
-      "header": "Sorry, there is a problem with the service",
+      "title": "There's a problem with this service",
+      "header": "Sorry, there's a problem with this service",
       "content": {
         "paragraph1": "Try again later."
       }
     },
     "timeoutError": {
-      "title": "You have been signed out",
+      "title": "You've been signed out",
       "header": "You have been signed out",
       "content": {
         "paragraph1": "You’ve been signed out because you did not use your account for 30 minutes or more.",


### PR DESCRIPTION
## What?

Content updates to error pages based on the latest Figma.

## Why?

Pages were built against content documents linked in the ticket.  Content has since changed and is superseded by the Figma. 
