### PR TITLE
AUTH-1306  - Make optimized docker image to run with Fargate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
-FROM node:16.13.0-alpine
+FROM node:16.13.0-alpine as builder
+WORKDIR /app
+COPY package.json ./
+COPY yarn.lock ./
+COPY tsconfig.json ./
+COPY ./src ./src
+COPY ./static ./static
+COPY ./@types ./@types
+RUN yarn install --production=true
+
+FROM node:16.13.0-alpine as final
+WORKDIR /app
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/node_modules/ node_modules
 
 ENV NODE_ENV "development"
 ENV PORT 3000
 
-WORKDIR /app
-
-COPY package.json ./
-COPY yarn.lock ./
-COPY tsconfig.json ./
-
-RUN yarn clean && yarn install
-
-COPY ./src ./src
-COPY ./static ./static
-COPY ./@types ./@types
-
-RUN yarn build
-
 EXPOSE $PORT
 
-CMD yarn run start
+CMD yarn start

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,20 @@ FROM node:16.13.0-alpine
 ENV NODE_ENV "development"
 ENV PORT 3000
 
-VOLUME ["/app"]
 WORKDIR /app
+
+COPY package.json ./
+COPY yarn.lock ./
+COPY tsconfig.json ./
+
+RUN yarn clean && yarn install
+
+COPY ./src ./src
+COPY ./static ./static
+COPY ./@types ./@types
+
+RUN yarn build
 
 EXPOSE $PORT
 
-CMD yarn install && yarn copy-assets && yarn dev
+CMD yarn run start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   di-auth-frontend:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: local.Dockerfile
     ports:
       - 3000:3000
       - 9230:9230

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,0 +1,11 @@
+FROM node:16.13.0-alpine
+
+ENV NODE_ENV "development"
+ENV PORT 3000
+
+VOLUME ["/app"]
+WORKDIR /app
+
+EXPOSE $PORT
+
+CMD yarn install && yarn copy-assets && yarn dev

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "cfenv": "^1.2.4",
     "connect-redis": "^6.0.0",
     "cookie-parser": "^1.4.5",
+    "copyfiles": "^2.4.1",
     "csurf": "^1.11.0",
     "dompurify": "^2.3.4",
     "express": "^4.17.2",
@@ -75,7 +76,8 @@
     "prettier": "^2.5.1",
     "redis": "^3.1.2",
     "uuid": "^8.3.2",
-    "xss": "^1.0.10"
+    "xss": "^1.0.10",
+    "uglify-js": "^3.14.5"
   },
   "devDependencies": {
     "@types/cfenv": "^1.2.2",


### PR DESCRIPTION
## What?

- Create a new docker image which will be used when running the frontend in Fargate.
- Use docker mult-stage builds to optimize our Dockerfile and reduce the size. This has brought the size down from 152.62 mb to 52.24 mb in ECR
- Carry on using the existing image when running locally and rename it to local.Dockerfile.

## Why?

- When we are running in an env other than local, there's a lot of dependencies that we don't require. 
-  In our Dockerfile which will be used for all env other than local, we can specify `yarn install --production=true` which will ensure we exclude all dependencies under devDependencies in package.json. This has meant that some of these dependencies that we do require had to be copied up to the dependencies in package.json.
- We need the local.Dockerfile to carry on using tools such as hot deploys when running locally. 