### PR TITLE
GOVSI-839 - Amend frontend for dropoffs

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -60,6 +60,10 @@ export function enterPasswordPost(
       return res.redirect(PATH_NAMES.ACCOUNT_LOCKED);
     }
 
+    if (userLogin.sessionState === USER_STATE.REQUIRES_TWO_FACTOR) {
+      return res.redirect(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+    }
+
     if (userLogin.sessionState === USER_STATE.LOGGED_IN) {
       req.session.user.phoneNumber = userLogin.redactedPhoneNumber;
       await mfaCodeService.sendMfaCode(sessionId, email);

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -88,6 +88,29 @@ describe("enter password controller", () => {
       expect(res.redirect).to.have.calledWith(PATH_NAMES.AUTH_CODE);
     });
 
+
+    it("should redirect to enter phone number when phone number is not verified", async () => {
+      const fakeService: EnterPasswordServiceInterface = {
+        loginUser: sandbox.fake.returns({
+          sessionState: USER_STATE.REQUIRES_TWO_FACTOR,
+        }),
+      };
+
+      res.locals.sessionId = "123456-djjad";
+      res.locals.clientSessionId = "00000-djjad";
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+      req.body["password"] = "password";
+
+      await enterPasswordPost(false, fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER);
+    });
+
     it("should throw error when API call throws error", async () => {
       const error = new Error("Internal server error");
       const fakeService: EnterPasswordServiceInterface = {

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -158,4 +158,21 @@ describe("Integration::enter password", () => {
       .expect("Location", "/account-locked")
       .expect(302, done);
   });
+
+  it("should redirect to /enter-phone-number when user does not have a verified phone number", (done) => {
+    nock(baseApi).post("/login").once().reply(200, {
+      sessionState: USER_STATE.REQUIRES_TWO_FACTOR,
+    });
+
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "password",
+      })
+      .expect("Location", "/enter-phone-number")
+      .expect(302, done);
+  });
 });

--- a/src/components/enter-password/types.ts
+++ b/src/components/enter-password/types.ts
@@ -1,5 +1,5 @@
 export interface UserLogin {
-  redactedPhoneNumber: string;
+  redactedPhoneNumber?: string;
   sessionState: string;
 }
 


### PR DESCRIPTION

## What?

- Change the login lambda to check if the REQUIRES_TWO_FACTOR state is returned from login and redirect them to the CREATE_ACCOUNT_ENTER_PHONE_NUMBER screen if so
- Make redacted phone number optional as it will not be returned if this state is returned

## Why?

- When the REQUIRES_TWO_FACTOR state is returned from the login endpoint, we need to direct the user to the CREATE_ACCOUNT_ENTER_PHONE_NUMBER page so that they can register a phone number and verify it.
