### PR TITLE
Handle logout errors via front end

### DIFF
--- a/src/components/signed-out/signed-out-controller.ts
+++ b/src/components/signed-out/signed-out-controller.ts
@@ -1,6 +1,14 @@
 import { Request, Response } from "express";
+import { BadRequestError } from "../../utils/error";
 
 export function signedOutGet(req: Request, res: Response): void {
+  if (req.query && req.query.error_code) {
+    throw new BadRequestError(
+      req.query.error_description as string,
+      req.query.error_code as string
+    );
+  }
+
   if (req.cookies) {
     for (const cookieName of Object.keys(req.cookies)) {
       if (cookieName !== "lng" && cookieName !== "cookies_preferences_set") {
@@ -8,5 +16,6 @@ export function signedOutGet(req: Request, res: Response): void {
       }
     }
   }
+
   res.render("signed-out/index.njk");
 }

--- a/src/components/signed-out/tests/signed-out-controller.test.ts
+++ b/src/components/signed-out/tests/signed-out-controller.test.ts
@@ -16,6 +16,7 @@ describe("signed out controller", () => {
 
     req = {
       body: {},
+      query: {},
       session: {},
       cookies: {
         aps: "123",
@@ -44,6 +45,15 @@ describe("signed out controller", () => {
       expect(res.clearCookie).not.to.have.calledWith("cookies_preferences_set");
       expect(res.clearCookie).not.to.have.calledWith("lng");
       expect(res.clearCookie).to.have.calledWith("gs");
+    });
+
+    it("should throw error when invalid sign out request", () => {
+      req.query.error_code = "invalid_request";
+      req.query.error_description = "something bad happened";
+
+      expect(() => signedOutGet(req as Request, res as Response)).to.throw(
+        "Bad Request:invalid_request:something bad happened"
+      );
     });
   });
 });

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,6 +1,6 @@
 export class BadRequestError extends Error {
   private status: number;
-  constructor(message: string, code: number) {
+  constructor(message: string, code: number | string) {
     super(`Bad Request:${code}:${message}`);
     this.status = 400;
   }


### PR DESCRIPTION
## What?

Handle logout endpoint issues in front end.

## Why?

So errors are handled gracefully.
