### PR TITLE
GOVSI-1154 - Send session and persistent id in request to reset-password

### DIFF
--- a/dev-app.js
+++ b/dev-app.js
@@ -16,7 +16,7 @@ const AUTHORIZE_REQUEST =
   "redirect_uri=https%3A%2F%2Fdi-auth-stub-relying-party-build.london.cloudapps.digital%2Foidc%2Fauthorization-code%2Fcallback&" +
   "state=sEazICy8jKFFlt-NLSw5yqYRA2r4q5BZGcAf9sYeWRg&" +
   "nonce=gyRdMfQGsQS9BvhU-lBwENOZ0UU&" +
-  process.env.TEST_CLIENT_ID +
+  "client_id=" + process.env.TEST_CLIENT_ID +
   "&cookie_consent=accept" +
   "&_ga=test";
 

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -31,6 +31,14 @@ function getCode(code: string): string {
   return code.split(".")[0];
 }
 
+function getSessionId(code: string): string {
+  return code.split(".")[2];
+}
+
+function getPersistentSessionId(code: string): string {
+  return code.split(".")[3];
+}
+
 export function resetPasswordGet(req: Request, res: Response): void {
   const code = xss(req.query.code as string);
 
@@ -48,7 +56,11 @@ export function resetPasswordPost(
     const code = req.body.code;
     const newPassword = req.body.password;
 
-    if (isCodeExpired(code)) {
+    if (
+      isCodeExpired(code) ||
+      !getSessionId(code) ||
+      !getPersistentSessionId(code)
+    ) {
       return res.redirect(PATH_NAMES.RESET_PASSWORD_EXPIRED_LINK);
     }
 
@@ -56,7 +68,8 @@ export function resetPasswordPost(
       newPassword,
       getCode(code),
       req.ip,
-      res.locals.persistentSessionId
+      getSessionId(code),
+      getPersistentSessionId(code)
     );
 
     if (response.success) {

--- a/src/components/reset-password/tests/reset-password-controller.test.ts
+++ b/src/components/reset-password/tests/reset-password-controller.test.ts
@@ -33,7 +33,8 @@ describe("reset password controller", () => {
 
   describe("resetPasswordGet", () => {
     it("should render change password page", () => {
-      req.query.code = "asdkki8ddas.1758350212000";
+      req.query.code =
+        "asdkki8ddas.1758350212000.some-session-id.some-persistent-session-id";
 
       resetPasswordGet(req as Request, res as Response);
 
@@ -48,7 +49,8 @@ describe("reset password controller", () => {
       };
 
       req.body.password = "Password1";
-      req.body.code = "asdkki8ddas.1758350212000";
+      req.body.code =
+        "asdkki8ddas.1758350212000.some-session-id.some-persistent-session-id";
 
       await resetPasswordPost(fakeService)(req as Request, res as Response);
 
@@ -66,7 +68,43 @@ describe("reset password controller", () => {
       };
 
       req.body.password = "Password1";
-      req.body.code = "asdkki8ddas.234";
+      req.body.code =
+        "asdkki8ddas.234.some-session-id.some-persistent-session-id";
+
+      await resetPasswordPost(fakeService)(req as Request, res as Response);
+
+      expect(fakeService.updatePassword).to.have.been.not.calledOnce;
+      expect(res.redirect).to.have.calledWith(
+        PATH_NAMES.RESET_PASSWORD_EXPIRED_LINK
+      );
+    });
+  });
+  describe("resetPasswordPost", () => {
+    it("should redirect to /reset-password-expired-link when code is missing", async () => {
+      const fakeService: ResetPasswordServiceInterface = {
+        updatePassword: sandbox.fake.returns({ success: true }),
+      };
+
+      req.body.password = "Password1";
+      req.body.code =
+        "1758350212000.some-session-id.some-persistent-session-id";
+
+      await resetPasswordPost(fakeService)(req as Request, res as Response);
+
+      expect(fakeService.updatePassword).to.have.been.not.calledOnce;
+      expect(res.redirect).to.have.calledWith(
+        PATH_NAMES.RESET_PASSWORD_EXPIRED_LINK
+      );
+    });
+  });
+  describe("resetPasswordPost", () => {
+    it("should redirect to /reset-password-expired-link when session-id is missing", async () => {
+      const fakeService: ResetPasswordServiceInterface = {
+        updatePassword: sandbox.fake.returns({ success: true }),
+      };
+
+      req.body.password = "Password1";
+      req.body.code = "asdkki8ddas.1758350212000.some-persistent-session-id";
 
       await resetPasswordPost(fakeService)(req as Request, res as Response);
 

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -12,7 +12,8 @@ describe("Integration::reset password", () => {
   let app: any;
   let baseApi: string;
 
-  const ENDPOINT = "/reset-password?code=WBTxBpSQdd3cSxT-!X5s.1758350212000";
+  const ENDPOINT =
+    "/reset-password?code=WBTxBpSQdd3cSxT-!X5s.1758350212000.a-session-id.a-persistent-id";
 
   before(() => {
     sandbox = sinon.createSandbox();
@@ -166,7 +167,7 @@ describe("Integration::reset password", () => {
       .set("Cookie", cookies)
       .send({
         _csrf: token,
-        code: "WBTxBpSQdd3cSxT-!X5s.1758350212000",
+        code: "WBTxBpSQdd3cSxT-!X5s.1758350212000.a-session-id.a-persistent-id",
         password: "p@ssw0rd-123",
         "confirm-password": "p@ssw0rd-123",
       })
@@ -208,7 +209,7 @@ describe("Integration::reset password", () => {
       .set("Cookie", cookies)
       .send({
         _csrf: token,
-        code: "WBTxBpSQdd3cSxT-!X5s.1758350212000",
+        code: "WBTxBpSQdd3cSxT-!X5s.1758350212000.a-session-id.a-persistent-id",
         password: "Testpassword1",
         "confirm-password": "Testpassword1",
       })

--- a/src/components/reset-password/types.ts
+++ b/src/components/reset-password/types.ts
@@ -5,6 +5,7 @@ export interface ResetPasswordServiceInterface {
     newPassword: string,
     code: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ) => Promise<ApiResponseResult>;
 }


### PR DESCRIPTION
## What?

- Pull off the session-id and persistent-id from the reset password link and send them in the API request.
- If they can't be found then return the expired password link page to the user, the same as we do if the code has been tampered with
- Set the client-id correctly in the dev-app.js for when we run the frontend locally
- Add extra tests

## Why?

- So the reset password has the session-id and persistent-session-id available to it 