### PR TITLE
AUTH-1277: add healthcheck endpoint to frontend application

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -41,6 +41,7 @@ export const PATH_NAMES = {
   CONTACT_US: "/contact-us",
   CONTACT_US_SUBMIT_SUCCESS: "/contact-us-submit-success",
   PROVE_IDENTITY: "/prove-identity",
+  HEALTHCHECK: "/healthcheck",
 };
 
 export const HTTP_STATUS_CODES = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -57,6 +57,7 @@ import { contactUsRouter } from "./components/contact-us/contact-us-routes";
 import { getSessionCookieOptions, getSessionStore } from "./config/session";
 import session from "express-session";
 import { proveIdentityRouter } from "./components/prove-identity/prove-identity-routes";
+import { healthcheckRouter } from "./components/healthcheck/healthcheck-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -87,6 +88,7 @@ function registerRoutes(app: express.Application, appEnvIsProduction: boolean) {
   app.use(upliftJourneyRouter);
   app.use(browserBackButtonErrorRouter);
   app.use(contactUsRouter);
+  app.use(healthcheckRouter);
   if (!appEnvIsProduction) {
     app.use(proveIdentityRouter);
   }

--- a/src/components/healthcheck/healthcheck-controller.ts
+++ b/src/components/healthcheck/healthcheck-controller.ts
@@ -1,0 +1,6 @@
+import { Request, Response } from "express";
+import { HTTP_STATUS_CODES } from "../../app.constants";
+
+export function healthcheckGet(req: Request, res: Response): void {
+  res.status(HTTP_STATUS_CODES.OK).send("OK");
+}

--- a/src/components/healthcheck/healthcheck-routes.ts
+++ b/src/components/healthcheck/healthcheck-routes.ts
@@ -1,0 +1,10 @@
+import { PATH_NAMES } from "../../app.constants";
+
+import * as express from "express";
+import { healthcheckGet } from "./healthcheck-controller";
+
+const router = express.Router();
+
+router.get(PATH_NAMES.HEALTHCHECK, healthcheckGet);
+
+export { router as healthcheckRouter };

--- a/src/components/healthcheck/tests/healthcheck-controller.test.ts
+++ b/src/components/healthcheck/tests/healthcheck-controller.test.ts
@@ -1,0 +1,36 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import { healthcheckGet } from "../healthcheck-controller";
+import { HTTP_STATUS_CODES } from "../../../app.constants";
+
+describe("healthcheck controller", () => {
+  let sandbox: sinon.SinonSandbox;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    req = {
+      body: {},
+    };
+    res = {
+      status: sandbox.stub().returnsThis(),
+      send: sandbox.fake(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("healthcheckGet", () => {
+    it("should return 200", () => {
+      healthcheckGet(req as Request, res as Response);
+
+      expect(res.status).to.have.been.calledWith(HTTP_STATUS_CODES.OK);
+    });
+  });
+});

--- a/src/components/healthcheck/tests/healthcheck-integration.test.ts
+++ b/src/components/healthcheck/tests/healthcheck-integration.test.ts
@@ -1,0 +1,26 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import { PATH_NAMES } from "../../../app.constants";
+import decache from "decache";
+
+describe("Integration::healthcheck", () => {
+  let sandbox: sinon.SinonSandbox;
+  let app: any;
+
+  before(() => {
+    decache("../../../app");
+    decache("../../../middleware/requires-auth-middleware");
+    sandbox = sinon.createSandbox();
+    app = require("../../../app").createApp();
+  });
+
+  after(() => {
+    sandbox.restore();
+    app = undefined;
+  });
+
+  it("healthcheck should return 200 OK", (done) => {
+    request(app).get(PATH_NAMES.HEALTHCHECK).expect(200, done);
+  });
+});


### PR DESCRIPTION
## What?

Add healthcheck endpoint to frontend management application.
The endpoint returns a simple '200 OK'

## Why?

ALB and Fargate requires a healthcheck endpoint to know whether the app has started.

## Related PRs

https://github.com/alphagov/di-authentication-account-management/pull/304
