### PR TITLE
GOVSI-619: pass clientSessionId to sendnotification service

### DIFF
--- a/src/components/account-not-found/account-not-found-controller.ts
+++ b/src/components/account-not-found/account-not-found-controller.ts
@@ -22,9 +22,11 @@ export function accountNotFoundPost(
   return async function (req: Request, res: Response) {
     const email = req.session.email;
     const sessionId = res.locals.sessionId;
+    const clientSessionId = res.locals.clientSessionId;
 
     const result = await service.sendNotification(
       sessionId,
+      clientSessionId,
       email,
       NOTIFICATION_TYPE.VERIFY_EMAIL,
       req.ip

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -34,6 +34,7 @@ export const checkYourPhonePost = (
       ) {
         await notificationService.sendNotification(
           res.locals.sessionId,
+          res.locals.clientSessionId,
           req.session.email,
           NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION,
           req.ip

--- a/src/components/common/send-notification/send-notification-service.ts
+++ b/src/components/common/send-notification/send-notification-service.ts
@@ -13,6 +13,7 @@ export function sendNotificationService(
 ): SendNotificationServiceInterface {
   const sendNotification = async function (
     sessionId: string,
+    clientSessionId: string,
     email: string,
     notificationType: string,
     sourceIp: string,
@@ -32,6 +33,7 @@ export function sendNotificationService(
       payload,
       getRequestConfig({
         sessionId: sessionId,
+        clientSessionId: clientSessionId,
         sourceIp: sourceIp,
       })
     );

--- a/src/components/common/send-notification/types.ts
+++ b/src/components/common/send-notification/types.ts
@@ -3,6 +3,7 @@ import { ApiResponseResult } from "../../../types";
 export interface SendNotificationServiceInterface {
   sendNotification: (
     sessionId: string,
+    clientSessionId: string,
     email: string,
     notificationType: string,
     sourceIp: string,

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -43,6 +43,7 @@ export function enterEmailCreatePost(
   return async function (req: Request, res: Response) {
     const email = req.body.email;
     const sessionId = res.locals.sessionId;
+    const clientSessionId = res.locals.clientSessionId;
 
     req.session.email = email;
     const userExistsResponse = await service.userExists(
@@ -62,6 +63,7 @@ export function enterEmailCreatePost(
 
     const sendNotificationResponse = await notificationService.sendNotification(
       sessionId,
+      clientSessionId,
       email,
       NOTIFICATION_TYPE.VERIFY_EMAIL,
       req.ip

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -45,6 +45,7 @@ export function enterPhoneNumberPost(
 
     const sendNotificationResponse = await service.sendNotification(
       id,
+      clientSessionId,
       email,
       NOTIFICATION_TYPE.VERIFY_PHONE_NUMBER,
       req.ip,


### PR DESCRIPTION

## What?

Pass clientSessionId to sendnotification service.

## Why?

As part of changes to the back to support test clients, SendNotification now needs to know which client is using it.  This requires the frontend to pass the clientSessionId.

## Related PRs

To be merged before the backend changes in this PR:

https://github.com/alphagov/di-authentication-api/pull/716
