### PR TITLE
BAU: remove dependabot open-pull-requests-limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,12 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
-    open-pull-requests-limit: 10
     target-branch: main
     labels:
     - dependabot
     ignore:
       - dependency-name: "node"
-        versions: ["16.x", "17.x","18.x"]
+        versions: ["17.x","18.x"]
     commit-message:
       prefix: BAU
   - package-ecosystem: docker
@@ -19,7 +18,6 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
-    open-pull-requests-limit: 10
     target-branch: main
     labels:
     - dependabot


### PR DESCRIPTION
## What?

Remove dependabot open-pull-requests-limit.

## Why?

Ability to choose from all available upgrades.

## Related PRs

https://github.com/alphagov/di-authentication-account-management/pull/246