### PR TITLE
GOVSI-748: repoint to frontend api

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -29,5 +29,6 @@ jobs:
     env:
       ENVIRONMENT: development
       API_BASE_URL: http://localhost:6000/api
+      FRONTEND_API_BASE_URL: http://localhost:6060/api
       SESSION_SECRET: secret
       API_KEY: test-key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     environment:
       - ENVIRONMENT="development"
       - API_BASE_URL=
+      - FRONTEND_API_BASE_URL=
       - TEST_CLIENT_ID=
     restart: on-failure
     networks:

--- a/manifest.yml
+++ b/manifest.yml
@@ -9,6 +9,7 @@ applications:
     env:
       NODE_ENV: "production"
       API_BASE_URL: ((api_base_url))
+      FRONTEND_API_BASE_URL: ((frontend_api_base_url))
       SESSION_EXPIRY: ((session_expiry))
       SESSION_SECRET: ((session_secret))
       API_KEY: ((api_key))

--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -28,7 +28,7 @@ describe("Integration:: check your email email", () => {
       });
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)
       .get("/check-your-email")

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -29,7 +29,7 @@ describe("Integration:: check your phone", () => {
       });
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)
       .get("/check-your-phone")

--- a/src/components/create-password/tests/create-password-integration.test.ts
+++ b/src/components/create-password/tests/create-password-integration.test.ts
@@ -28,7 +28,7 @@ describe("Integration::register create password", () => {
       });
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)
       .get("/create-password")

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -26,7 +26,7 @@ describe("Integration::enter email", () => {
       });
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)
       .get("/enter-email")

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -29,7 +29,7 @@ describe("Integration:: enter mfa", () => {
       });
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)
       .get("/enter-code")

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -32,7 +32,7 @@ describe("Integration::enter password", () => {
       });
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)
       .get(ENDPOINT)

--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -28,7 +28,7 @@ describe("Integration::enter phone number", () => {
       });
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)
       .get("/enter-phone-number")

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -29,7 +29,7 @@ describe("Integration:: resend mfa code", () => {
       });
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)
       .get("/resend-code")

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
@@ -27,7 +27,7 @@ describe("Integration::reset password check email ", () => {
       });
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
   });
 
   beforeEach(() => {

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -18,7 +18,7 @@ describe("Integration::reset password", () => {
     sandbox = sinon.createSandbox();
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)
       .get(ENDPOINT)

--- a/src/components/share-info/tests/share-info-integration.test.ts
+++ b/src/components/share-info/tests/share-info-integration.test.ts
@@ -40,7 +40,7 @@ describe("Integration::share info", () => {
       });
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     createClientInfoNock(baseApi);
 

--- a/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
+++ b/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
@@ -43,7 +43,7 @@ describe("Integration:: updated-terms-code", () => {
       });
 
     app = require("../../../app").createApp();
-    baseApi = process.env.API_BASE_URL;
+    baseApi = process.env.FRONTEND_API_BASE_URL;
 
     nockClientInfo(baseApi);
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,10 @@ export function getApiBaseUrl(): string {
   return process.env.API_BASE_URL;
 }
 
+export function getFrontendApiBaseUrl(): string {
+  return process.env.FRONTEND_API_BASE_URL;
+}
+
 export function getNodeEnv(): string {
   return process.env.NODE_ENV || "development";
 }

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -4,7 +4,7 @@ import axios, {
   AxiosError,
   AxiosResponse,
 } from "axios";
-import { getApiBaseUrl, getApiKey } from "../config";
+import { getApiKey, getFrontendApiBaseUrl } from "../config";
 import { logger } from "./logger";
 import { ApiResponseResult } from "../types";
 import { HTTP_STATUS_CODES } from "../app.constants";
@@ -83,7 +83,7 @@ export class Http {
 
   private initHttp() {
     const http = axios.create({
-      baseURL: getApiBaseUrl(),
+      baseURL: getFrontendApiBaseUrl(),
       headers: headers,
       validateStatus: (status) => {
         return (


### PR DESCRIPTION

## What?

Repoint to frontend api.

The oidc and frontend endpoints have been split into two separate apis.  These changes repoint the frontend to use the new api.

New environment variable FRONTEND_API_BASE_URL with the new api url.

## Why?

Ability to isolate the two APIs. They can then be deployed separately and have different configurations (such as access controls and rate limits).

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/642
