### PR TITLE
AUTH-1388: Create frontend DNS record

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -2,3 +2,5 @@ redis_service_plan  = "tiny-ha-5_x"
 environment         = "build"
 common_state_bucket = "digital-identity-dev-tfstate"
 public_access       = true
+
+paas_frontend_cdn_route_destination = "d158sddez3vxwe.cloudfront.net"

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -2,3 +2,5 @@ redis_service_plan  = "tiny-ha-5_x"
 environment         = "integration"
 common_state_bucket = "digital-identity-dev-tfstate"
 public_access       = true
+
+paas_frontend_cdn_route_destination = "d3a5c9upzkx78l.cloudfront.net"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -3,3 +3,5 @@ environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
 public_access       = false
 ecs_desired_count   = 4
+
+paas_frontend_cdn_route_destination = "d2fete2ah9wab4.cloudfront.net"

--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -1,3 +1,11 @@
+resource "aws_route53_record" "frontend" {
+  name    = local.frontend_fqdn
+  type    = "CNAME"
+  zone_id = local.zone_id
+  records = [var.paas_frontend_cdn_route_destination]
+  ttl     = 300
+}
+
 resource "aws_route53_record" "frontend_fg" {
   name    = "signin-fg.${local.service_domain}"
   type    = "A"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -144,3 +144,8 @@ variable "deployment_min_healthy_percent" {
 variable "deployment_max_percent" {
   default = 150
 }
+
+variable "paas_frontend_cdn_route_destination" {
+  type        = string
+  description = "The Cloudfront instance to forward all PaaS requests to"
+}


### PR DESCRIPTION
## What?

- Add the Terraform to create the frontend DNS record. This record already exists and will be migrated into Terraform state manually.

## Why?

We are migrating the frontend and account management applications from PaaS to Fargate, as such these records need to point at the ALBs associated with those applications. The ALBs are created in the Terraform deployments for the individual apps, so the creation of the DNS record needs to sit along side this.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/163

