### PR TITLE
Only create a new session if one doesn't exist

### DIFF
--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -6,6 +6,6 @@ export function landingGet(req: Request, res: Response): void {
   if (!req.query.interrupt) {
     return res.redirect(PATH_NAMES.SIGN_IN_OR_CREATE);
   }
-  //TODO add values for consent and t&cs
+
   res.redirect(getNextPathByState(req.query.interrupt as string));
 }

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -6,7 +6,10 @@ export function initialiseSessionMiddleware(
   res: Response,
   next: NextFunction
 ): void {
-  req.session.user = {};
+  if (!req.cookies || !req.cookies["aps"]) {
+    req.session.user = {};
+  }
+
   next();
 }
 


### PR DESCRIPTION
## What?

Only create a new session if one doesn't exist

## Why?

To allow SSO to work with consent, tc's and VTR. This will all be superseeded when the session is moved to redis.
