### PR TITLE
AUTH-1316: Tweak ZDD and rate limit

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -142,5 +142,5 @@ variable "deployment_min_healthy_percent" {
 }
 
 variable "deployment_max_percent" {
-  default = 100
+  default = 150
 }

--- a/ci/terraform/waf.tf
+++ b/ci/terraform/waf.tf
@@ -14,7 +14,7 @@ resource "aws_wafv2_web_acl" "frontend_alb_waf_regional_web_acl" {
     name     = "${var.environment}-frontend-alb-waf-rate-based-rule"
     statement {
       rate_based_statement {
-        limit              = 250
+        limit              = 5000
         aggregate_key_type = "IP"
       }
     }


### PR DESCRIPTION
## What?

- Adjust WAF rate limiting rule to allow 5000 requests in 5 mins
- Adjust service deployment parameters to allow a max 150% 

## Why?

Rate limit rule was being triggered while testing due to the fact that each page visit incurs circa 10 page requests.

The deployment rules ensure that ECS has enough scope to start up new tasks before shutting down old versions whilst still maintaining the desired number of running instances.