### PR TITLE
GOVSI-619: pass clientSessionId to the mfa service

### DIFF
--- a/src/components/common/mfa/mfa-service.ts
+++ b/src/components/common/mfa/mfa-service.ts
@@ -6,6 +6,7 @@ import { ApiResponse, ApiResponseResult } from "../../../types";
 export function mfaService(axios: Http = http): MfaServiceInterface {
   const sendMfaCode = async function (
     sessionId: string,
+    clientSessionId: string,
     emailAddress: string,
     sourceIp: string
   ): Promise<ApiResponseResult> {
@@ -16,6 +17,7 @@ export function mfaService(axios: Http = http): MfaServiceInterface {
       },
       getRequestConfig({
         sessionId: sessionId,
+        clientSessionId: clientSessionId,
         sourceIp: sourceIp,
       })
     );

--- a/src/components/common/mfa/types.ts
+++ b/src/components/common/mfa/types.ts
@@ -3,6 +3,7 @@ import { ApiResponseResult } from "../../../types";
 export interface MfaServiceInterface {
   sendMfaCode: (
     sessionId: string,
+    clientSessionId: string,
     emailAddress: string,
     sourceIp: string
   ) => Promise<ApiResponseResult>;

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -65,6 +65,7 @@ export function enterPasswordPost(
       if (userLogin.sessionState === USER_STATE.LOGGED_IN) {
         const result = await mfaCodeService.sendMfaCode(
           sessionId,
+          clientSessionId,
           email,
           req.ip
         );

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -17,8 +17,9 @@ export function resendMfaCodePost(
   return async function (req: Request, res: Response) {
     const { email } = req.session;
     const id = res.locals.sessionId;
+    const clientSessionId = res.locals.clientSessionId;
 
-    const result = await service.sendMfaCode(id, email, req.ip);
+    const result = await service.sendMfaCode(id, clientSessionId, email, req.ip);
 
     if (!result.success && !result.sessionState) {
       throw new BadRequestError(result.message, result.code);

--- a/src/components/uplift-journey/uplift-journey-controller.ts
+++ b/src/components/uplift-journey/uplift-journey-controller.ts
@@ -11,8 +11,9 @@ export function upliftJourneyGet(
   return async function (req: Request, res: Response) {
     const { email } = req.session;
     const { sessionId } = res.locals;
+    const { clientSessionId } = res.locals;
 
-    const result = await mfaCodeService.sendMfaCode(sessionId, email, req.ip);
+    const result = await mfaCodeService.sendMfaCode(sessionId, clientSessionId, email, req.ip);
     res.redirect(getNextPathByState(result.sessionState));
   };
 }


### PR DESCRIPTION
## What?

Pass clientSessionId to the mfa service

## Why?

Server-side needs to know the clientSessionId to check whether a test client is in use.
