### PR TITLE
GOVSI-1142: read 'di-persistent-session-id' cookie and pass to api calls as header

### DIFF
--- a/src/components/account-not-found/account-not-found-controller.ts
+++ b/src/components/account-not-found/account-not-found-controller.ts
@@ -21,15 +21,15 @@ export function accountNotFoundPost(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const email = req.session.email;
-    const sessionId = res.locals.sessionId;
-    const clientSessionId = res.locals.clientSessionId;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     const result = await service.sendNotification(
       sessionId,
       clientSessionId,
       email,
       NOTIFICATION_TYPE.VERIFY_EMAIL,
-      req.ip
+      req.ip,
+      persistentSessionId
     );
 
     if (!result.success && !result.sessionState) {

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -37,7 +37,8 @@ export const checkYourPhonePost = (
           res.locals.clientSessionId,
           req.session.email,
           NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION,
-          req.ip
+          req.ip,
+          res.locals.persistentSessionId
         );
       }
 

--- a/src/components/common/client-info/client-info-service.ts
+++ b/src/components/common/client-info/client-info-service.ts
@@ -13,7 +13,8 @@ export function clientInfoService(
   const clientInfo = async function (
     sessionId: string,
     clientSessionId: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ): Promise<ClientInfoResponse> {
     const response = await axios.client.get(
       API_ENDPOINTS.CLIENT_INFO,
@@ -21,6 +22,7 @@ export function clientInfoService(
         sessionId: sessionId,
         clientSessionId: clientSessionId,
         sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
       })
     );
 

--- a/src/components/common/client-info/types.ts
+++ b/src/components/common/client-info/types.ts
@@ -17,6 +17,7 @@ export interface ClientInfoServiceInterface {
   clientInfo: (
     sessionId: string,
     clientSessionId: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ) => Promise<ClientInfoResponse>;
 }

--- a/src/components/common/mfa/mfa-service.ts
+++ b/src/components/common/mfa/mfa-service.ts
@@ -8,7 +8,8 @@ export function mfaService(axios: Http = http): MfaServiceInterface {
     sessionId: string,
     clientSessionId: string,
     emailAddress: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ): Promise<ApiResponseResult> {
     const { data, status } = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.MFA,
@@ -19,6 +20,7 @@ export function mfaService(axios: Http = http): MfaServiceInterface {
         sessionId: sessionId,
         clientSessionId: clientSessionId,
         sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
       })
     );
 

--- a/src/components/common/mfa/types.ts
+++ b/src/components/common/mfa/types.ts
@@ -5,6 +5,7 @@ export interface MfaServiceInterface {
     sessionId: string,
     clientSessionId: string,
     emailAddress: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ) => Promise<ApiResponseResult>;
 }

--- a/src/components/common/send-notification/send-notification-service.ts
+++ b/src/components/common/send-notification/send-notification-service.ts
@@ -17,6 +17,7 @@ export function sendNotificationService(
     email: string,
     notificationType: string,
     sourceIp: string,
+    persistentSessionId: string,
     phoneNumber?: string
   ): Promise<ApiResponseResult> {
     const payload: any = {
@@ -35,6 +36,7 @@ export function sendNotificationService(
         sessionId: sessionId,
         clientSessionId: clientSessionId,
         sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
       })
     );
 

--- a/src/components/common/send-notification/types.ts
+++ b/src/components/common/send-notification/types.ts
@@ -7,6 +7,7 @@ export interface SendNotificationServiceInterface {
     email: string,
     notificationType: string,
     sourceIp: string,
+    persistentSessionId: string,
     phoneNumber?: string
   ) => Promise<ApiResponseResult>;
 }

--- a/src/components/common/update-profile/types.ts
+++ b/src/components/common/update-profile/types.ts
@@ -6,7 +6,8 @@ export interface UpdateProfileServiceInterface {
     clientSessionId: string,
     email: string,
     requestType: RequestType,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ) => Promise<ApiResponseResult>;
 }
 

