### PR TITLE
AUTH-1276: Fix incorrect bucket name in production.tfvars

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,3 +1,3 @@
 redis_service_plan  = "large-ha-5_x"
 environment         = "production"
-common_state_bucket = "digital-identity-dev-tfstate"
+common_state_bucket = "digital-identity-prod-tfstate"


### PR DESCRIPTION
## What?

- Use the correct value for `common_state_bucket` in the `production.tfvars`, this is incorrectly pointing at the non-production state bucket.

## Why?

The deploy to production is failing as it can't read from the specified (incorrect) bucket.

## Related PRs

#472 