### PR TITLE
GOVSI-641: add new 'reset password check email' page

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -10,6 +10,7 @@ export const PATH_NAMES = {
   CHECK_YOUR_EMAIL: "/check-your-email",
   ENTER_PASSWORD: "/enter-password",
   ENTER_PASSWORD_ACCOUNT_EXISTS: "/enter-password-account-exists",
+  RESET_PASSWORD_CHECK_EMAIL: "/reset-password-check-email",
   CREATE_ACCOUNT_CHECK_EMAIL: "/check-email",
   CREATE_ACCOUNT_SET_PASSWORD: "/create-password",
   CREATE_ACCOUNT_ENTER_PHONE_NUMBER: "/enter-phone-number",

--- a/src/app.ts
+++ b/src/app.ts
@@ -45,6 +45,7 @@ import { shareInfoRouter } from "./components/share-info/share-info-routes";
 import { updatedTermsCondsRouter } from "./components/updated-terms-conds/updated-terms-conds-routes";
 import { signInOrCreateRouter } from "./components/sign-in-or-create/sign-in-or-create-routes";
 import { accountNotFoundRouter } from "./components/account-not-found/account-not-found-routes";
+import { resetPasswordCheckEmailRouter } from "./components/reset-password-check-email/reset-password-check-email-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -57,6 +58,7 @@ function registerRoutes(app: express.Application) {
   app.use(enterEmailRouter);
   app.use(accountNotFoundRouter);
   app.use(enterPasswordRouter);
+  app.use(resetPasswordCheckEmailRouter);
   app.use(verifyEmailRouter);
   app.use(createPasswordRouter);
   app.use(enterPhoneNumberRouter);

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -33,7 +33,7 @@
 }}
 
 <p class="govuk-body">
-    <a href="" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>
+    <a href="/reset-password-check-email" class="govuk-link" rel="noreferrer noopener">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>
 </p>
 
 {{ govukButton({
@@ -45,4 +45,3 @@
 </form>
 
 {% endblock %}
-

--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -1,0 +1,18 @@
+{% extends "common/layout/base.njk" %}
+{% set pageTitleName = 'pages.resetPasswordCheckEmail.title' | translate %}
+{% block content %}
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resetPasswordCheckEmail.header' | translate}}</h1>
+
+<p class="govuk-body">
+    {{'pages.resetPasswordCheckEmail.paragraph1' | translate}}
+    {{email}}.
+    {{'pages.resetPasswordCheckEmail.paragraph2' | translate}}
+</p>
+<p class="govuk-body">{{'pages.resetPasswordCheckEmail.paragraph3' | translate}}</p>
+
+<p class="govuk-body">
+    <a href="/reset-password-check-email" class="govuk-link" rel="noreferrer noopener">{{'pages.resetPasswordCheckEmail.sendAnotherEmailLinkText' | translate }}</a>
+</p>
+
+{% endblock %}`

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from "express";
+
+export function resetPasswordCheckEmailGet(req: Request, res: Response): void {
+  const email = req.session.user.email;
+  res.render("reset-password-check-email/index.njk", {
+    email,
+  });
+}

--- a/src/components/reset-password-check-email/reset-password-check-email-routes.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-routes.ts
@@ -1,0 +1,15 @@
+import { PATH_NAMES } from "../../app.constants";
+
+import * as express from "express";
+import { resetPasswordCheckEmailGet } from "./reset-password-check-email-controller";
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL,
+  validateSessionMiddleware,
+  resetPasswordCheckEmailGet
+);
+
+export { router as resetPasswordCheckEmailRouter };

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-controller.test.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import { UserSession } from "../../../types";
+
+import { resetPasswordCheckEmailGet } from "../reset-password-check-email-controller";
+
+describe("reset password check email controller", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    req = { body: {}, session: { user: {} as UserSession } };
+    res = { render: sandbox.fake(), redirect: sandbox.fake(), locals: {} };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("resetPasswordCheckEmailGet", () => {
+    it("should render reset password check email view", () => {
+      resetPasswordCheckEmailGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "reset-password-check-email/index.njk"
+      );
+    });
+  });
+});

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -232,6 +232,14 @@
         "text": "I've forgotten my password"
       }
     },
+    "resetPasswordCheckEmail": {
+      "title": "Check your email",
+      "header": "Check your email",
+      "paragraph1": "We sent an email to ",
+      "paragraph2": "Use the link in the email to reset your password.",
+      "paragraph3": "The link will expire after 15 minutes.",
+      "sendAnotherEmailLinkText": "Send another email"
+    },
     "createPassword": {
       "title": "Create your password",
       "header": "Create your password",


### PR DESCRIPTION
## What?

Add new 'reset password check email' page
Update link from 'forgotten password' on 'enter password page.

This is only the new page, build of backend service to follow.

## Why?

As part of Account Recovery, when an existing user is logging in, we need to have an option for them to reset their password, in case they have forgotten it.
