### PR TITLE
Only add if session exists - fix for public facing pages

### DIFF
--- a/src/middleware/cross-domain-tracking-middleware.ts
+++ b/src/middleware/cross-domain-tracking-middleware.ts
@@ -6,7 +6,7 @@ export function crossDomainTrackingMiddleware(
   res: Response,
   next: NextFunction
 ): void {
-  if (req.query._ga) {
+  if (req.query._ga && req.session) {
     req.session.client.crossDomainGaTrackingId = xss(req.query._ga as string);
   }
 


### PR DESCRIPTION
Fixes issue for public facing pages e.g privacy-policy which don't require a session id