### PR TITLE
AUTH-1309 - Adjust formatting and text on contact-us pages

### DIFF
--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -25,6 +25,11 @@
     } if (errors['issueDescription'])
 }) }}
 
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -41,6 +41,11 @@
     } if (errors['optionalDescription'])
 }) }}
 
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -22,21 +22,25 @@
     } if (errors['issueDescription'])
 }) }}
 
-<h2 class="govuk-heading-m">
-  {{ 'pages.contactUsQuestions.anotherProblem.section2.header' | translate }}
-</h2>
-
 {{ govukTextarea({
     label: {
-      text: 'pages.contactUsQuestions.anotherProblem.section2.paragraph1' | translate,
+      text: 'pages.contactUsQuestions.anotherProblem.section2.header' | translate,
       classes: "govuk-label--s"
     },
+    hint: {
+        text: 'pages.contactUsQuestions.anotherProblem.section2.paragraph1' | translate
+      },
     id: "additionalDescription",
     name: "additionalDescription",
     value: additionalDescription,
     errorMessage: {
         text: errors['additionalDescription'].text
     } if (errors['additionalDescription'])
+}) }}
+
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
 }) }}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}

--- a/src/components/contact-us/questions/_email-subscriptions-questions.njk
+++ b/src/components/contact-us/questions/_email-subscriptions-questions.njk
@@ -37,6 +37,11 @@
     } if (errors['optionalDescription'])
 }) }}
 
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -25,6 +25,11 @@
     } if (errors['optionalDescription'])
 }) }}
 
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -25,6 +25,11 @@
     } if (errors['optionalDescription'])
 }) }}
 
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -25,6 +25,11 @@
     } if (errors['optionalDescription'])
 }) }}
 
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -25,6 +25,11 @@
     } if (errors['optionalDescription'])
 }) }}
 
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({

--- a/src/components/contact-us/questions/_no-uk-mobile-questions.njk
+++ b/src/components/contact-us/questions/_no-uk-mobile-questions.njk
@@ -25,6 +25,11 @@
     } if (errors['optionalDescription'])
 }) }}
 
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({

--- a/src/components/contact-us/questions/_reply_by_email.njk
+++ b/src/components/contact-us/questions/_reply_by_email.njk
@@ -1,8 +1,3 @@
-{{ govukWarningText({
-    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
-    iconFallbackText: "Warning"
-}) }}
-
 {% set emailHtml %}
 {{ govukInput({
   id: "email",

--- a/src/components/contact-us/questions/_signing-in-problem-questions.njk
+++ b/src/components/contact-us/questions/_signing-in-problem-questions.njk
@@ -25,6 +25,11 @@
     } if (errors['issueDescription'])
 }) }}
 
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({

--- a/src/components/contact-us/questions/_suggestion-feedback-questions.njk
+++ b/src/components/contact-us/questions/_suggestion-feedback-questions.njk
@@ -21,6 +21,11 @@
     } if (errors['issueDescription'])
 }) }}
 
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -38,7 +38,12 @@
     } if (errors['additionalDescription'])
 }) }}
 
-{{ govukTextarea({
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
+{{ govukInput({
     label: {
       text: 'pages.contactUsQuestions.technicalError.section3.header' | translate,
       classes: "govuk-label--s"


### PR DESCRIPTION
## What?

- On `There was a technical error` screen, move the warning text above the URL text field.
- As the warning text isn't always going to be the last element on the page before the `reply by email` radio boxes, move it into the page
- Change the text field on the `Another problem` to match the other text fields

## Why?

- To make it consistent and clear to the user
