### PR TITLE
AUTH-1316: Bring ECS sizing in line with PaaS deployment

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -10,6 +10,9 @@ resource "aws_ecs_service" "frontend_ecs_service" {
   desired_count   = var.ecs_desired_count
   launch_type     = "FARGATE"
 
+  deployment_minimum_healthy_percent = var.deployment_min_healthy_percent
+  deployment_maximum_percent         = var.deployment_max_percent
+
   network_configuration {
     security_groups = [
       local.allow_egress_security_group_id,

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -2,3 +2,4 @@ redis_service_plan  = "large-ha-5_x"
 environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
 public_access       = false
+ecs_desired_count   = 4

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -82,7 +82,7 @@ variable "image_digest" {
 
 variable "ecs_desired_count" {
   type    = number
-  default = 3
+  default = 2
 }
 
 variable "app_port" {
@@ -135,4 +135,12 @@ variable "zendesk_api_token" {
 
 variable "frontend_api_fqdn" {
   default = null
+}
+
+variable "deployment_min_healthy_percent" {
+  default = 50
+}
+
+variable "deployment_max_percent" {
+  default = 100
 }


### PR DESCRIPTION
## What?

- Set instances to 2 for non-prod and 4 prod
- Set deployment strategy as 50% minimum and 100% maximum

## Why?

To ensure the Fargate allocations are similar to that of PaaS. 

The deployment strategy was set using Verify Hub as a reference to ensure old versions of tasks don't lurk around after a deployment.