### PR TITLE
GOVSI-1111 - Bring email validation inline with Notify

### DIFF
--- a/src/components/enter-email/enter-email-validation.ts
+++ b/src/components/enter-email/enter-email-validation.ts
@@ -22,6 +22,11 @@ export function validateEnterEmailRequest(
       .isEmail()
       .withMessage((value, { req }) => {
         return req.t("pages.enterEmail.email.validationError.email", { value });
+      })
+      /* eslint-disable-next-line */
+      .matches(/^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\-]+@([^.@][^@\s]+)$/)
+      .withMessage((value, { req }) => {
+        return req.t("pages.enterEmail.email.validationError.email", { value });
       }),
     validateBodyMiddleware(template),
   ];

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -85,7 +85,39 @@ describe("Integration::enter email", () => {
       .set("Cookie", cookies)
       .send({
         _csrf: token,
-        email: "INVALID",
+        email: "test.tµrn@example.com",
+      })
+      .expect(function (res) {
+        const page = cheerio.load(res.text);
+        expect(page("#email-error").text()).to.contains(
+          "Enter an email address in the correct format, like name@example.com\n"
+        );
+      })
+      .expect(400);
+
+      request(app)
+      .post("/enter-email")
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        email: "test.trnexample.com",
+      })
+      .expect(function (res) {
+        const page = cheerio.load(res.text);
+        expect(page("#email-error").text()).to.contains(
+          "Enter an email address in the correct format, like name@example.com\n"
+        );
+      })
+      .expect(400);
+
+      request(app)
+      .post("/enter-email")
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        email: "test.trn@examplecom",
       })
       .expect(function (res) {
         const page = cheerio.load(res.text);


### PR DESCRIPTION
## What?

- Use the Notify validation when validating emails in our frontend. https://github.com/alphagov/notifications-utils/blob/c264fa9facedf721c8dd9cf8ee2766591e750e0c/notifications_utils/__init__.py#L14
- Disable lint validation on regex

## Why?

- There were email addresses that were passing our validation but then failing on Notify.
