### PR TITLE
BAU: add zendesk env var to on merge check

### DIFF
--- a/.github/workflows/analyse-on-merge.yml
+++ b/.github/workflows/analyse-on-merge.yml
@@ -50,3 +50,4 @@ jobs:
       API_KEY: test-key
       REDIS_HOST: localhost
       REDIS_PORT: 6389
+      ZENDESK_API_URL: https://zendesk.com


### PR DESCRIPTION
## What?

Add zendesk env var to on merge check.

## Why?

Sonarqube checks now run on merge, which also runs the integration tests for coverage, so they env var is needed here too.

## Related PRs

#396 
