### PR TITLE
AUTH-1833: Integration basic auth sidecar

### DIFF
--- a/ci/tasks/deploy-frontend.yml
+++ b/ci/tasks/deploy-frontend.yml
@@ -23,9 +23,12 @@ params:
   ZENDESK_USERNAME: ((build-zendesk-username))
   ZENDESK_API_TOKEN: ((build-zendesk-api-token))
   ZENDESK_GROUP_ID_PUBLIC: ((build-zendesk-group-id-public))
+  BASIC_AUTH_USERNAME: ((no-basic-auth-username))
+  BASIC_AUTH_PASSWORD: ((no-basic-auth-password))
 inputs:
   - name: frontend-src
   - name: frontend-image
+  - name: basic-auth-sidecar-image
 outputs:
   - name: terraform-outputs
 run:
@@ -36,6 +39,18 @@ run:
       export IMAGE_URI=$(cat frontend-image/repository)
       export IMAGE_TAG=$(cat frontend-image/tag)
       export IMAGE_DIGEST=$(cat frontend-image/digest)
+      
+      export SIDECAR_IMAGE_URI=$(cat basic-auth-sidecar-image/repository)
+      export SIDECAR_IMAGE_TAG=$(cat basic-auth-sidecar-image/tag)
+      export SIDECAR_IMAGE_DIGEST=$(cat basic-auth-sidecar-image/digest)
+      
+      NORMALISED_BASIC_AUTH_USERNAME="${BASIC_AUTH_USERNAME}"
+      NORMALISED_BASIC_AUTH_PASSWORD="${BASIC_AUTH_PASSWORD}"
+      
+      if [ ${NORMALISED_BASIC_AUTH_PASSWORD} == "none" ]; then
+        NORMALISED_BASIC_AUTH_USERNAME=""
+        NORMALISED_BASIC_AUTH_PASSWORD=""
+      fi
       
       cd "frontend-src/ci/terraform/"
       terraform init -input=false \
@@ -65,6 +80,11 @@ run:
         -var "image_uri=${IMAGE_URI}" \
         -var "image_tag=${IMAGE_TAG}" \
         -var "image_digest=${IMAGE_DIGEST}" \
+        -var "sidecar_image_uri=${SIDECAR_IMAGE_URI}" \
+        -var "sidecar_image_tag=${SIDECAR_IMAGE_TAG}" \
+        -var "sidecar_image_digest=${SIDECAR_IMAGE_DIGEST}" \
+        -var "basic_auth_username=${NORMALISED_BASIC_AUTH_USERNAME}" \
+        -var "basic_auth_password=${NORMALISED_BASIC_AUTH_PASSWORD}" \      
         -var-file ${DEPLOY_ENVIRONMENT}.tfvars \
 
       terraform output --json > ../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -23,7 +23,7 @@ resource "aws_alb_target_group" "frontend_alb_target_group" {
     protocol            = "HTTP"
     matcher             = "200"
     timeout             = "3"
-    path                = "/healthcheck"
+    path                = "/healthcheck/"
     unhealthy_threshold = "2"
   }
 
