### PR TITLE
GOVSI-1094: update account-created confirmation page for email subs

### DIFF
--- a/src/components/account-created/index.njk
+++ b/src/components/account-created/index.njk
@@ -25,6 +25,10 @@
     <h2 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.accountCreated.subHeader' | translate}}</h2>
 
     <p class="govuk-body">{{'pages.accountCreated.info.paragraph1' | translate}}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.accountCreated.info.listItem1' | translate}}</li>
+        <li>{{ 'pages.accountCreated.info.listItem2' | translate}}</li>
+    </ul>
     <p class="govuk-body">{{'pages.accountCreated.info.paragraph2' | translate}}</p>
     <p class="govuk-body">{{'pages.accountCreated.info.paragraph3' | translate}}</p>
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -295,7 +295,9 @@
       "subHeader": "What you can do with your GOV.UK account",
       "text": "You need to return to GOV.UK to continue.",
       "info": {
-        "paragraph1": "At the moment, you can only use your GOV.UK account to save your answers when you use the Brexit checker.",
+        "paragraph1": "At the moment, you can only use your GOV.UK account to:",
+        "listItem1": "manage your GOV.UK email subscriptions",
+        "listItem2": "save your answers when you use the Brexit checker",
         "paragraph2": "In the future, you’ll be able to use your GOV.UK account to sign in to all government services. It will take a few years for this to happen.",
         "paragraph3": "For now, you need to use different accounts for different government services."
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -295,7 +295,9 @@
       "subHeader": "What you can do with your GOV.UK account",
       "text": "You need to return to GOV.UK to continue.",
       "info": {
-        "paragraph1": "At the moment, you can only use your GOV.UK account to save your answers when you use the Brexit checker.",
+        "paragraph1": "At the moment, you can only use your GOV.UK account to:",
+        "listItem1": "manage your GOV.UK email subscriptions",
+        "listItem2": "save your answers when you use the Brexit checker",
         "paragraph2": "In the future, you’ll be able to use your GOV.UK account to sign in to all government services. It will take a few years for this to happen.",
         "paragraph3": "For now, you need to use different accounts for different government services."
       },


### PR DESCRIPTION
## What?

Update account-created confirmation page to include email subscriptions.

There will be a corresponding email template change directly in Notify.

## Why?

This service will soon be supported by GOV.UK.

The PR will only be merged when the service actually goes live.
