### PR TITLE
AUTH-1369: Rename ECS service log group

### DIFF
--- a/ci/terraform/cloudwatch.tf
+++ b/ci/terraform/cloudwatch.tf
@@ -49,7 +49,7 @@ resource "aws_kms_key" "cloudwatch_log_encryption" {
 }
 
 resource "aws_cloudwatch_log_group" "ecs_frontend_task_log" {
-  name              = "${var.environment}-frontend-ecs-task"
+  name              = "/ecs/${var.environment}-frontend"
   kms_key_id        = aws_kms_key.cloudwatch_log_encryption.arn
   retention_in_days = var.cloudwatch_log_retention
 


### PR DESCRIPTION
## What?

- Rename the ECS service log group to be prefixed with `/ecs/`

## Why?

This will group all the ECS related logs together (alphabetically) in Cloudwatch and make it easier to pick out the log groups in the Splunk processor.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/158
https://github.com/alphagov/di-authentication-account-management/pull/333
https://github.com/alphagov/centralised-security-logging-service/pull/797