### PR TITLE
GOVSI-1053: Fix invalid coverage property name

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,5 @@ sonar.host.url=https://sonarcloud.io
 sonar.sources=src/
 sonar.tests=test/
 
-sonar.language=js
 sonar.sourceEncoding=UTF-8
-sonar.javascript.lcov.reportPath=coverage/lcov.info
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## What?

- The property to specify the coverage path is now plural
- Also, remove the deprecated `sonar.language` property

## Why?

Coverage was not being correctly reported to SonarCloud

## Related PRs

#372 