### PR TITLE
GOVSI-1102: remove spaces from OTP error page hyperlinks

### DIFF
--- a/src/components/security-code-error/index-too-many-requests.njk
+++ b/src/components/security-code-error/index-too-many-requests.njk
@@ -7,9 +7,9 @@
 
 <p class="govuk-body">{{'pages.securityRequestsExceededExpired.info.paragraph1' | translate}}</p>
     <p class="govuk-body">
-        {{'pages.securityCodeInvalid.info.paragraph2Start' | translate}}
-        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeInvalid.info.link' | translate}}</a>
-        {{'pages.securityCodeInvalid.info.paragraph2End' | translate}}
+        {{'pages.securityRequestsExceededExpired.info.paragraph2Start' | translate}}
+        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityRequestsExceededExpired.info.link' | translate}}</a>
+        {{'pages.securityRequestsExceededExpired.info.paragraph2End' | translate}}
     </p>
 
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -362,8 +362,8 @@
       "info": {
         "paragraph1": "You need to wait 15 minutes.",
         "paragraph2Start": "You can then ",
-        "link": "get a new code ",
-        "paragraph2End": "and try again."
+        "link": "get a new code",
+        "paragraph2End": " and try again."
       }
     },
     "securityRequestsExceededExpired": {
@@ -372,8 +372,8 @@
       "info": {
         "paragraph1": "You need to wait 15 minutes.",
         "paragraph2Start": "You can then ",
-        "link": "get a new code ",
-        "paragraph2End": "and try again."
+        "link": "get a new code",
+        "paragraph2End": " and try again."
       }
     },
     "securityCodeWaitToRequest": {
@@ -382,8 +382,8 @@
       "info": {
         "paragraph1": "This is because you requested too many security codes.",
         "paragraph2Start": "You can ",
-        "link": "get a new code ",
-        "paragraph2End": "after 15 minutes have passed."
+        "link": "get a new code",
+        "paragraph2End": " after 15 minutes have passed."
       }
     },
     "enterMfa": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -362,8 +362,8 @@
       "info": {
         "paragraph1": "You need to wait 15 minutes.",
         "paragraph2Start": "You can then ",
-        "link": "get a new code ",
-        "paragraph2End": "and try again."
+        "link": "get a new code",
+        "paragraph2End": " and try again."
       }
     },
     "securityRequestsExceededExpired": {
@@ -372,8 +372,8 @@
       "info": {
         "paragraph1": "You need to wait 15 minutes.",
         "paragraph2Start": "You can then ",
-        "link": "get a new code ",
-        "paragraph2End": "and try again."
+        "link": "get a new code",
+        "paragraph2End": " and try again."
       }
     },
     "securityCodeWaitToRequest": {
@@ -382,8 +382,8 @@
       "info": {
         "paragraph1": "This is because you requested too many security codes.",
         "paragraph2Start": "You can ",
-        "link": "get a new code ",
-        "paragraph2End": "after 15 minutes have passed."
+        "link": "get a new code",
+        "paragraph2End": " after 15 minutes have passed."
       }
     },
     "enterMfa": {


### PR DESCRIPTION
## What?

Remove spaces from OTP error page hyperlinks.

Use securityRequestsExceededExpired resources rather than securityCodeInvalid for 'too many requests'

## Why?

'get a new code' links contained an extra hyperlinked space at the end.