### PR TITLE
GOVSI-1053: Add Coverage Reports for Sonar

### DIFF
--- a/.github/workflows/analyse-on-merge.yml
+++ b/.github/workflows/analyse-on-merge.yml
@@ -1,0 +1,52 @@
+name: Pre-merge checks
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6389:6379
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.8.0
+      - name: Install dependencies
+        run: yarn install
+      - name: Build app
+        run: yarn build
+      - name: Run unit tests
+        run: yarn test:unit
+      - name: Run integration tests
+        run: yarn test:integration
+      - name: Run lint
+        run: yarn lint
+      - name: Run test coverage
+        run: yarn test:coverage
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    env:
+      ENVIRONMENT: development
+      API_BASE_URL: http://localhost:6000/api
+      FRONTEND_API_BASE_URL: http://localhost:6060/api
+      SESSION_SECRET: secret
+      API_KEY: test-key
+      REDIS_HOST: localhost
+      REDIS_PORT: 6389

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -38,6 +38,13 @@ jobs:
         run: yarn test:integration
       - name: Run lint
         run: yarn lint
+      - name: Run test coverage
+        run: yarn test:coverage
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     env:
       ENVIRONMENT: development
       API_BASE_URL: http://localhost:6000/api

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:integration": "rm -rf test/coverage && NODE_ENV=development nyc mocha -r dotenv/config  \"src/**/*-integration.test.ts\"",
     "test:unit": "rm -rf test/coverage && NODE_ENV=development nyc mocha --exclude \"src/**/*-integration.test.ts\"  \"test/unit/**/*.test.ts\" --recursive \"src/**/*.test.ts\"",
     "test": "rm -rf test/coverage && NODE_ENV=development nyc mocha -r dotenv/config  \"test/unit/**/*.test.ts\" --recursive \"src/**/*.test.ts\"",
-    "test:coverage": "nyc report",
+    "test:coverage": "nyc report --reporter=lcov --reporter=text",
     "watch-node": "nodemon -r dotenv/config --inspect=0.0.0.0:9230 dist/server.js | pino-pretty",
     "watch-ts": "tsc -w",
     "watch-sass": "sass --watch src/assets/scss/application.scss dist/public/style.css"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+sonar.projectKey=alphagov_di-authentication-frontend
+sonar.projectName=di-authentication-frontend
+
+sonar.sources=src/
+sonar.tests=test/
+
+sonar.language=js
+sonar.sourceEncoding=UTF-8
+sonar.javascript.lcov.reportPath=coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=alphagov_di-authentication-frontend
-sonar.projectName=di-authentication-frontend
+sonar.organization=alphagov
+sonar.host.url=https://sonarcloud.io
 
 sonar.sources=src/
 sonar.tests=test/


### PR DESCRIPTION
## What?

- Ensure `nyc` outputs the coverage reports in LCOV format
- Add `sonar-project.properties` file

## Why?

Sonar is analysing this repo but not producing coverage stats

