### PR TITLE
GOVSI-1014: Convert email to lower case when checking if user exists

### DIFF
--- a/src/components/enter-email/enter-email-service.ts
+++ b/src/components/enter-email/enter-email-service.ts
@@ -19,7 +19,7 @@ export function enterEmailService(
     const response = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.USER_EXISTS,
       {
-        email: emailAddress,
+        email: emailAddress.toLowerCase(),
       },
       getRequestConfig({ sessionId: sessionId, sourceIp: sourceIp })
     );


### PR DESCRIPTION
## What?

Format all user email addresses to lower case when checking if a user account exists with that email.

## Why?

Fix a bug which means users can sign up repeatedly with the same email if they change the case of the email address.

