### PR TITLE
BAU: log referer path as 'from' for a request

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -11,6 +11,7 @@ const logger = pino({
         id: req.id,
         method: req.method,
         url: req.url,
+        from: getRefererFrom(req.headers.referer),
       };
     },
     res: (res) => {
@@ -24,6 +25,19 @@ const logger = pino({
     },
   },
 });
+
+export function getRefererFrom(referer: string): string {
+  if (referer) {
+    try {
+      const refererUrl = new URL(referer);
+      return refererUrl.pathname + refererUrl.search;
+    } catch (error) {
+      return undefined;
+    }
+  } else {
+    return undefined;
+  }
+}
 
 const loggerMiddleware = PinoHttp({
   logger,

--- a/test/unit/utils/logger.test.ts
+++ b/test/unit/utils/logger.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { getRefererFrom } from "../../../src/utils/logger";
+
+describe("logger", () => {
+  describe("getRefererFrom", () => {
+    it("should return path from a url", () => {
+      expect(getRefererFrom("http://localhost:8080/hello")).to.equal("/hello");
+    });
+
+    it("should return path from a gov.uk url", () => {
+      expect(getRefererFrom("http://gov.uk/hello")).to.equal("/hello");
+    });
+
+    it("should return path from an https gov.uk url", () => {
+      expect(getRefererFrom("https://gov.uk/hello")).to.equal("/hello");
+    });
+
+    it("should return path from a url without port", () => {
+      expect(getRefererFrom("http://localhost/hello")).to.equal("/hello");
+    });
+
+    it("should return a longer path from a url", () => {
+      expect(
+        getRefererFrom("http://localhost:8080/hello/good/morning")
+      ).to.equal("/hello/good/morning");
+    });
+
+    it("should return path and query from a url", () => {
+      expect(getRefererFrom("http://localhost:8080/hello?world=true")).to.equal(
+        "/hello?world=true"
+      );
+    });
+
+    it("should return query only from a url", () => {
+      expect(getRefererFrom("http://localhost:8080?world=true")).to.equal(
+        "/?world=true"
+      );
+    });
+
+    it("should return a longer path and query from a url", () => {
+      expect(
+        getRefererFrom("http://localhost:8080/hello/good/morning?world=true")
+      ).to.equal("/hello/good/morning?world=true");
+    });
+
+    it("should return a longer path and two query params from a url", () => {
+      expect(
+        getRefererFrom(
+          "http://localhost:8080/hello/good/morning?world=true&morning=good"
+        )
+      ).to.equal("/hello/good/morning?world=true&morning=good");
+    });
+
+    it("should return empty path from a url", () => {
+      expect(getRefererFrom("http://localhost:8080")).to.equal("/");
+    });
+
+    it("should return empty path from a url ending with /", () => {
+      expect(getRefererFrom("http://localhost:8080/")).to.equal("/");
+    });
+
+    it("should return undefined for null url", () => {
+      expect(getRefererFrom(null)).to.equal(undefined);
+    });
+
+    it("should return undefined for undefined url", () => {
+      expect(getRefererFrom(undefined)).to.equal(undefined);
+    });
+
+    it("should return undefined for invalid url", () => {
+      expect(getRefererFrom("hello")).to.equal(undefined);
+    });
+
+    it("should return undefined for invalid protocol", () => {
+      expect(getRefererFrom("https;//hello")).to.equal(undefined);
+    });
+
+    it("should return undefined for invalid port", () => {
+      expect(getRefererFrom("https://localhost:hello")).to.equal(undefined);
+    });
+  });
+});


### PR DESCRIPTION
## What?

Log referer path as 'from' for a request.

Use the 'referer' header for a request to log the page where the user came from.

## Why?

Understand actual user journey more easily from the logs.
