### PR TITLE
Change request sessions state name and remove error page where it wasn't needed

### DIFF
--- a/src/components/browser-back-button-error/index.njk
+++ b/src/components/browser-back-button-error/index.njk
@@ -16,9 +16,6 @@
   {{ 'pages.browserBackButtonError.header' | translate }}
 </h1>
 
-{# might not need this? #}
-<h2 class="govuk-body-l">{{ clientName }}</h2> 
-
 <p class="govuk-body">{{'pages.browserBackButtonError.paragraph1' | translate}}</p>
 
 {{ govukButton({

--- a/src/components/check-your-email/check-your-email-controller.ts
+++ b/src/components/check-your-email/check-your-email-controller.ts
@@ -23,7 +23,7 @@ export const checkYourEmailPost = (
     validationKey: "pages.checkYourEmail.code.validationError.invalidCode",
     validationState: USER_STATE.EMAIL_CODE_NOT_VALID,
     callback: (req, res, state) => {
-      req.session.nextState = state;
+      req.session.backState = state;
       return res.redirect(getNextPathByState(state));
     },
   });

--- a/src/components/check-your-email/tests/check-your-email-controller.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-controller.test.ts
@@ -86,11 +86,11 @@ describe("check your email controller", () => {
         }),
       };
 
-      expect(req.session.nextState).to.be.undefined;
+      expect(req.session.backState).to.be.undefined;
 
       await checkYourEmailPost(fakeService)(req as Request, res as Response);
 
-      expect(req.session.nextState).to.equal("EMAIL_CODE_VERIFIED");
+      expect(req.session.backState).to.equal("EMAIL_CODE_VERIFIED");
     });
   });
 });

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -23,6 +23,7 @@ export const checkYourPhonePost = (
     validationKey: "pages.checkYourPhone.code.validationError.invalidCode",
     validationState: USER_STATE.PHONE_NUMBER_CODE_NOT_VALID,
     callback: (req, res, state) => {
+      req.session.backState = state;
       if (state === USER_STATE.CONSENT_REQUIRED) {
         req.session.nextState = state;
         return res.redirect(PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL);

--- a/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
@@ -104,11 +104,11 @@ describe("check your phone controller", () => {
         }),
       };
 
-      expect(req.session.nextState).to.be.undefined;
+      expect(req.session.backState).to.be.undefined;
 
       await checkYourPhonePost(fakeService)(req as Request, res as Response);
 
-      expect(req.session.nextState).to.equal("CONSENT_REQUIRED");
+      expect(req.session.backState).to.equal("CONSENT_REQUIRED");
     });
   });
 });

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -24,7 +24,7 @@ export function createPasswordPost(
       throw new BadRequestError(result.message, result.code);
     }
 
-    req.session.nextState = result.sessionState;
+    req.session.backState = result.sessionState;
 
     return res.redirect(getNextPathByState(result.sessionState));
   };

--- a/src/components/create-password/tests/create-password-controller.test.ts
+++ b/src/components/create-password/tests/create-password-controller.test.ts
@@ -103,5 +103,20 @@ describe("create-password controller", () => {
       ).to.be.rejectedWith(Error, "Internal server error");
       expect(fakeService.signUpUser).to.have.been.called;
     });
+
+    it("should update the user session state value in the req", async () => {
+      const fakeService: CreatePasswordServiceInterface = {
+        signUpUser: sandbox.fake.returns({
+          success: true,
+          sessionState: USER_STATE.REQUIRES_TWO_FACTOR,
+        }),
+      };
+
+      expect(req.session.backState).to.be.undefined;
+
+      await createPasswordPost(fakeService)(req as Request, res as Response);
+
+      expect(req.session.backState).to.equal(USER_STATE.REQUIRES_TWO_FACTOR);
+    });
   });
 });

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -71,8 +71,6 @@ export function enterPasswordPost(
         redirectTo = getNextPathByState(result.sessionState);
       }
 
-      req.session.nextState = userLogin.sessionState;
-
       return res.redirect(redirectTo);
     }
 

--- a/src/components/enter-password/enter-password-routes.ts
+++ b/src/components/enter-password/enter-password-routes.ts
@@ -11,10 +11,7 @@ import {
   validateEnterPasswordAccountExistsRequest,
   validateEnterPasswordRequest,
 } from "./enter-password-validation";
-import {
-  validateSessionMiddleware,
-  handleBackButtonMiddleware,
-} from "../../middleware/session-middleware";
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { asyncHandler } from "../../utils/async";
 
 const router = express.Router();
