### PR TITLE
AUTH-1388: Switchover

### DIFF
--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -36,7 +36,7 @@ resource "aws_alb_listener" "frontend_alb_listener_https" {
   protocol          = "HTTPS"
 
   ssl_policy      = "ELBSecurityPolicy-2016-08"
-  certificate_arn = aws_acm_certificate.frontend_certificate.arn
+  certificate_arn = aws_acm_certificate.frontend_alb_certificate.arn
 
   default_action {
     target_group_arn = aws_alb_target_group.frontend_alb_target_group.id

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,6 +1,5 @@
 redis_service_plan  = "tiny-ha-5_x"
 environment         = "build"
 common_state_bucket = "digital-identity-dev-tfstate"
-public_access       = true
 
 paas_frontend_cdn_route_destination = "d158sddez3vxwe.cloudfront.net"

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -96,7 +96,7 @@ resource "aws_ecs_task_definition" "frontend_task_definition" {
         },
         {
           name  = "BASE_URL"
-          value = aws_route53_record.frontend_fg.name
+          value = aws_route53_record.frontend.name
         },
         {
           name  = "SESSION_EXPIRY"

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,6 +1,5 @@
 redis_service_plan  = "tiny-ha-5_x"
 environment         = "integration"
 common_state_bucket = "digital-identity-dev-tfstate"
-public_access       = true
 
 paas_frontend_cdn_route_destination = "d3a5c9upzkx78l.cloudfront.net"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,7 +1,6 @@
 redis_service_plan  = "large-ha-5_x"
 environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
-public_access       = false
 ecs_desired_count   = 4
 
 paas_frontend_cdn_route_destination = "d2fete2ah9wab4.cloudfront.net"

--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -1,9 +1,13 @@
 resource "aws_route53_record" "frontend" {
   name    = local.frontend_fqdn
-  type    = "CNAME"
+  type    = "A"
   zone_id = local.zone_id
-  records = [var.paas_frontend_cdn_route_destination]
-  ttl     = 300
+
+  alias {
+    evaluate_target_health = false
+    name                   = aws_lb.frontend_alb.dns_name
+    zone_id                = aws_lb.frontend_alb.zone_id
+  }
 }
 
 resource "aws_route53_record" "frontend_fg" {

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -13,5 +13,4 @@ image_uri               = "706615647326.dkr.ecr.eu-west-2.amazonaws.com/frontend
 image_digest            = "sha256:dfbe4c6ccbbaf4c8ae7589a31d0bf73940cef19b8cfcb3eaf20c35cfed6a693d"
 session_expiry          = 300000
 gtm_id                  = ""
-public_access           = true
 

--- a/ci/terraform/security-groups.tf
+++ b/ci/terraform/security-groups.tf
@@ -54,8 +54,6 @@ resource "aws_security_group" "frontend_alb_sg" {
 }
 
 resource "aws_security_group_rule" "allow_alb_http_ingress_from_anywhere" {
-  count = var.public_access ? 1 : 0
-
   security_group_id = aws_security_group.frontend_alb_sg.id
   type              = "ingress"
 
@@ -67,8 +65,6 @@ resource "aws_security_group_rule" "allow_alb_http_ingress_from_anywhere" {
 }
 
 resource "aws_security_group_rule" "allow_alb_https_ingress_from_anywhere" {
-  count = var.public_access ? 1 : 0
-
   security_group_id = aws_security_group.frontend_alb_sg.id
   type              = "ingress"
 

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -113,11 +113,6 @@ variable "logging_endpoint_enabled" {
   description = "Whether the service should ship its Lambda logs to the `logging_endpoint_arn`"
 }
 
-variable "public_access" {
-  type    = bool
-  default = false
-}
-
 variable "zendesk_username" {
   type    = string
   default = ""


### PR DESCRIPTION
## What?

- Remove the flag that controls the creation of the security group rule allowing ingress from anywhere.
- Switch the frontend DNS record (`signin.account.gov.uk`) to point at the Fargate ALB.
- Ensure the Fargate ALB is using the correct certificate.

## Why?

We are ready to switchover hosting of the frontend.
