### PR TITLE
Amend support link to point to contact form

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -93,7 +93,7 @@
               text: 'general.footer.privacy.linkText' | translate
           },
           {
-                href: "/support",
+                href: "/contact-us?supportType=PUBLIC",
               attributes: {target: "_blank"},
               text: 'general.footer.support.linkText' | translate
           }


### PR DESCRIPTION
## What?

Amend support link to point to contact form.

## Why?
For go-live, since we are only going ahead with an end-user “Contact us” form, we need to amend the “Support” link on the Sign In footer to lead users directly to the “Contact us” form. Currently, it takes users to a “Support” page.
