### PR TITLE
Add splunk binding to manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -24,3 +24,4 @@ applications:
       - route: ((route_name))
     services:
       - ((environment_name))-frontend-redis
+      - ((environment_name))-splunk


### PR DESCRIPTION
## What?

Add splunk binding to manifest.

## Why?

To send logs to splunk.