@@ -22,14 +19,12 @@ const router = express.Router();
 router.get(
   PATH_NAMES.ENTER_PASSWORD,
   validateSessionMiddleware,
-  handleBackButtonMiddleware,
   enterPasswordGet
 );
 
 router.get(
   PATH_NAMES.ENTER_PASSWORD_ACCOUNT_EXISTS,
   validateSessionMiddleware,
-  handleBackButtonMiddleware,
   enterPasswordAccountExistsGet
 );
 

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -167,39 +167,5 @@ describe("enter password controller", () => {
       ).to.be.rejectedWith(Error, "Internal server error");
       expect(fakeService.loginUser).to.have.been.calledOnce;
     });
-
-    it("should update the user session state value in the req", async () => {
-      const fakeService: EnterPasswordServiceInterface = {
-        loginUser: sandbox.fake.returns({
-          sessionState: USER_STATE.LOGGED_IN,
-          redactedPhoneNumber: "******3456",
-          success: true,
-        }),
-      };
-
-      const fakeMfaService: MfaServiceInterface = {
-        sendMfaCode: sandbox.fake.returns({
-          sessionState: "MFA_SMS_CODE_SENT",
-          success: true,
-        }),
-      };
-
-      res.locals.sessionId = "123456-djjad";
-      res.locals.clientSessionId = "00000-djjad";
-      req.session = {
-        email: "joe.bloggs@test.com",
-      };
-      req.body["password"] = "password";
-
-      expect(req.session.nextState).to.be.undefined;
-
-      await enterPasswordPost(
-        false,
-        fakeService,
-        fakeMfaService
-      )(req as Request, res as Response);
-
-      expect(req.session.nextState).to.equal(USER_STATE.LOGGED_IN);
-    });
   });
 });

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -58,7 +58,7 @@ export function enterPhoneNumberPost(
       );
     }
 
-    req.session.nextState = sendNotificationResponse.sessionState;
+    req.session.backState = sendNotificationResponse.sessionState;
 
     return res.redirect(
       getNextPathByState(sendNotificationResponse.sessionState)

--- a/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
@@ -163,14 +163,14 @@ describe("enter phone number controller", () => {
         email: "test@test.com",
       };
 
-      expect(req.session.nextState).to.be.undefined;
+      expect(req.session.backState).to.be.undefined;
 
       await enterPhoneNumberPost(fakeNotificationService, fakeProfileService)(
         req as Request,
         res as Response
       );
 
-      expect(req.session.nextState).to.equal("VERIFY_PHONE_NUMBER_CODE_SENT");
+      expect(req.session.backState).to.equal("VERIFY_PHONE_NUMBER_CODE_SENT");
     });
   });
 });

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -53,13 +53,13 @@ export function handleBackButtonMiddleware(
   res: Response,
   next: NextFunction
 ): void {
-  const { nextState } = req.session;
+  const { backState } = req.session;
 
-  if (nextState) {
-    const nextPath = getNextPathByState(nextState);
+  if (backState) {
+    const nextPath = getNextPathByState(backState);
 
     if (req.route.path !== nextPath) {
-      req.session.nextState = null;
+      req.session.backState = null;
       return res.redirect(PATH_NAMES.INVALID_SESSION);
     }
   }

--- a/test/unit/middleware/session-middleware.ts
+++ b/test/unit/middleware/session-middleware.ts
@@ -75,7 +75,7 @@ describe("session-middleware", () => {
   describe("handleBackButtonMiddleware", () => {
     it("should call next when session state is missing", () => {
       req.session = {
-        nextState: null
+        backState: null
       };
       handleBackButtonMiddleware(req as Request, res as Response, next);
 
@@ -84,7 +84,7 @@ describe("session-middleware", () => {
 
     it("should call next when the next path matches the current request path", () => {
       req.session = {
-        nextState: USER_STATE.LOGGED_IN
+        backState: USER_STATE.LOGGED_IN
       };
       req.route = {
         path: PATH_NAMES.ENTER_MFA
@@ -97,14 +97,14 @@ describe("session-middleware", () => {
 
     it("should redirect to invalid session error page if next path does not match current request path", () => {
       req.session = {
-        nextState: USER_STATE.LOGGED_IN
+        backState: USER_STATE.LOGGED_IN
       };
       req.route = {
         path: "/incorrect-path"
       };
 
       handleBackButtonMiddleware(req as Request, res as Response, next);
-      expect(req.session.nextState).to.be.null;
+      expect(req.session.backState).to.be.null;
       expect(res.redirect).to.be.calledWith("/invalid-session");
     });
   });


### PR DESCRIPTION

## What?

Bugfix to change the request sessions state variable name to backState since nextState was already used for something else. Also removed the back button error page from the enter-password route since its not needed there.

## Why?

The nextState session variable was being used for something else which caused a bug with the new back button error pages.

