### PR TITLE
Add missing user journey to data layer

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -186,6 +186,7 @@ var cookies = function (trackingId, analyticsCookieDomain) {
   function getJourneyMapping(url) {
     const JOURNEY_DATA_LAYER_PATHS = {
       "/enter-email?type=create-account": generateSessionJourney('sign up', 'start'),
+      "/account-not-found": generateSessionJourney('sign up', 'start'),
       "/check-your-email": generateSessionJourney('sign up', 'middle'),
       "/create-password": generateSessionJourney('sign up', 'middle'),
       "/enter-phone-number": generateSessionJourney('sign up', 'middle'),


### PR DESCRIPTION
## What?

Add missing user journey to data layer for journey tracking.

## Why?

Missed a required user session to track when users load up the account management page.