--- a/src/components/common/update-profile/update-profile-service.ts
+++ b/src/components/common/update-profile/update-profile-service.ts
@@ -17,7 +17,8 @@ export function updateProfileService(
     clientSessionId: string,
     email: string,
     requestType: RequestType,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ): Promise<ApiResponseResult> {
     const response = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.UPDATE_PROFILE,
@@ -26,7 +27,12 @@ export function updateProfileService(
         profileInformation: requestType.profileInformation,
         updateProfileType: requestType.updateProfileType,
       },
-      getRequestConfig({ sessionId, clientSessionId, sourceIp })
+      getRequestConfig({
+        sessionId,
+        clientSessionId,
+        sourceIp,
+        persistentSessionId,
+      })
     );
 
     return createApiResponse(response);

--- a/src/components/common/verify-code/types.ts
+++ b/src/components/common/verify-code/types.ts
@@ -6,6 +6,7 @@ export interface VerifyCodeInterface {
     code: string,
     notificationType: string,
     clientSessionId: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ) => Promise<ApiResponseResult>;
 }

--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -22,15 +22,15 @@ export function verifyCodePost(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const code = req.body["code"];
-    const sessionId = res.locals.sessionId;
-    const clientSessionId = res.locals.clientSessionId;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     const result = await service.verifyCode(
       sessionId,
       code,
       options.notificationType,
       clientSessionId,
-      req.ip
+      req.ip,
+      persistentSessionId
     );
 
     if (!result.success && !result.sessionState) {

--- a/src/components/common/verify-code/verify-code-service.ts
+++ b/src/components/common/verify-code/verify-code-service.ts
@@ -14,7 +14,8 @@ export function codeService(axios: Http = http): VerifyCodeInterface {
     code: string,
     notificationType: string,
     clientSessionId: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ): Promise<ApiResponseResult> {
     const response = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.VERIFY_CODE,
@@ -26,6 +27,7 @@ export function codeService(axios: Http = http): VerifyCodeInterface {
         sessionId,
         clientSessionId,
         sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
       })
     );
 

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -17,7 +17,8 @@ export function createPasswordPost(
       res.locals.sessionId,
       req.session.email,
       req.body.password,
-      req.ip
+      req.ip,
+      res.locals.persistentSessionId
     );
 
     if (!result.success) {

--- a/src/components/create-password/create-password-service.ts
+++ b/src/components/create-password/create-password-service.ts
@@ -15,7 +15,8 @@ export function createPasswordService(
     sessionId: string,
     emailAddress: string,
     password: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ): Promise<ApiResponseResult> {
     const response = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.SIGNUP_USER,
@@ -23,7 +24,11 @@ export function createPasswordService(
         email: emailAddress,
         password: password,
       },
-      getRequestConfig({ sessionId: sessionId, sourceIp: sourceIp })
+      getRequestConfig({
+        sessionId: sessionId,
+        sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
+      })
     );
 
     return createApiResponse(response);

--- a/src/components/create-password/types.ts
+++ b/src/components/create-password/types.ts
@@ -5,6 +5,7 @@ export interface CreatePasswordServiceInterface {
     sessionId: string,
     emailAddress: string,
     password: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ) => Promise<ApiResponseResult>;
 }

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -23,7 +23,12 @@ export function enterEmailPost(
     const sessionId = res.locals.sessionId;
     req.session.email = email.toLowerCase();
 
-    const result = await service.userExists(sessionId, email, req.ip);
+    const result = await service.userExists(
+      sessionId,
+      email,
+      req.ip,
+      res.locals.persistentSessionId
+    );
 
     if (!result.success) {
       throw new BadRequestError(result.message, result.code);
@@ -39,14 +44,14 @@ export function enterEmailCreatePost(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const email = req.body.email;
-    const sessionId = res.locals.sessionId;
-    const clientSessionId = res.locals.clientSessionId;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     req.session.email = email.toLowerCase();
     const userExistsResponse = await service.userExists(
       sessionId,
       email,
-      req.ip
+      req.ip,
+      persistentSessionId
     );
 
     if (
@@ -63,7 +68,8 @@ export function enterEmailCreatePost(
       clientSessionId,
       email,
       NOTIFICATION_TYPE.VERIFY_EMAIL,
-      req.ip
+      req.ip,
+      persistentSessionId
     );
 
     if (!sendNotificationResponse.success && sendNotificationResponse.code) {

--- a/src/components/enter-email/enter-email-service.ts
+++ b/src/components/enter-email/enter-email-service.ts
@@ -14,14 +14,19 @@ export function enterEmailService(
   const userExists = async function (
     sessionId: string,
     emailAddress: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ): Promise<UserExists> {
     const response = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.USER_EXISTS,
       {
         email: emailAddress.toLowerCase(),
       },
-      getRequestConfig({ sessionId: sessionId, sourceIp: sourceIp })
+      getRequestConfig({
+        sessionId: sessionId,
+        sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
+      })
     );
 
     const apiResponse = createApiResponse(response) as UserExists;

--- a/src/components/enter-email/types.ts
+++ b/src/components/enter-email/types.ts
@@ -8,6 +8,7 @@ export interface EnterEmailServiceInterface {
   userExists: (
     sessionId: string,
     emailAddress: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ) => Promise<ApiResponseResult>;
 }

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -49,14 +49,15 @@ export function enterPasswordPost(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const { email } = req.session;
-    const { sessionId, clientSessionId } = res.locals;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     const userLogin = await service.loginUser(
       sessionId,
       email,
       req.body["password"],
       clientSessionId,
-      req.ip
+      req.ip,
+      persistentSessionId
     );
 
     if (userLogin.success && userLogin.sessionState) {
@@ -68,7 +69,8 @@ export function enterPasswordPost(
           sessionId,
           clientSessionId,
           email,
-          req.ip
+          req.ip,
+          persistentSessionId
         );
 
         if (!result.success) {

--- a/src/components/enter-password/enter-password-service.ts
+++ b/src/components/enter-password/enter-password-service.ts
@@ -15,7 +15,8 @@ export function enterPasswordService(
     emailAddress: string,
     password: string,
     clientSessionId: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ): Promise<UserLoginResponse> {
     const response = await axios.client.post<UserLoginResponse>(
       API_ENDPOINTS.LOG_IN_USER,
@@ -31,6 +32,7 @@ export function enterPasswordService(
           HTTP_STATUS_CODES.UNAUTHORIZED,
         ],
         sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
       })
     );
 

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -55,6 +55,7 @@ describe("enter password controller", () => {
 
       res.locals.sessionId = "123456-djjad";
       res.locals.clientSessionId = "00000-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
       req.session = {
         email: "joe.bloggs@test.com",
       };
@@ -80,6 +81,7 @@ describe("enter password controller", () => {
 
       res.locals.sessionId = "123456-djjad";
       res.locals.clientSessionId = "00000-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
       req.session = {
         email: "joe.bloggs@test.com",
       };
@@ -103,6 +105,7 @@ describe("enter password controller", () => {
 
       res.locals.sessionId = "123456-djjad";
       res.locals.clientSessionId = "00000-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
       req.session = {
         email: "joe.bloggs@test.com",
       };
@@ -128,6 +131,7 @@ describe("enter password controller", () => {
 
       res.locals.sessionId = "123456-djjad";
       res.locals.clientSessionId = "00000-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
       req.session = {
         email: "joe.bloggs@test.com",
       };

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -25,6 +25,7 @@ describe("Integration::enter password", () => {
       .callsFake(function (req: any, res: any, next: any): void {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
         res.locals.clientSessionId = "gdsfsfdsgsdgsd-mjdzU854";
+        res.locals.persistentSessionId = "dips-123456-abc";
         req.session.email = "joe.bloggs@digital.cabinet-office.gov.uk";
         next();
       });

--- a/src/components/enter-password/types.ts
+++ b/src/components/enter-password/types.ts
@@ -10,6 +10,7 @@ export interface EnterPasswordServiceInterface {
     email: string,
     password: string,
     clientSessionId: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ) => Promise<UserLoginResponse>;
 }

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -20,20 +20,20 @@ export function enterPhoneNumberPost(
   return async function (req: Request, res: Response) {
     const phoneNumber = req.body.phoneNumber;
     const { email } = req.session;
-    const id = res.locals.sessionId;
-    const clientSessionId = res.locals.clientSessionId;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     req.session.phoneNumber = redactPhoneNumber(phoneNumber);
 
     const updateProfileResponse = await profileService.updateProfile(
-      id,
+      sessionId,
       clientSessionId,
       email,
       {
         profileInformation: phoneNumber,
         updateProfileType: "ADD_PHONE_NUMBER",
       },
-      req.ip
+      req.ip,
+      persistentSessionId
     );
 
     if (!updateProfileResponse.success) {
@@ -44,11 +44,12 @@ export function enterPhoneNumberPost(
     }
 
     const sendNotificationResponse = await service.sendNotification(
-      id,
+      sessionId,
       clientSessionId,
       email,
       NOTIFICATION_TYPE.VERIFY_PHONE_NUMBER,
       req.ip,
+      persistentSessionId,
       phoneNumber
     );
 

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -16,14 +16,14 @@ export function resendMfaCodePost(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const { email } = req.session;
-    const id = res.locals.sessionId;
-    const clientSessionId = res.locals.clientSessionId;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     const result = await service.sendMfaCode(
-      id,
+      sessionId,
       clientSessionId,
       email,
-      req.ip
+      req.ip,
+      persistentSessionId
     );
 
     if (!result.success && !result.sessionState) {

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -11,7 +11,12 @@ export function resetPasswordCheckEmailGet(
   return async function (req: Request, res: Response) {
     const { email } = req.session;
     const sessionId = res.locals.sessionId;
-    const result = await service.resetPasswordRequest(email, sessionId, req.ip);
+    const result = await service.resetPasswordRequest(
+      email,
+      sessionId,
+      req.ip,
+      res.locals.persistentSessionId
+    );
 
     if (result.success) {
       return res.render("reset-password-check-email/index.njk", {

--- a/src/components/reset-password-check-email/reset-password-check-email-service.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-service.ts
@@ -10,7 +10,8 @@ export function resetPasswordCheckEmailService(
   const resetPasswordRequest = async function (
     email: string,
     sessionId: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ): Promise<ApiResponseResult> {
     const { data, status } = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.RESET_PASSWORD_REQUEST,
@@ -20,6 +21,7 @@ export function resetPasswordCheckEmailService(
       getRequestConfig({
         sessionId: sessionId,
         sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
       })
     );
     return {

--- a/src/components/reset-password-check-email/types.ts
+++ b/src/components/reset-password-check-email/types.ts
@@ -4,6 +4,7 @@ export interface ResetPasswordCheckEmailServiceInterface {
   resetPasswordRequest: (
     email: string,
     sessionId: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ) => Promise<ApiResponseResult>;
 }

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -12,7 +12,6 @@ import xss from "xss";
 
 const resetPasswordTemplate = "reset-password/index.njk";
 
-
 function isCodeExpired(code: string): boolean {
   if (!code) {
     return true;
@@ -56,7 +55,8 @@ export function resetPasswordPost(
     const response = await service.updatePassword(
       newPassword,
       getCode(code),
-      req.ip
+      req.ip,
+      res.locals.persistentSessionId
     );
 
     if (response.success) {

--- a/src/components/reset-password/reset-password-service.ts
+++ b/src/components/reset-password/reset-password-service.ts
@@ -14,7 +14,8 @@ export function resetPasswordService(
   const updatePassword = async function (
     newPassword: string,
     code: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ): Promise<ApiResponseResult> {
     const response = await axios.client.post<ApiResponse>(
       API_ENDPOINTS.RESET_PASSWORD,
@@ -24,6 +25,7 @@ export function resetPasswordService(
       },
       getRequestConfig({
         sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
       })
     );
 

--- a/src/components/reset-password/types.ts
+++ b/src/components/reset-password/types.ts
@@ -4,6 +4,7 @@ export interface ResetPasswordServiceInterface {
   updatePassword: (
     newPassword: string,
     code: string,
-    sourceIp: string
+    sourceIp: string,
+    persistentSessionId: string
   ) => Promise<ApiResponseResult>;
 }

--- a/src/components/share-info/share-info-controller.ts
+++ b/src/components/share-info/share-info-controller.ts
@@ -12,13 +12,13 @@ export function shareInfoGet(
   service: ClientInfoServiceInterface = clientInfoService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const sessionId = res.locals.sessionId;
-    const clientSessionId = res.locals.clientSessionId;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     const clientInfoResponse = await service.clientInfo(
       sessionId,
       clientSessionId,
-      req.ip
+      req.ip,
+      persistentSessionId
     );
 
     const prettyScopes = mapScopes(clientInfoResponse.data.scopes);
@@ -36,8 +36,7 @@ export function shareInfoPost(
   return async function (req: Request, res: Response) {
     const consentValue = req.body.consentValue;
     const { email } = req.session;
-    const sessionId = res.locals.sessionId;
-    const clientSessionId = res.locals.clientSessionId;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     const result = await service.updateProfile(
       sessionId,
@@ -47,7 +46,8 @@ export function shareInfoPost(
         profileInformation: consentValue,
         updateProfileType: "CAPTURE_CONSENT",
       },
-      req.ip
+      req.ip,
+      persistentSessionId
     );
 
     if (!result.success) {

--- a/src/components/share-info/tests/share-info-controller.test.ts
+++ b/src/components/share-info/tests/share-info-controller.test.ts
@@ -44,6 +44,7 @@ describe("share-info controller", () => {
 
       res.locals.sessionId = "s-123456-djjad";
       res.locals.clientSessionId = "c-123456-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
 
       await shareInfoGet(fakeClientInfoService)(
         req as Request,
@@ -67,6 +68,7 @@ describe("share-info controller", () => {
       req.body.consentValue = true;
       res.locals.sessionId = "s-123456-djjad";
       res.locals.clientSessionId = "c-123456-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
       req.session.email = "test@test.com";
 
       await shareInfoPost(fakeService)(req as Request, res as Response);

--- a/src/components/share-info/tests/share-info-integration.test.ts
+++ b/src/components/share-info/tests/share-info-integration.test.ts
@@ -33,6 +33,7 @@ describe("Integration::share info", () => {
       .callsFake(function (req: any, res: any, next: any): void {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
         res.locals.clientSessionId = "csy103saszhcxbQq0-mjdzU854";
+        res.locals.persistentSessionId = "dips-123456-abc";
         req.session.email = "test@test.com";
         next();
       });

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -10,13 +10,13 @@ export function signInOrCreateGet(
   service: ClientInfoServiceInterface = clientInfoService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const sessionId = res.locals.sessionId;
-    const clientSessionId = res.locals.clientSessionId;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     const clientInfoResponse = await service.clientInfo(
       sessionId,
       clientSessionId,
-      req.ip
+      req.ip,
+      persistentSessionId
     );
 
     if (!clientInfoResponse.success) {

--- a/src/components/sign-in-or-create/tests/sign-in-or-create-controller.test.ts
+++ b/src/components/sign-in-or-create/tests/sign-in-or-create-controller.test.ts
@@ -34,6 +34,7 @@ describe("sign in or create controller", () => {
 
       res.locals.sessionId = "s-123456-djjad";
       res.locals.clientSessionId = "c-123456-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
 
       await signInOrCreateGet(fakeService)(req as Request, res as Response);
 

--- a/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
+++ b/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
@@ -34,6 +34,7 @@ describe("Integration:: updated-terms-code", () => {
       .callsFake(function (req: any, res: any, next: any): void {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
         res.locals.clientSessionId = "tDy103saszhcxbQq0-mjdzU33d";
+        res.locals.persistentSessionId = "dips-123456-abc";
         req.session.email = "test@test.com";
         req.session.phoneNumber = "******7867";
         req.session.redirectUri = "http://localhost:5000/callback";

--- a/src/components/updated-terms-conditions/tests/updated-terms-conditions.test.ts
+++ b/src/components/updated-terms-conditions/tests/updated-terms-conditions.test.ts
@@ -52,6 +52,7 @@ describe("updated terms conditions controller", () => {
 
       res.locals.sessionId = "s-123456-djjad";
       res.locals.clientSessionId = "c-123456-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
 
       await updatedTermsConditionsGet(fakeService)(
         req as Request,
@@ -77,6 +78,7 @@ describe("updated terms conditions controller", () => {
       req.body.termsAndConditionsResult = "accept";
       res.locals.sessionId = "s-123456-djjad";
       res.locals.clientSessionId = "c-123456-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
       req.session.email = "test@test.com";
 
       await updatedTermsConditionsPost(fakeService)(
@@ -97,6 +99,7 @@ describe("updated terms conditions controller", () => {
       req.body.termsAndConditionsResult = "govUk";
       res.locals.sessionId = "s-123456-djjad";
       res.locals.clientSessionId = "c-123456-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
       req.session.email = "test@test.com";
       req.session.state = "test";
 

--- a/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
+++ b/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
@@ -12,13 +12,13 @@ export function updatedTermsConditionsGet(
   service: ClientInfoServiceInterface = clientInfoService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const sessionId = res.locals.sessionId;
-    const clientSessionId = res.locals.clientSessionId;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     const clientInfoResponse = await service.clientInfo(
       sessionId,
       clientSessionId,
-      req.ip
+      req.ip,
+      persistentSessionId
     );
 
     req.session.serviceType = clientInfoResponse.data.serviceType;
@@ -46,7 +46,7 @@ export function updatedTermsConditionsPost(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const { email } = req.session;
-    const { sessionId, clientSessionId } = res.locals;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
     const termsAndConditionsResult = req.body.termsAndConditionsResult;
 
     if (termsAndConditionsResult === "govUk") {
@@ -65,7 +65,8 @@ export function updatedTermsConditionsPost(
         clientSessionId,
         email,
         { updateProfileType: "UPDATE_TERMS_CONDS", profileInformation: true },
-        req.ip
+        req.ip,
+        persistentSessionId
       );
 
       if (!result.success) {

--- a/src/components/uplift-journey/uplift-journey-controller.ts
+++ b/src/components/uplift-journey/uplift-journey-controller.ts
@@ -10,14 +10,14 @@ export function upliftJourneyGet(
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const { email } = req.session;
-    const { sessionId } = res.locals;
-    const { clientSessionId } = res.locals;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     const result = await mfaCodeService.sendMfaCode(
       sessionId,
       clientSessionId,
       email,
-      req.ip
+      req.ip,
+      persistentSessionId
     );
     res.redirect(getNextPathByState(result.sessionState));
   };

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -31,6 +31,11 @@ export function getSessionIdMiddleware(
     res.locals.sessionId = ids[0];
     res.locals.clientSessionId = ids[1];
   }
+  if (req.cookies && req.cookies["di-persistent-session-id"]) {
+    res.locals.persistentSessionId = xss(
+      req.cookies["di-persistent-session-id"]
+    );
+  }
   next();
 }
 

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -22,6 +22,7 @@ export interface ConfigOptions {
   clientSessionId?: string;
   validationStatues?: number[];
   sourceIp?: string;
+  persistentSessionId?: string;
 }
 
 export function createApiResponse(
@@ -60,6 +61,10 @@ export function getRequestConfig(options: ConfigOptions): AxiosRequestConfig {
     config.validateStatus = function (status: number) {
       return options.validationStatues.includes(status);
     };
+  }
+
+  if (options.persistentSessionId) {
+    config.headers["di-persistent-session-id"] = options.persistentSessionId;
   }
 
   return config;

--- a/test/unit/middleware/session-middleware.ts
+++ b/test/unit/middleware/session-middleware.ts
@@ -44,6 +44,15 @@ describe("session-middleware", () => {
       getSessionIdMiddleware(req as Request, res as Response, next);
 
       expect(res.locals).to.have.property("sessionId");
+      expect(res.locals).to.not.have.property("persistentSessionId");
+      expect(next).to.be.calledOnce;
+    });
+    it("should add persistent session id to locals when cookie present", () => {
+      req.cookies = { "di-persistent-session-id": "psid123456xyz" };
+      getSessionIdMiddleware(req as Request, res as Response, next);
+
+      expect(res.locals).to.have.property("persistentSessionId");
+      expect(res.locals.persistentSessionId).to.equal("psid123456xyz");
       expect(next).to.be.calledOnce;
     });
     it("should not have session id on response when no session cookie present", () => {


### PR DESCRIPTION
## What?

Read 'di-persistent-session-id' cookie and pass to api calls as header.

- Cookie value is read by the middleware and saved into 'res.locals', then retrieved for each api call.

## Why?

Cookie value to be logged by each api.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/1087