### PR TITLE
AUTH-1358: read redis configuration from ssm for ecs fargate

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "semi": true
   },
   "dependencies": {
+    "aws-sdk": "^2.1066.0",
     "axios": "^0.24.0",
     "cfenv": "^1.2.4",
     "connect-redis": "^6.0.0",
@@ -75,9 +76,9 @@
     "pino-http": "^6.5.0",
     "prettier": "^2.5.1",
     "redis": "^3.1.2",
+    "uglify-js": "^3.14.5",
     "uuid": "^8.3.2",
-    "xss": "^1.0.10",
-    "uglify-js": "^3.14.5"
+    "xss": "^1.0.10"
   },
   "devDependencies": {
     "@types/cfenv": "^1.2.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -18,8 +18,10 @@ import Backend from "i18next-fs-backend";
 import {
   getAppEnv,
   getNodeEnv,
+  getRedisConfig,
   getSessionExpiry,
   getSessionSecret,
+  isFargate,
 } from "./config";
 import { logErrorMiddleware } from "./middleware/log-error-middleware";
 import { enterEmailRouter } from "./components/enter-email/enter-email-routes";
@@ -128,10 +130,13 @@ async function createApp(): Promise<express.Application> {
   app.use(i18nextMiddleware.handle(i18next));
   app.use(helmet(helmetConfiguration));
 
+  const redisConfig =
+    isProduction && isFargate() ? await getRedisConfig(getAppEnv()) : undefined;
+
   app.use(
     session({
       name: "aps",
-      store: getSessionStore(),
+      store: getSessionStore(redisConfig),
       saveUninitialized: true,
       secret: getSessionSecret(),
       unset: "destroy",

--- a/src/app.ts
+++ b/src/app.ts
@@ -95,7 +95,7 @@ function registerRoutes(app: express.Application, appEnvIsProduction: boolean) {
   }
 }
 
-function createApp(): express.Application {
+async function createApp(): Promise<express.Application> {
   const app: express.Application = express();
   const isProduction = getNodeEnv() === ENVIRONMENT_NAME.PROD;
   const appEnvIsProduction = getAppEnv() === APP_ENV_NAME.PROD;

--- a/src/components/check-your-email/tests/check-your-email-integration.test.ts
+++ b/src/components/check-your-email/tests/check-your-email-integration.test.ts
@@ -12,7 +12,7 @@ describe("Integration:: check your email", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -25,7 +25,7 @@ describe("Integration:: check your email", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -12,7 +12,7 @@ describe("Integration:: check your phone", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -25,7 +25,7 @@ describe("Integration:: check your phone", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -13,7 +13,7 @@ describe("Integration:: contact us - public user", () => {
   let app: any;
   let zendeskApiUrl: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -28,7 +28,7 @@ describe("Integration:: contact us - public user", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     zendeskApiUrl = process.env.ZENDESK_API_URL;
 
     request(app)

--- a/src/components/create-password/tests/create-password-integration.test.ts
+++ b/src/components/create-password/tests/create-password-integration.test.ts
@@ -12,7 +12,7 @@ describe("Integration::register create password", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -25,7 +25,7 @@ describe("Integration::register create password", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -12,7 +12,7 @@ describe("Integration::enter email", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -25,7 +25,7 @@ describe("Integration::enter email", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -12,7 +12,7 @@ describe("Integration:: enter mfa", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -26,7 +26,7 @@ describe("Integration:: enter mfa", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -15,7 +15,7 @@ describe("Integration::enter password", () => {
 
   const ENDPOINT = "/enter-password";
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -30,7 +30,7 @@ describe("Integration::enter password", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)

--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -12,7 +12,7 @@ describe("Integration::enter phone number", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -25,7 +25,7 @@ describe("Integration::enter phone number", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)

--- a/src/components/healthcheck/tests/healthcheck-integration.test.ts
+++ b/src/components/healthcheck/tests/healthcheck-integration.test.ts
@@ -8,11 +8,11 @@ describe("Integration::healthcheck", () => {
   let sandbox: sinon.SinonSandbox;
   let app: any;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/requires-auth-middleware");
     sandbox = sinon.createSandbox();
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
   });
 
   after(() => {

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -12,7 +12,7 @@ describe("Integration:: resend mfa code", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -27,7 +27,7 @@ describe("Integration:: resend mfa code", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)

--- a/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
+++ b/src/components/reset-password-check-email/tests/reset-password-check-email-integration.test.ts
@@ -11,7 +11,7 @@ describe("Integration::reset password check email ", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -24,7 +24,7 @@ describe("Integration::reset password check email ", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
   });
 

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -15,10 +15,10 @@ describe("Integration::reset password", () => {
   const ENDPOINT =
     "/reset-password?code=WBTxBpSQdd3cSxT-!X5s.1758350212000.a-session-id.a-persistent-id";
 
-  before(() => {
+  before(async () => {
     sandbox = sinon.createSandbox();
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     request(app)

--- a/src/components/share-info/tests/share-info-integration.test.ts
+++ b/src/components/share-info/tests/share-info-integration.test.ts
@@ -23,7 +23,7 @@ describe("Integration::share info", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -38,7 +38,7 @@ describe("Integration::share info", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     createClientInfoNock(baseApi);

--- a/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
+++ b/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
@@ -24,7 +24,7 @@ describe("Integration:: updated-terms-code", () => {
   let app: any;
   let baseApi: string;
 
-  before(() => {
+  before(async () => {
     decache("../../../app");
     decache("../../../middleware/session-middleware");
     const sessionMiddleware = require("../../../middleware/session-middleware");
@@ -42,7 +42,7 @@ describe("Integration:: updated-terms-code", () => {
         next();
       });
 
-    app = require("../../../app").createApp();
+    app = await require("../../../app").createApp();
     baseApi = process.env.FRONTEND_API_BASE_URL;
 
     nockClientInfo(baseApi);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,17 +1,18 @@
-import http from "http";
 import { createApp } from "./app";
 import { logger } from "./utils/logger";
 
-const app = createApp();
 const port: number | string = process.env.PORT || 3000;
 
-const server = http.createServer(app);
-
-server
-  .listen(port, () => {
-    logger.info(`Server listening on port ${port}`);
-    app.emit("appStarted");
-  })
-  .on("error", (error: Error) => {
-    logger.error(`Unable to start server because of ${error.message}`);
-  });
+(async () => {
+  const app = await createApp();
+  app
+    .listen(port, () => {
+      logger.info(`Server listening on port ${port}`);
+      app.emit("appStarted");
+    })
+    .on("error", (error: Error) => {
+      logger.error(`Unable to start server because of ${error.message}`);
+    });
+})().catch((ex) => {
+  logger.error(`Server failed to create app ${ex.message}`);
+});

--- a/src/utils/ssm.ts
+++ b/src/utils/ssm.ts
@@ -1,0 +1,3 @@
+const AWS = require("aws-sdk");
+
+export default new AWS.SSM();

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -24,3 +24,12 @@ interface RequesterAnonymous {
 export interface ZendeskInterface {
   createTicket(form: CreateTicketPayload): Promise<void>;
 }
+
+export interface RedisConfig {
+  host: string;
+  port: string;
+  password: string;
+  name?: string;
+  uri?: string;
+  tls?: boolean;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -857,6 +857,21 @@ atomic-sleep@^1.0.0:
   resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
   integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
+aws-sdk@^2.1066.0:
+  version "2.1066.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1066.0.tgz#2a9b00d983f3c740a7adda18d4e9a5c34d4d3887"
+  integrity sha512-9BZPdJgIvau8Jf2l3PxInNqQd733uKLqGGDywMV71duxNTLgdBZe2zvCkbgl22+ldC8R2LVMdS64DzchfQIxHg==
+  dependencies:
+    buffer "4.9.2"
+    events "1.1.1"
+    ieee754 "1.1.13"
+    jmespath "0.16.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 axios@^0.24.0:
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.24.0.tgz#804e6fa1e4b9c5288501dd9dff56a7a0940d20d6"
@@ -868,6 +883,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+base64-js@^1.0.2:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -944,6 +964,15 @@ browserslist@^4.17.5:
     escalade "^3.1.1"
     node-releases "^2.0.1"
     picocolors "^1.0.0"
+
+buffer@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
+  integrity sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 bytes@3.1.1:
   version "3.1.1"
@@ -1815,6 +1844,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 express-session@^1.17.2:
   version "1.17.2"
   resolved "https://registry.yarnpkg.com/express-session/-/express-session-1.17.2.tgz#397020374f9bf7997f891b85ea338767b30d0efd"
@@ -2358,6 +2392,16 @@ iconv-lite@0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
+ieee754@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
+  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+
+ieee754@^1.1.4:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
@@ -2528,7 +2572,7 @@ isarray@0.0.1:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
-isarray@~1.0.0:
+isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -2598,6 +2642,11 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+jmespath@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
+  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
 joycon@^3.1.1:
   version "3.1.1"
@@ -3430,6 +3479,11 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^1.3.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -3458,6 +3512,11 @@ qs@^6.9.4:
   integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
   dependencies:
     side-channel "^1.0.4"
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -3703,6 +3762,16 @@ sass@^1.44.0:
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
+
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 saxes@^5.0.1:
   version "5.0.1"
@@ -4265,6 +4334,14 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -4274,6 +4351,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 uuid@^3.3.3:
   version "3.4.0"
@@ -4415,6 +4497,19 @@ xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
   integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## What?

Read Redis configuration from SSM for ECS Fargate.

- Update server startup to support async calls.
- Update integration tests to support async startup.
- Include aws-sdk in dependencies to make use of aws.ssm library.
- Add a flag to show when the app is running under Fargate.
- Retrieve the Redis config from SSM when on Fargate.

## Why?

Frontend currently runs on PaaS and retrieves Redis connection details from PaaS services. This option is not available when running on ECS Fargate.

Some Redis connection details are secret so we decided to put them in AWS SSM Parameter store. This PR reads these parameters from SSM when running under Fargate so that the app can connect to Redis.

## Related PRs

https://github.com/alphagov/di-authentication-account-management/pull/312
