### PR TITLE
AUTH-1388: Change the hostname on the ALB certs

### DIFF
--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -19,7 +19,7 @@ resource "aws_route53_record" "frontend_fg" {
 }
 
 resource "aws_acm_certificate" "frontend_certificate" {
-  domain_name       = aws_route53_record.frontend_fg.name
+  domain_name       = aws_route53_record.frontend.name
   validation_method = "DNS"
 
   tags = local.default_tags


### PR DESCRIPTION
## What?

- In preparation for the migration lets change the hostname on the ALB TLS certificate to that of the real DNS name of the service.

## Why?

We will pointing the real DNS records at the ALBs in the near future, so let's get the certificates ready.