### PR TITLE
AUTH-1355: 'mins' to 'minutes'

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1022,7 +1022,7 @@
       "paragraph1": "This is because you tried to reset your password too many times the last time you tried to sign in.",
       "paragraph2": "You can ",
       "resetPasswordLinkText": "reset your password",
-      "paragraph3": " after 15 mins have passed."
+      "paragraph3": " after 15 minutes have passed."
     },
     "accountLocked": {
       "title": "You entered the wrong password too many times",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1022,7 +1022,7 @@
       "paragraph1": "This is because you tried to reset your password too many times the last time you tried to sign in.",
       "paragraph2": "You can ",
       "resetPasswordLinkText": "reset your password",
-      "paragraph3": " after 15 mins have passed."
+      "paragraph3": " after 15 minutes have passed."
     },
     "accountLocked": {
       "title": "You entered the wrong password too many times",


### PR DESCRIPTION
## What?

Update 'mins' to 'minutes' on the 'You cannot reset your password at the moment' screen.

## Why?

Was carried over from the previous text.

## Related

#495 