### PR TITLE
GOVSI-1154 - Send session-id as header to reset password

### DIFF
--- a/src/components/reset-password/reset-password-service.ts
+++ b/src/components/reset-password/reset-password-service.ts
@@ -15,6 +15,7 @@ export function resetPasswordService(
     newPassword: string,
     code: string,
     sourceIp: string,
+    sessionId: string,
     persistentSessionId: string
   ): Promise<ApiResponseResult> {
     const response = await axios.client.post<ApiResponse>(
@@ -25,6 +26,7 @@ export function resetPasswordService(
       },
       getRequestConfig({
         sourceIp: sourceIp,
+        sessionId: sessionId,
         persistentSessionId: persistentSessionId,
       })
     );


### PR DESCRIPTION


## What?

 - Send session-id as header to reset password
## Why?

- The session-id wasn't being sent as it wasn't configured in the reset-password-service.ts

