### PR TITLE
Update cookie consent logic

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -138,6 +138,12 @@ export enum NOTIFICATION_TYPE {
   MFA_SMS = "MFA_SMS",
 }
 
+export const COOKIE_CONSENT = {
+  ACCEPT: "accept",
+  REJECT: "reject",
+  NOT_ENGAGED: "not-engaged",
+};
+
 export enum SUPPORT_TYPE {
   GOV_SERVICE = "GOV_SERVICE",
   PUBLIC = "PUBLIC",

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -1,9 +1,7 @@
 (function (w) {
   "use strict";
-  function appInit(trackingId, cookieDomain) {
-    var cookies = window.GOVSignIn.Cookies(trackingId, cookieDomain);
-
-    cookies.processCookieConsentFlag();
+  function appInit(trackingId) {
+    var cookies = window.GOVSignIn.Cookies(trackingId);
 
     if (cookies.hasConsentForAnalytics()) {
       cookies.initAnalytics();

--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -46,31 +46,6 @@ var cookies = function (trackingId, analyticsCookieDomain) {
     }
   }
 
-  function getQueryParameterByName(name) {
-    var match = RegExp("[?&]" + name + "=([^&]*)").exec(window.location.search);
-    return match && decodeURIComponent(match[1].replace(/\+/g, " "));
-  }
-
-  function processCookieConsentFlag() {
-    var cookieConsent = getQueryParameterByName("cookie_consent");
-
-    if (!cookieConsent) {
-      return;
-    }
-
-    cookieConsent = cookieConsent.trim();
-
-    if (cookieConsent === "accept" || cookieConsent === "reject") {
-      setCookie(COOKIES_PREFERENCES_SET, {
-        analytics: cookieConsent === "accept",
-      });
-    }
-
-    if (cookieConsent === "not-engaged") {
-      setCookie(COOKIES_PREFERENCES_SET, "", { days: -1 });
-    }
-  }
-
   function setBannerCookieConsent(analyticsConsent) {
     setCookie(
       COOKIES_PREFERENCES_SET,
@@ -237,7 +212,6 @@ var cookies = function (trackingId, analyticsCookieDomain) {
     cookiesPageInit,
     hasConsentForAnalytics,
     initAnalytics,
-    processCookieConsentFlag,
   };
 };
 

--- a/src/components/auth-code/auth-code-controller.ts
+++ b/src/components/auth-code/auth-code-controller.ts
@@ -1,8 +1,24 @@
 import { Request, Response } from "express";
 import { getApiBaseUrl } from "../../config";
-import { API_ENDPOINTS } from "../../app.constants";
+import { API_ENDPOINTS, COOKIE_CONSENT } from "../../app.constants";
+import * as querystring from "querystring";
 
 export function authCodeGet(req: Request, res: Response): void {
-  const authCodeUrl = getApiBaseUrl() + API_ENDPOINTS.AUTH_CODE;
-  res.redirect(authCodeUrl);
+  const authCodeRedirect = `${getApiBaseUrl()}${API_ENDPOINTS.AUTH_CODE}`;
+  const cookieConsent = req.cookies.cookies_preferences_set;
+  let consentValue = COOKIE_CONSENT.NOT_ENGAGED;
+
+  if (cookieConsent) {
+    const parsedCookie = JSON.parse(cookieConsent);
+    consentValue =
+      parsedCookie.analytics === true
+        ? COOKIE_CONSENT.ACCEPT
+        : COOKIE_CONSENT.REJECT;
+  }
+
+  const queryParamCookieConsent = querystring.stringify({
+    cookie_consent: consentValue,
+  });
+
+  res.redirect(authCodeRedirect + "?" + queryParamCookieConsent);
 }

--- a/src/components/auth-code/tests/auth-code-controller.test.ts
+++ b/src/components/auth-code/tests/auth-code-controller.test.ts
@@ -10,9 +10,11 @@ describe("auth code controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
   let res: Partial<Response>;
+  const config = require("../../../config.ts");
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    sandbox.stub(config, "getApiBaseUrl").returns("http://test-url");
 
     req = {
       body: {},
@@ -31,10 +33,34 @@ describe("auth code controller", () => {
   });
 
   describe("authCodeGet", () => {
-    it("should redirect to auth code API endpoint", () => {
+    it("should redirect to auth code API endpoint with cookie consent param set as not-engaged", () => {
+      req.cookies = {};
+
       authCodeGet(req as Request, res as Response);
 
-      expect(res.redirect).to.have.been.calledOnce;
+      expect(res.redirect).to.have.been.calledWith(
+        "http://test-url/auth-code?cookie_consent=not-engaged"
+      );
+    });
+
+    it("should redirect to auth code API endpoint with cookie consent param set as accept", () => {
+      req.cookies = { cookies_preferences_set: '{"analytics":true}' };
+
+      authCodeGet(req as Request, res as Response);
+
+      expect(res.redirect).to.have.been.calledWith(
+        "http://test-url/auth-code?cookie_consent=accept"
+      );
+    });
+
+    it("should redirect to auth code API endpoint with cookie consent param set as reject", () => {
+      req.cookies = { cookies_preferences_set: '{"analytics":false}' };
+
+      authCodeGet(req as Request, res as Response);
+
+      expect(res.redirect).to.have.been.calledWith(
+        "http://test-url/auth-code?cookie_consent=reject"
+      );
     });
   });
 });

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -121,7 +121,5 @@
 {% block bodyEnd %}
   <script type="text/javascript" src="/public/scripts/cookies.js"></script>
   <script type="text/javascript"  src="/public/scripts/application.js"></script>
-  <script type="text/javascript" nonce='{{scriptNonce}}'>window.GOVSignIn.appInit("{{gtmId}}", "{{analyticsCookieDomain}}")</script>
+  <script type="text/javascript" nonce='{{scriptNonce}}'>window.GOVSignIn.appInit("{{gtmId}}")</script>
 {% endblock %}
-
-

--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -1,6 +1,31 @@
 import { Request, Response } from "express";
-import { PATH_NAMES } from "../../app.constants";
+import { COOKIE_CONSENT, PATH_NAMES } from "../../app.constants";
 import { getNextPathByState } from "../common/constants";
+
+const COOKIES_PREFERENCES_SET = "cookies_preferences_set";
+
+function setPreferencesCookie(cookieConsent: string, res: Response) {
+  if ([COOKIE_CONSENT.ACCEPT, COOKIE_CONSENT.REJECT].includes(cookieConsent)) {
+    const yearFromNow = new Date();
+    yearFromNow.setFullYear(yearFromNow.getFullYear() + 1);
+
+    res.cookie(
+      COOKIES_PREFERENCES_SET,
+      JSON.stringify({ analytics: cookieConsent === COOKIE_CONSENT.ACCEPT }),
+      {
+        expires: yearFromNow,
+        secure: true,
+      }
+    );
+  } else {
+    const expiredDate = new Date();
+    expiredDate.setFullYear(expiredDate.getFullYear() - 1);
+    res.cookie(COOKIES_PREFERENCES_SET, "", {
+      expires: expiredDate,
+      secure: true,
+    });
+  }
+}
 
 export function landingGet(req: Request, res: Response): void {
   let redirectPath = PATH_NAMES.SIGN_IN_OR_CREATE;
@@ -9,19 +34,13 @@ export function landingGet(req: Request, res: Response): void {
     redirectPath = getNextPathByState((req.query.interrupt as string).trim());
   }
 
-  res.redirect(
-    appendQueryParam(
-      "cookie_consent",
-      req.query.cookie_consent as string,
-      redirectPath
-    )
-  );
-}
+  const cookieConsent = req.query.cookie_consent as string;
 
-function appendQueryParam(param: string, value: string, url: string) {
-  if (!param || !value) {
-    return url;
+  if (!cookieConsent) {
+    return res.redirect(redirectPath);
   }
 
-  return `${url}?${param}=${value.trim()}`;
+  setPreferencesCookie(cookieConsent, res);
+
+  res.redirect(redirectPath);
 }

--- a/src/components/landing/tests/landing-controller.test.ts
+++ b/src/components/landing/tests/landing-controller.test.ts
@@ -15,7 +15,12 @@ describe("landing controller", () => {
     sandbox = sinon.createSandbox();
 
     req = { body: {}, session: {}, query: {} };
-    res = { render: sandbox.fake(), redirect: sandbox.fake(), locals: {} };
+    res = {
+      render: sandbox.fake(),
+      redirect: sandbox.fake(),
+      locals: {},
+      cookie: sandbox.fake(),
+    };
   });
 
   afterEach(() => {
@@ -32,14 +37,13 @@ describe("landing controller", () => {
       expect(res.redirect).to.have.calledWith("/sign-in-or-create");
     });
 
-    it("should redirect to /sign-in-or-create page with cookie consent query param", () => {
+    it("should redirect to /sign-in-or-create page with cookie preferences set", () => {
       req.query.cookie_consent = "accept";
 
       landingGet(req as Request, res as Response);
 
-      expect(res.redirect).to.have.calledWith(
-        "/sign-in-or-create?cookie_consent=accept"
-      );
+      expect(res.cookie).to.have.been.called;
+      expect(res.redirect).to.have.calledWith("/sign-in-or-create");
     });
 
     it("should redirect to /uplift page when interrupt query param set", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,10 +30,6 @@ export function getGtmId(): string {
   return process.env.GTM_ID;
 }
 
-export function getAnalyticsCookieDomain(): string {
-  return process.env.ANALYTICS_COOKIE_DOMAIN;
-}
-
 export function getRedisHost(): string {
   return process.env.REDIS_HOST ?? "redis";
 }

--- a/src/middleware/set-local-vars-middleware.ts
+++ b/src/middleware/set-local-vars-middleware.ts
@@ -1,9 +1,5 @@
 import { NextFunction, Request, Response } from "express";
-import {
-  getAccountManagementUrl,
-  getAnalyticsCookieDomain,
-  getGtmId,
-} from "../config";
+import { getAccountManagementUrl, getGtmId } from "../config";
 import { generateNonce } from "../utils/strings";
 
 export function setLocalVarsMiddleware(
@@ -13,7 +9,6 @@ export function setLocalVarsMiddleware(
 ): void {
   res.locals.gtmId = getGtmId();
   res.locals.scriptNonce = generateNonce();
-  res.locals.analyticsCookieDomain = getAnalyticsCookieDomain();
   res.locals.accountManagementUrl = getAccountManagementUrl();
   next();
 }


### PR DESCRIPTION
## What?

Update cookie consent logic to set cookie at the landing route and tag the value on at auth code.

## Why?

There was a bug raised that the cookie_consent query param was not being passed on to the correct routes.