@@ -39,7 +39,7 @@ resource "aws_alb_listener" "frontend_alb_listener_https" {
   certificate_arn = aws_acm_certificate.frontend_alb_certificate.arn
 
   default_action {
-    target_group_arn = aws_alb_target_group.frontend_alb_target_group.id
+    target_group_arn = aws_alb_target_group.frontend_alb_target_group.arn
     type             = "forward"
   }
 

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -22,7 +22,7 @@ locals {
         protocol      = "tcp"
         containerPort = var.app_port
         hostPort      = var.app_port
-      }]
+    }]
     environment = [
       {
         name  = "NODE_ENV"
@@ -108,7 +108,7 @@ locals {
         protocol      = "tcp"
         containerPort = local.nginx_port
         hostPort      = local.nginx_port
-      }]
+    }]
     environment = [
       {
         name  = "BASIC_AUTH_USERNAME"

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -1,6 +1,133 @@
 locals {
   service_name   = "${var.environment}-frontend-ecs-service"
   container_name = "frontend-application"
+
+  nginx_port       = 8080
+  application_port = var.basic_auth_password == "" ? var.app_port : local.nginx_port
+
+  frontend_container_definition = {
+    name      = local.container_name
+    image     = "${var.image_uri}:${var.image_tag}@${var.image_digest}"
+    essential = true
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.ecs_frontend_task_log.name
+        awslogs-region        = var.aws_region
+        awslogs-stream-prefix = local.service_name
+      }
+    }
+    portMappings = [
+      {
+        protocol      = "tcp"
+        containerPort = var.app_port
+        hostPort      = var.app_port
+      }]
+    environment = [
+      {
+        name  = "NODE_ENV"
+        value = "production"
+      },
+      {
+        name  = "APP_ENV"
+        value = var.environment
+      },
+      {
+        name  = "FARGATE"
+        value = "1"
+      },
+      {
+        name  = "API_BASE_URL"
+        value = "https://${local.oidc_api_fqdn}"
+      },
+      {
+        name  = "FRONTEND_API_BASE_URL"
+        value = "https://${local.frontend_api_fqdn}/"
+      },
+      {
+        name  = "API_KEY"
+        value = local.api_key
+      },
+      {
+        name  = "ACCOUNT_MANAGEMENT_URL"
+        value = "https://${local.account_management_fqdn}"
+      },
+      {
+        name  = "BASE_URL"
+        value = aws_route53_record.frontend.name
+      },
+      {
+        name  = "SESSION_EXPIRY"
+        value = var.session_expiry
+      },
+      {
+        name  = "SESSION_SECRET"
+        value = random_string.session_secret.result
+      },
+      {
+        name  = "GTM_ID"
+        value = var.gtm_id
+      },
+      {
+        name  = "ANALYTICS_COOKIE_DOMAIN"
+        value = local.service_domain
+      },
+      {
+        name  = "REDIS_KEY"
+        value = local.redis_key
+      },
+      {
+        name  = "ZENDESK_API_TOKEN"
+        value = var.zendesk_api_token
+      },
+      {
+        name  = "ZENDESK_GROUP_ID_PUBLIC"
+        value = var.zendesk_group_id_public
+      },
+      {
+        name  = "ZENDESK_USERNAME"
+        value = var.zendesk_username
+      },
+    ]
+  }
+
+  sidecar_container_definition = {
+    name      = "nginx-sidecar"
+    image     = "${var.sidecar_image_uri}:${var.sidecar_image_tag}@${var.sidecar_image_digest}"
+    essential = true
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.ecs_frontend_task_log.name
+        awslogs-region        = var.aws_region
+        awslogs-stream-prefix = local.service_name
+      }
+    }
+    portMappings = [
+      {
+        protocol      = "tcp"
+        containerPort = local.nginx_port
+        hostPort      = local.nginx_port
+      }]
+    environment = [
+      {
+        name  = "BASIC_AUTH_USERNAME"
+        value = var.basic_auth_username
+      },
+      {
+        name  = "BASIC_AUTH_PASSWORD"
+        value = var.basic_auth_password
+      },
+      {
+        name  = "PROXY_PASS"
+        value = "http://localhost:${var.app_port}"
+      },
+      {
+        name  = "NGINX_PORT"
+        value = "8080"
+      },
+    ]
+  }
 }
 
 resource "random_string" "session_secret" {
@@ -31,8 +158,8 @@ resource "aws_ecs_service" "frontend_ecs_service" {
 
   load_balancer {
     target_group_arn = aws_alb_target_group.frontend_alb_target_group.arn
-    container_name   = local.container_name
-    container_port   = var.app_port
+    container_name   = var.basic_auth_password == "" ? local.frontend_container_definition.name : local.sidecar_container_definition.name
+    container_port   = local.application_port
   }
 
   tags = local.default_tags
@@ -46,92 +173,10 @@ resource "aws_ecs_task_definition" "frontend_task_definition" {
   network_mode             = "awsvpc"
   cpu                      = 1024
   memory                   = 2048
-  container_definitions = jsonencode([
-    {
-      name      = local.container_name
-      image     = "${var.image_uri}:${var.image_tag}@${var.image_digest}"
-      essential = true
-      logConfiguration = {
-        logDriver = "awslogs"
-        options = {
-          awslogs-group         = aws_cloudwatch_log_group.ecs_frontend_task_log.name
-          awslogs-region        = var.aws_region
-          awslogs-stream-prefix = local.service_name
-        }
-      }
-      portMappings = [
-        {
-          protocol      = "tcp"
-          containerPort = var.app_port
-          hostPort      = var.app_port
-      }]
-      environment = [
-        {
-          name  = "NODE_ENV"
-          value = "production"
-        },
-        {
-          name  = "APP_ENV"
-          value = var.environment
-        },
-        {
-          name  = "FARGATE"
-          value = "1"
-        },
-        {
-          name  = "API_BASE_URL"
-          value = "https://${local.oidc_api_fqdn}"
-        },
-        {
-          name  = "FRONTEND_API_BASE_URL"
-          value = "https://${local.frontend_api_fqdn}/"
-        },
-        {
-          name  = "API_KEY"
-          value = local.api_key
-        },
-        {
-          name  = "ACCOUNT_MANAGEMENT_URL"
-          value = "https://${local.account_management_fqdn}"
-        },
-        {
-          name  = "BASE_URL"
-          value = aws_route53_record.frontend.name
-        },
-        {
-          name  = "SESSION_EXPIRY"
-          value = var.session_expiry
-        },
-        {
-          name  = "SESSION_SECRET"
-          value = random_string.session_secret.result
-        },
-        {
-          name  = "GTM_ID"
-          value = var.gtm_id
-        },
-        {
-          name  = "ANALYTICS_COOKIE_DOMAIN"
-          value = local.service_domain
-        },
-        {
-          name  = "REDIS_KEY"
-          value = local.redis_key
-        },
-        {
-          name  = "ZENDESK_API_TOKEN"
-          value = var.zendesk_api_token
-        },
-        {
-          name  = "ZENDESK_GROUP_ID_PUBLIC"
-          value = var.zendesk_group_id_public
-        },
-        {
-          name  = "ZENDESK_USERNAME"
-          value = var.zendesk_username
-        },
-      ]
-  }])
+  container_definitions = var.basic_auth_password == "" ? jsonencode([local.frontend_container_definition]) : jsonencode([
+    local.frontend_container_definition,
+    local.sidecar_container_definition,
+  ])
 
   tags = local.default_tags
 }

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -5,7 +5,7 @@ cf_org_name             = "gds-digital-identity-authentication"
 aws_region              = "eu-west-2"
 account_management_fqdn = "acc-mgmt-fg.sandpit.auth.ida.digital.cabinet-office.gov.uk"
 oidc_api_fqdn           = "api.sandpit.auth.ida.digital.cabinet-office.gov.uk"
-frontend_fqdn           = "signin-fg.sandpit.auth.ida.digital.cabinet-office.gov.uk"
+frontend_fqdn           = "signin.sandpit.auth.ida.digital.cabinet-office.gov.uk"
 frontend_api_fqdn       = "auth.sandpit.auth.ida.digital.cabinet-office.gov.uk"
 service_domain          = "sandpit.auth.ida.digital.cabinet-office.gov.uk"
 zone_id                 = "Z050645231Q0HZAX6FT5W"
@@ -14,3 +14,9 @@ image_digest            = "sha256:dfbe4c6ccbbaf4c8ae7589a31d0bf73940cef19b8cfcb3
 session_expiry          = 300000
 gtm_id                  = ""
 
+paas_frontend_cdn_route_destination = "d2eyuvxr6b3efm.cloudfront.net"
+
+basic_auth_username  = ""
+basic_auth_password  = ""
+sidecar_image_uri    = "706615647326.dkr.ecr.eu-west-2.amazonaws.com/basic-auth-sidecar-image-repository"
+sidecar_image_digest = "sha256:b676bdc0aa24f1bf02364a1afeaa0649f585ce572849746769b3104f63b71976"

--- a/ci/terraform/security-groups.tf
+++ b/ci/terraform/security-groups.tf
@@ -81,8 +81,8 @@ resource "aws_security_group_rule" "allow_alb_application_egress_to_task_group" 
 
   description              = "http"
   protocol                 = "tcp"
-  from_port                = var.app_port
-  to_port                  = var.app_port
+  from_port                = local.application_port
+  to_port                  = local.application_port
   source_security_group_id = aws_security_group.frontend_ecs_tasks_sg.id
 }
 
@@ -103,7 +103,7 @@ resource "aws_security_group_rule" "allow_ecs_task_ingress_from_alb" {
 
   description              = "http"
   protocol                 = "tcp"
-  from_port                = var.app_port
-  to_port                  = var.app_port
+  from_port                = local.application_port
+  to_port                  = local.application_port
   source_security_group_id = aws_security_group.frontend_alb_sg.id
 }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -144,3 +144,19 @@ variable "paas_frontend_cdn_route_destination" {
   type        = string
   description = "The Cloudfront instance to forward all PaaS requests to"
 }
+
+variable "sidecar_image_uri" {
+  default = ""
+}
+variable "sidecar_image_tag" {
+  default = "latest"
+}
+variable "sidecar_image_digest" {
+  default = ""
+}
+variable "basic_auth_username" {
+  default = ""
+}
+variable "basic_auth_password" {
+  default = ""
+}


### PR DESCRIPTION
## What?

- If we provide a basic auth password to the Terraform then deploy a sidecar Nginx container as a proxy
- The sidecar should proxy requests through to the frontend app use the basic creds provided once its authenticated the user with basic auth creds
- Update security groups to work with this configuration
- Inject sidecar image details to the Terraform, these will be provided by the pipeline.
- Inject basic auth credentials which will be stored in Concourse secrets. As you can't have a blank secret, evaluate the special case of "none" to a blank string.

## Why?

We wish to protect the integration environment from general use.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/168