### PR TITLE
Only sonarscan when none dependabot PR

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Run test coverage
         run: yarn test:coverage
       - name: SonarCloud Scan
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Dependabot can't access github repo secrets for PR's created by dependabot. PR removes sonar scans on dependabot PR's.