### PR TITLE
GOVSI-819 - Skip 2FA when the state of AUTHENTICATED is returned

### DIFF
--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { PATH_NAMES, USER_STATE } from "../../app.constants";
+import { PATH_NAMES } from "../../app.constants";
 import { ExpressRouteFunc } from "../../types";
 import { createPasswordService } from "./create-password-service";
 import { CreatePasswordServiceInterface } from "./types";
@@ -12,15 +12,11 @@ export function createPasswordPost(
   service: CreatePasswordServiceInterface = createPasswordService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const userState = await service.signUpUser(
+    await service.signUpUser(
       res.locals.sessionId,
       req.session.user.email,
       req.body.password
     );
-
-    if (userState !== USER_STATE.REQUIRES_TWO_FACTOR) {
-      return res.redirect(PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL);
-    }
 
     res.redirect(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER);
   };

--- a/src/components/create-password/tests/create-password-controller.test.ts
+++ b/src/components/create-password/tests/create-password-controller.test.ts
@@ -53,23 +53,6 @@ describe("create-password controller", () => {
       expect(fakeService.signUpUser).to.have.been.calledOnce;
     });
 
-    it("should redirect to account-created when 2 factor is not required", async () => {
-      const fakeService: CreatePasswordServiceInterface = {
-        signUpUser: sandbox.fake.returns(""),
-      };
-
-      req.body.password = "password1";
-      req.session.user = {
-        id: "12-d0dasdk",
-        email: "joe.bloggs@test.com",
-      };
-
-      await createPasswordPost(fakeService)(req as Request, res as Response);
-
-      expect(res.redirect).to.have.calledWith("/account-created");
-      expect(fakeService.signUpUser).to.have.been.calledOnce;
-    });
-
     it("should throw error when session is not populated", async () => {
       const fakeService: CreatePasswordServiceInterface = {
         signUpUser: sandbox.fake(),

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -39,6 +39,12 @@ function isUserLoggedIn(userLogin: UserLogin) {
   );
 }
 
+function isUserDoesNotRequireMfa(userLogin: UserLogin) {
+  return (
+    userLogin.sessionState && userLogin.sessionState === USER_STATE.AUTHENTICATED
+  );
+}
+
 export function enterPasswordPost(
   fromAccountExists = false,
   service: EnterPasswordServiceInterface = enterPasswordService(),
@@ -53,6 +59,10 @@ export function enterPasswordPost(
       req.session.user.phoneNumber = userLogin.redactedPhoneNumber;
       await mfaCodeService.sendMfaCode(id, email);
       return res.redirect(PATH_NAMES.ENTER_MFA);
+    }
+
+    if(isUserDoesNotRequireMfa(userLogin)) {
+      return res.redirect(PATH_NAMES.AUTH_CODE);
     }
 
     if (fromAccountExists) {

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -64,6 +64,28 @@ describe("enter password controller", () => {
       expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_MFA);
     });
 
+    it("should redirect to auth code when mfa is not required", async () => {
+      const fakeService: EnterPasswordServiceInterface = {
+        loginUser: sandbox.fake.returns({
+          sessionState: USER_STATE.AUTHENTICATED,
+          redactedPhoneNumber: "******3456",
+        }),
+      };
+
+      res.locals.sessionId = "123456-djjad";
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+      req.body["password"] = "password";
+
+      await enterPasswordPost(
+        false,
+        fakeService
+      )(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.AUTH_CODE);
+    });
+
     it("should throw error when API call throws error", async () => {
       const error = new Error("Internal server error");
       const fakeService: EnterPasswordServiceInterface = {

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -123,4 +123,24 @@ describe("Integration::enter password", () => {
       .expect("Location", "/enter-code")
       .expect(302, done);
   });
+
+  it("should redirect to auth-code page when password is correct", (done) => {
+    nock(baseApi)
+      .post("/login")
+      .once()
+      .reply(200, {
+        sessionState: USER_STATE.AUTHENTICATED,
+      })
+
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "password",
+      })
+      .expect("Location", "/auth-code")
+      .expect(302, done);
+  });
 });


### PR DESCRIPTION
## What?

- Skip 2FA when the state of AUTHENTICATED is returned
- We can remove the check in the create-password-controller and MFA is required atm for users who are signing up

## Why?

- When a user successfully logs in the service requires MFA then the LOGGED_IN is returned from the API and the user is required to confirm who they are using 2FA which is why they are then redirected to the check your phone page.
- For services that don't require MFA when a user logs in then the AUTHENTICATED state is returned from the API and we can redirect the user to auth-code, skipping the need for 2FA.

