### PR TITLE
GOVSI-818 - Pass through the client session ID to the login endpoint

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -53,7 +53,8 @@ export function enterPasswordPost(
   return async function (req: Request, res: Response) {
     const { email } = req.session.user;
     const id = res.locals.sessionId;
-    const userLogin = await service.loginUser(id, email, req.body["password"]);
+    const clientSessionId = res.locals.clientSessionId;
+    const userLogin = await service.loginUser(id, email, req.body["password"], clientSessionId);
 
     if (isUserLoggedIn(userLogin)) {
       req.session.user.phoneNumber = userLogin.redactedPhoneNumber;

--- a/src/components/enter-password/enter-password-service.ts
+++ b/src/components/enter-password/enter-password-service.ts
@@ -1,4 +1,4 @@
-import { getBaseRequestConfig, Http, http } from "../../utils/http";
+import { getBaseRequestConfigWithClientSession, Http, http } from "../../utils/http";
 import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../app.constants";
 import { EnterPasswordServiceInterface, UserLogin } from "./types";
 
@@ -8,9 +8,10 @@ export function enterPasswordService(
   const loginUser = async function (
     sessionId: string,
     emailAddress: string,
-    password: string
+    password: string,
+    clientSessionId: string
   ): Promise<UserLogin> {
-    const config = getBaseRequestConfig(sessionId);
+    const config = getBaseRequestConfigWithClientSession(sessionId, clientSessionId);
     config.validateStatus = function (status: any) {
       return (
         status === HTTP_STATUS_CODES.OK ||

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -50,6 +50,7 @@ describe("enter password controller", () => {
       };
 
       res.locals.sessionId = "123456-djjad";
+      res.locals.clientSessionId = "00000-djjad";
       req.session.user = {
         email: "joe.bloggs@test.com",
       };
@@ -73,6 +74,7 @@ describe("enter password controller", () => {
       };
 
       res.locals.sessionId = "123456-djjad";
+      res.locals.clientSessionId = "00000-djjad";
       req.session.user = {
         email: "joe.bloggs@test.com",
       };
@@ -97,6 +99,7 @@ describe("enter password controller", () => {
       };
 
       res.locals.sessionId = "123456-djjad";
+      res.locals.clientSessionId = "00000-djjad";
       req.session.user = {
         email: "joe.bloggs@test.com",
       };

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -24,6 +24,7 @@ describe("Integration::enter password", () => {
       .stub(sessionMiddleware, "validateSessionMiddleware")
       .callsFake(function (req: any, res: any, next: any): void {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+        res.locals.clientSessionId = "gdsfsfdsgsdgsd-mjdzU854";
         req.session.user = {
           email: "joe.bloggs@digital.cabinet-office.gov.uk",
         };

--- a/src/components/enter-password/types.ts
+++ b/src/components/enter-password/types.ts
@@ -7,6 +7,7 @@ export interface EnterPasswordServiceInterface {
   loginUser: (
     sessionId: string,
     email: string,
-    password: string
+    password: string,
+    clientSessionId: string
   ) => Promise<UserLogin>;
 }


### PR DESCRIPTION
## What?

- Pass through the client session ID to the login endpoint

## Why?

- It is required by the Login lambda so it can find out the relevant client details and calculate the state machine rule

