### PR TITLE
BAU: only log res fields supported by pino

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -16,11 +16,10 @@ const logger = pino({
     },
     res: (res) => {
       return {
-        id: res.id,
-        method: res.method,
-        url: res.url,
+        status: res.statusCode,
         sessionId: res.locals.sessionId,
         clientSessionId: res.locals.clientSessionId,
+        persistentSessionId: res.locals.persistentSessionId,
       };
     },
   },


### PR DESCRIPTION
## What?

- Only log 'res' fields supported by pino.
- Log persistentSessionId

## Why?

pino 'res' supports 'statusCode' but not the other fields:

https://github.com/pinojs/pino-std-serializers

## Related PRs

https://github.com/alphagov/di-authentication-account-management/pull/249
