### PR TITLE
Updated the gtm blocklist tags

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -87,13 +87,7 @@ var cookies = function (trackingId, analyticsCookieDomain) {
     window.dataLayer = [
       {
         "gtm.allowlist": ["google"],
-        "gtm.blocklist": [
-          "nonGoogleScripts",
-          "nonGoogleIframes",
-          "nonGooglePixels",
-          "customScripts",
-          "customPixels",
-        ],
+        "gtm.blocklist": ["adm", "awct", "sp", "gclidw", "gcs", "opt"],
       },
       {
         department: {


### PR DESCRIPTION
## What?

Updated the google tag manager blocklist options.

## Why?

Ensures all other tags are blocked apart from google analytics tags.

