### PR TITLE
Fix bug with consent not being populated when registering

### DIFF
--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -26,6 +26,8 @@ export function createPasswordPost(
       throw new BadRequestError(result.data.message, result.data.code);
     }
 
+    req.session.user.isConsentRequired = result.data.consentRequired;
+
     return res.redirect(
       getNextPathAndUpdateJourney(
         req,

--- a/src/components/create-password/create-password-service.ts
+++ b/src/components/create-password/create-password-service.ts
@@ -4,9 +4,9 @@ import {
   Http,
   http,
 } from "../../utils/http";
-import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../app.constants";
-import { CreatePasswordServiceInterface } from "./types";
-import { ApiResponseResult, DefaultApiResponse } from "../../types";
+import { API_ENDPOINTS } from "../../app.constants";
+import { CreatePasswordServiceInterface, SignUpResponse } from "./types";
+import { ApiResponseResult } from "../../types";
 
 export function createPasswordService(
   axios: Http = http
@@ -17,8 +17,8 @@ export function createPasswordService(
     password: string,
     sourceIp: string,
     persistentSessionId: string
-  ): Promise<ApiResponseResult<DefaultApiResponse>> {
-    const response = await axios.client.post<DefaultApiResponse>(
+  ): Promise<ApiResponseResult<SignUpResponse>> {
+    const response = await axios.client.post<SignUpResponse>(
       API_ENDPOINTS.SIGNUP_USER,
       {
         email: emailAddress,
@@ -31,9 +31,7 @@ export function createPasswordService(
       })
     );
 
-    return createApiResponse<DefaultApiResponse>(response, [
-      HTTP_STATUS_CODES.NO_CONTENT,
-    ]);
+    return createApiResponse<SignUpResponse>(response);
   };
 
   return {

--- a/src/components/create-password/tests/create-password-controller.test.ts
+++ b/src/components/create-password/tests/create-password-controller.test.ts
@@ -45,6 +45,9 @@ describe("create-password controller", () => {
     it("should redirect to enter-phone-number when 2 factor is required", async () => {
       const fakeService: CreatePasswordServiceInterface = {
         signUpUser: sinon.fake.returns({
+          data: {
+            consentRequired: false,
+          },
           success: true,
         }),
       };

--- a/src/components/create-password/tests/create-password-integration.test.ts
+++ b/src/components/create-password/tests/create-password-integration.test.ts
@@ -4,7 +4,11 @@ import { expect, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
-import { API_ENDPOINTS, PATH_NAMES } from "../../../app.constants";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  PATH_NAMES,
+} from "../../../app.constants";
 
 describe("Integration::register create password", () => {
   let token: string | string[];
@@ -165,7 +169,10 @@ describe("Integration::register create password", () => {
   });
 
   it("should redirect to enter phone number when valid password entered", (done) => {
-    nock(baseApi).post(API_ENDPOINTS.SIGNUP_USER).once().reply(204, {});
+    nock(baseApi)
+      .post(API_ENDPOINTS.SIGNUP_USER)
+      .once()
+      .reply(HTTP_STATUS_CODES.OK, {});
 
     request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)

--- a/src/components/create-password/types.ts
+++ b/src/components/create-password/types.ts
@@ -7,5 +7,9 @@ export interface CreatePasswordServiceInterface {
     password: string,
     sourceIp: string,
     persistentSessionId: string
-  ) => Promise<ApiResponseResult<DefaultApiResponse>>;
+  ) => Promise<ApiResponseResult<SignUpResponse>>;
+}
+
+export interface SignUpResponse extends DefaultApiResponse {
+  consentRequired: boolean;
 }


### PR DESCRIPTION
Previously the backend used to return a state to say whether consent is required. This is the new way of doing that so when registering users can accept or reject consent. 
