### PR TITLE
Add mfa rate limiting

### DIFF
--- a/src/components/common/mfa/mfa-service.ts
+++ b/src/components/common/mfa/mfa-service.ts
@@ -1,19 +1,34 @@
-import { MfaServiceInterface, UserSessionState } from "./types";
-import { API_ENDPOINTS } from "../../../app.constants";
+import { MfaServiceInterface } from "./types";
+import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../../app.constants";
 import { getBaseRequestConfig, http, Http } from "../../../utils/http";
+import { ApiResponse, ApiResponseResult } from "../../../types";
 
 export function mfaService(axios: Http = http): MfaServiceInterface {
   const sendMfaCode = async function (
     sessionId: string,
     emailAddress: string
-  ): Promise<void> {
-    await axios.client.post<UserSessionState>(
+  ): Promise<ApiResponseResult> {
+    const config = getBaseRequestConfig(sessionId);
+    config.validateStatus = function (status: number) {
+      return (
+        status === HTTP_STATUS_CODES.OK ||
+        status === HTTP_STATUS_CODES.BAD_REQUEST
+      );
+    };
+
+    const { data, status } = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.MFA,
       {
         email: emailAddress,
       },
-      getBaseRequestConfig(sessionId)
+      config
     );
+
+    return {
+      success: status === HTTP_STATUS_CODES.OK,
+      code: data.code,
+      message: data.message,
+    };
   };
 
   return {

--- a/src/components/common/mfa/types.ts
+++ b/src/components/common/mfa/types.ts
@@ -1,7 +1,8 @@
-export interface MfaServiceInterface {
-  sendMfaCode: (sessionId: string, emailAddress: string) => Promise<void>;
-}
+import { ApiResponseResult } from "../../../types";
 
-export interface UserSessionState {
-  sessionState: string;
+export interface MfaServiceInterface {
+  sendMfaCode: (
+    sessionId: string,
+    emailAddress: string
+  ) => Promise<ApiResponseResult>;
 }

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { ExpressRouteFunc } from "../../types";
-import { PATH_NAMES } from "../../app.constants";
+import { ERROR_CODES, PATH_NAMES } from "../../app.constants";
 import { mfaService } from "../common/mfa/mfa-service";
 import { MfaServiceInterface } from "../common/mfa/types";
 
@@ -16,7 +16,15 @@ export function resendMfaCodePost(
   return async function (req: Request, res: Response) {
     const { email } = req.session.user;
     const id = res.locals.sessionId;
-    await service.sendMfaCode(id, email);
-    res.redirect(PATH_NAMES.ENTER_MFA);
+    const result = await service.sendMfaCode(id, email);
+
+    if (!result.success) {
+      if (result.code === ERROR_CODES.REQUESTED_TOO_MANY_SECURITY_CODES) {
+        return res.redirect(PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED);
+      }
+      return res.redirect(PATH_NAMES.SECURITY_CODE_WAIT);
+    }
+
+    return res.redirect(PATH_NAMES.ENTER_MFA);
   };
 }

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-controller.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-controller.test.ts
@@ -46,7 +46,7 @@ describe("resend mfa controller", () => {
   describe("resendMfaCodePost", () => {
     it("should send mfa code and redirect to /enter-code view", async () => {
       const fakeService: MfaServiceInterface = {
-        sendMfaCode: sandbox.fake(),
+        sendMfaCode: sandbox.fake.returns({ success: true }),
       };
 
       res.locals.sessionId = "123456-djjad";

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -93,4 +93,32 @@ describe("Integration:: resend mfa code", () => {
       })
       .expect(500, done);
   });
+
+  it("should redirect to /security-code-requested-too-many-times when request OTP more than 5 times", (done) => {
+    nock(baseApi).post("/mfa").once().reply(400, { code: "1024" });
+
+    request(app)
+      .post("/resend-code")
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+      })
+      .expect("Location", "/security-code-requested-too-many-times")
+      .expect(302, done);
+  });
+
+  it("should redirect to /security-code-invalid-request when exceeded OTP request limit", (done) => {
+    nock(baseApi).post("/mfa").once().reply(400, { code: "1025" });
+
+    request(app)
+      .post("/resend-code")
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+      })
+      .expect("Location", "/security-code-invalid-request")
+      .expect(302, done);
+  });
 });


### PR DESCRIPTION
## What?

Add error handling when rate limit hit on enter-mfa endpoint

## Why?

To prevent abuse of the system.