### PR TITLE
BAU: substitute shell environment variables in the docker-compose file

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -20,7 +20,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-          - 6379:6379
+          - 6389:6379
 
     steps:
       - uses: actions/checkout@v2
@@ -45,4 +45,4 @@ jobs:
       SESSION_SECRET: secret
       API_KEY: test-key
       REDIS_HOST: localhost
-      REDIS_PORT: 6379
+      REDIS_PORT: 6389

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,12 @@ services:
     volumes:
       - ./:/app
     environment:
-      - ENVIRONMENT="development"
-      - API_BASE_URL=
-      - SESSION_EXPIRY=3600000
-      - SESSION_SECRET="secret"
-      - API_KEY=
-      - FRONTEND_API_BASE_URL=
+      - ENVIRONMENT=${ENVIRONMENT}
+      - API_BASE_URL=${API_BASE_URL}
+      - SESSION_EXPIRY=${SESSION_EXPIRY}
+      - SESSION_SECRET=${SESSION_SECRET}
+      - API_KEY=${API_KEY}
+      - FRONTEND_API_BASE_URL=${FRONTEND_API_BASE_URL}
       - ANALYTICS_COOKIE_DOMAIN=localhost
     restart: on-failure
     networks:
@@ -26,7 +26,7 @@ services:
   redis:
     image: redis:6.0.5-alpine
     ports:
-      - 6379:6379
+      - 6389:6379
     networks:
       - di-net
 
@@ -39,10 +39,10 @@ services:
     ports:
       - 2000:2000
     environment:
-      - ENVIRONMENT="development"
-      - API_BASE_URL=
-      - FRONTEND_API_BASE_URL=
-      - TEST_CLIENT_ID=
+      - ENVIRONMENT=${ENVIRONMENT}
+      - API_BASE_URL=${API_BASE_URL}
+      - FRONTEND_API_BASE_URL=${FRONTEND_API_BASE_URL}
+      - TEST_CLIENT_ID=${TEST_CLIENT_ID}
     restart: on-failure
     networks:
       - di-net

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,10 @@ export function getRedisHost(): string {
   return process.env.REDIS_HOST ?? "redis";
 }
 
+export function getRedisPort(): number {
+  return Number(process.env.REDIS_PORT) ?? 6379;
+}
+
 export function getAccountManagementUrl(): string {
   return process.env.ACCOUNT_MANAGEMENT_URL;
 }

--- a/src/config/session.ts
+++ b/src/config/session.ts
@@ -2,7 +2,7 @@ import redis, { ClientOpts } from "redis";
 import connect_redis, { RedisStore } from "connect-redis";
 import session from "express-session";
 import CF_CONFIG from "./cf";
-import { getRedisHost } from "../config";
+import { getRedisHost, getRedisPort } from "../config";
 const RedisStore = connect_redis(session);
 
 export interface RedisConfigCf {
@@ -18,6 +18,7 @@ export function getSessionStore(): RedisStore {
   if (CF_CONFIG.isLocal) {
     config = {
       host: getRedisHost(),
+      port: getRedisPort()
     };
   } else {
     const redisConfig = CF_CONFIG.getServiceCreds(


### PR DESCRIPTION
## What?

Substitute shell environment variables in the docker-compose file.
Switch default Redis port and make port configurable with an environment variable.

## Why?

Environment variable values are then read in by default from a .env file.  This makes it easier to change the values when needed as the docker-compose.yml file is under source control but .env files are not.

Redis port made configurable so that the frontend can be run against the local backend.  The same port was in use by the authentication api so it wasn't possible to start them both together.
