### PR TITLE
GOVSI-1165: add new route to call ipv-authorize

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -40,6 +40,7 @@ export const PATH_NAMES = {
   INVALID_SESSION: "/invalid-session",
   CONTACT_US: "/contact-us",
   CONTACT_US_SUBMIT_SUCCESS: "/contact-us-submit-success",
+  PROVE_IDENTITY: "/prove-identity",
 };
 
 export const HTTP_STATUS_CODES = {
@@ -77,6 +78,7 @@ export const API_ENDPOINTS = {
   CLIENT_INFO: "/client-info",
   RESET_PASSWORD_REQUEST: "/reset-password-request",
   RESET_PASSWORD: "/reset-password",
+  IPV_AUTHORIZE: "/ipv-authorize"
 };
 
 export const ERROR_MESSAGES = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,13 +51,14 @@ import { browserBackButtonErrorRouter } from "./components/browser-back-button-e
 import { contactUsRouter } from "./components/contact-us/contact-us-routes";
 import { getSessionCookieOptions, getSessionStore } from "./config/session";
 import session from "express-session";
+import { proveIdentityRouter } from "./components/prove-identity/prove-identity-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
   path.resolve("node_modules/govuk-frontend/"),
 ];
 
-function registerRoutes(app: express.Application) {
+function registerRoutes(app: express.Application, isProduction: boolean) {
   app.use(landingRouter);
   app.use(signInOrCreateRouter);
   app.use(enterEmailRouter);
@@ -81,6 +82,7 @@ function registerRoutes(app: express.Application) {
   app.use(upliftJourneyRouter);
   app.use(browserBackButtonErrorRouter);
   app.use(contactUsRouter);
+  if (! isProduction) { app.use(proveIdentityRouter); }
 }
 
 function createApp(): express.Application {
@@ -139,7 +141,7 @@ function createApp(): express.Application {
   app.use(csrfMiddleware);
   app.use(setHtmlLangMiddleware);
 
-  registerRoutes(app);
+  registerRoutes(app, isProduction);
 
   app.use(logErrorMiddleware);
   app.use(serverErrorHandler);

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -9,7 +9,6 @@
 {% set pageTitleName = 'pages.checkYourEmail.title' | translate %}
 
 {% block content %}
-
 {% include "common/errors/errorSummary.njk" %}
 
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourEmail.header' | translate}}</h1>

--- a/src/components/prove-identity/prove-identity-controller.ts
+++ b/src/components/prove-identity/prove-identity-controller.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from "express";
+import { ExpressRouteFunc } from "../../types";
+import { BadRequestError } from "../../utils/error";
+import { proveIdentityService } from "./prove-identity-service";
+import { ProveIdentityServiceInterface } from "./types";
+
+export function proveIdentityGet(
+  service: ProveIdentityServiceInterface = proveIdentityService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const { email } = req.session;
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+    const result = await service.ipvAuthorize(
+      sessionId,
+      clientSessionId,
+      email,
+      req.ip,
+      persistentSessionId
+    );
+    if (!result.success) {
+      throw new BadRequestError(result.message, result.code);
+    }
+    return res.redirect(result.redirectUri);
+  };
+}

--- a/src/components/prove-identity/prove-identity-routes.ts
+++ b/src/components/prove-identity/prove-identity-routes.ts
@@ -1,0 +1,12 @@
+import { PATH_NAMES } from "../../app.constants";
+
+import * as express from "express";
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import { asyncHandler } from "../../utils/async";
+import { proveIdentityGet } from "./prove-identity-controller";
+
+const router = express.Router();
+
+router.get(PATH_NAMES.PROVE_IDENTITY, validateSessionMiddleware, asyncHandler(proveIdentityGet()));
+
+export { router as proveIdentityRouter };

--- a/src/components/prove-identity/prove-identity-service.ts
+++ b/src/components/prove-identity/prove-identity-service.ts
@@ -1,0 +1,41 @@
+import {
+  createApiResponse,
+  getRequestConfig,
+  Http,
+  http,
+} from "../../utils/http";
+import { API_ENDPOINTS } from "../../app.constants";
+import { IPVAuthorisationResponse, ProveIdentityServiceInterface } from "./types";
+
+export function proveIdentityService(
+  axios: Http = http
+): ProveIdentityServiceInterface {
+  const ipvAuthorize = async function (
+    sessionId: string,
+    clientSessionId: string,
+    emailAddress: string,
+    sourceIp: string,
+    persistentSessionId: string
+  ): Promise<IPVAuthorisationResponse> {
+    const response = await axios.client.post<IPVAuthorisationResponse>(
+      API_ENDPOINTS.IPV_AUTHORIZE,
+      {
+        email: emailAddress,   
+      },
+      getRequestConfig({
+        sessionId: sessionId,
+        clientSessionId: clientSessionId,
+        sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
+      })
+    );
+    const apiResponse = createApiResponse(response) as IPVAuthorisationResponse;
+    apiResponse.redirectUri = response.data.redirectUri;
+
+    return apiResponse;
+  };
+
+  return {
+    ipvAuthorize,
+  };
+}

--- a/src/components/prove-identity/tests/prove-identity-controller.test.ts
+++ b/src/components/prove-identity/tests/prove-identity-controller.test.ts
@@ -1,0 +1,45 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+
+import { ProveIdentityServiceInterface } from "../types"
+import { proveIdentityGet } from "../prove-identity-controller"
+
+describe("prove identity controller", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+
+    req = { body: {}, session: {} };
+    res = { render: sandbox.fake(), redirect: sandbox.fake(), locals: {} };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("proveIdentityGet", () => {
+    it("should redirect to IPV authorisation", async () => {
+      const fakeService: ProveIdentityServiceInterface = {
+        ipvAuthorize: sandbox.fake.returns({
+          success: true,
+          sessionState: "IPV_REQUIRED",
+          redirectUri: "https://test-ipv-authorisation-uri",
+        }),
+      };
+
+      res.locals.sessionId = "s-123456-djjad";
+      res.locals.clientSessionId = "c-123456-djjad";
+      res.locals.persistentSessionId = "dips-123456-abc";
+
+      await proveIdentityGet(fakeService)(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith("https://test-ipv-authorisation-uri");
+    });
+  });
+});

--- a/src/components/prove-identity/types.ts
+++ b/src/components/prove-identity/types.ts
@@ -1,0 +1,15 @@
+import { ApiResponseResult } from "../../types";
+
+export interface IPVAuthorisationResponse extends ApiResponseResult {
+  redirectUri?: string;
+}
+
+export interface ProveIdentityServiceInterface {
+  ipvAuthorize: (
+    sessionId: string,
+    clientSessionId: string,
+    emailAddress: string,
+    sourceIp: string,
+    persistentSessionId: string
+  ) => Promise<IPVAuthorisationResponse>;
+}


### PR DESCRIPTION
## What?

Add new route to call ipv-authorize

- Provide a way to test redirecting to the IPV service by calling the ipv-api 'ipv-authorize' endpoint then redirecting to the uri provided.
- The route is not integrated into the flow and needs to be hit manually.
- A session with an email address is required, so make sure to get past 'enter-mail' before entering the 'prove-identity' url in the browser to test.
- The browser will then redirect to the IPV stub.
- The new route is only deployed to build and integration.

## Why?

Test handoff integration with the IPV stub.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/1165