### PR TITLE
AUTH-1385 - Add referer to Zendesk api 

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -66,6 +66,9 @@ export function contactUsFormPost(req: Request, res: Response): void {
 }
 
 export function furtherInformationGet(req: Request, res: Response): void {
+  if (!req.query.theme) {
+    return res.redirect(PATH_NAMES.CONTACT_US);
+  }
   return res.render("contact-us/further-information/index.njk", {
     theme: req.query.theme,
     fromPage: req.query.fromPage,
@@ -84,6 +87,9 @@ export function furtherInformationPost(req: Request, res: Response): void {
 }
 
 export function contactUsQuestionsGet(req: Request, res: Response): void {
+  if (!req.query.theme) {
+    return res.redirect(PATH_NAMES.CONTACT_US);
+  }
   let pageTitle = themeToPageTitle[req.query.theme as string];
   if (
     req.query.subtheme === ZENDESK_THEMES.SOMETHING_ELSE &&

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -37,13 +37,24 @@ export function contactUsGet(req: Request, res: Response): void {
   if (req.query.supportType === SUPPORT_TYPE.GOV_SERVICE) {
     return res.render("contact-us/index-gov-service-contact-us.njk");
   }
+  let fromPage = req.headers.referer;
 
-  return res.render("contact-us/index-public-contact-us.njk");
+  if (req.headers.referer && req.headers.referer.includes("fromPage")) {
+    const urlObj = new URL(req.headers.referer);
+    fromPage = urlObj.searchParams.get("fromPage");
+  }
+
+  return res.render("contact-us/index-public-contact-us.njk", {
+    fromPage: fromPage,
+  });
 }
 
 export function contactUsFormPost(req: Request, res: Response): void {
   let url = PATH_NAMES.CONTACT_US_QUESTIONS;
-  const queryParams = new URLSearchParams({ theme: req.body.theme }).toString();
+  const queryParams = new URLSearchParams({
+    theme: req.body.theme,
+    fromPage: req.body.fromPage,
+  }).toString();
   if (
     [ZENDESK_THEMES.ACCOUNT_CREATION, ZENDESK_THEMES.SIGNING_IN].includes(
       req.body.theme
@@ -57,6 +68,7 @@ export function contactUsFormPost(req: Request, res: Response): void {
 export function furtherInformationGet(req: Request, res: Response): void {
   return res.render("contact-us/further-information/index.njk", {
     theme: req.query.theme,
+    fromPage: req.query.fromPage,
   });
 }
 
@@ -65,6 +77,7 @@ export function furtherInformationPost(req: Request, res: Response): void {
   const queryParams = new URLSearchParams({
     theme: req.body.theme,
     subtheme: req.body.subtheme,
+    fromPage: req.body.fromPage,
   }).toString();
 
   res.redirect(url + "?" + queryParams);
@@ -84,6 +97,7 @@ export function contactUsQuestionsGet(req: Request, res: Response): void {
     theme: req.query.theme,
     subtheme: req.query.subtheme,
     backurl: req.headers.referer,
+    fromPage: req.query.fromPage,
     pageTitleHeading: pageTitle,
   });
 }
@@ -116,6 +130,7 @@ export function contactUsQuestionsFormPost(
       feedbackContact: req.body.contact === "true",
       questions: questions,
       themeQuestions: themeQuestions,
+      referer: req.body.fromPage,
     });
 
     return res.redirect(PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS);

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -80,10 +80,10 @@ export function contactUsService(
     htmlBody.push(`<p>${optionalData.sessionId}</p>`);
 
     htmlBody.push(`<span>[From page]</span>`);
-    if (!referer) {
-      htmlBody.push(`<p>undefined</p>`);
-    } else {
+    if (referer) {
       htmlBody.push(`<p>${referer}</p>`);
+    } else {
+      htmlBody.push(`<p>Unable to capture referer</p>`);
     }
 
     htmlBody.push(`<span>[User Agent]</span>`);

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -25,7 +25,8 @@ export function contactUsService(
             contactForm.descriptions,
             contactForm.optionalData,
             contactForm.questions,
-            contactForm.themeQuestions
+            contactForm.themeQuestions,
+            contactForm.referer
           ),
         },
         group_id: getZendeskGroupIdPublic(),
@@ -47,7 +48,8 @@ export function contactUsService(
     descriptions: Descriptions,
     optionalData: OptionalData,
     questions: Questions,
-    themeQuestions: ThemeQuestions
+    themeQuestions: ThemeQuestions,
+    referer: string
   ) {
     const htmlBody = [];
 
@@ -76,6 +78,13 @@ export function contactUsService(
 
     htmlBody.push(`<span>[Session ID]</span>`);
     htmlBody.push(`<p>${optionalData.sessionId}</p>`);
+
+    htmlBody.push(`<span>[From page]</span>`);
+    if (!referer) {
+      htmlBody.push(`<p>undefined</p>`);
+    } else {
+      htmlBody.push(`<p>${referer}</p>`);
+    }
 
     htmlBody.push(`<span>[User Agent]</span>`);
     htmlBody.push(`<p>${optionalData.userAgent}</p>`);

--- a/src/components/contact-us/further-information/_account-creation-further-information.njk
+++ b/src/components/contact-us/further-information/_account-creation-further-information.njk
@@ -6,6 +6,7 @@
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
     {{ govukRadios({
         idPrefix: "account-creation",

--- a/src/components/contact-us/further-information/_signing-in-further-information.njk
+++ b/src/components/contact-us/further-information/_signing-in-further-information.njk
@@ -6,6 +6,7 @@
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
     {{ govukRadios({
         idPrefix: "signing-in",

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -7,7 +7,7 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set showBack = true %}
-{% set hrefBack = 'support' %}
+{% set hrefBack = fromPage %}
 {% set pageTitleName = 'pages.contactUsPublic.title' | translate %}
 
 {% block content %}
@@ -34,6 +34,7 @@
 <form action="/contact-us" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
     {{ govukRadios({
         idPrefix: "contact-us",

--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -9,6 +9,7 @@
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="accountCreationProblem"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -9,6 +9,7 @@
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="accountNotFound"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -9,6 +9,7 @@
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="accountProblem"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_email-subscriptions-questions.njk
+++ b/src/components/contact-us/questions/_email-subscriptions-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="emailSubscription"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -9,6 +9,7 @@
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="forgottenPassword"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -9,6 +9,7 @@
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="invalidSecurityCode"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -9,6 +9,7 @@
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="noPhoneNumberAccess"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -9,6 +9,7 @@
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="noSecurityCode"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_no-uk-mobile-questions.njk
+++ b/src/components/contact-us/questions/_no-uk-mobile-questions.njk
@@ -9,6 +9,7 @@
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="noUKMobile"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_signing-in-problem-questions.njk
+++ b/src/components/contact-us/questions/_signing-in-problem-questions.njk
@@ -9,6 +9,7 @@
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="signingInProblem"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_suggestion-feedback-questions.njk
+++ b/src/components/contact-us/questions/_suggestion-feedback-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="suggestionFeedback"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -9,6 +9,7 @@
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="technicalError"/>
+<input type="hidden" name="fromPage" value="{{fromPage}}"/>
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -169,6 +169,7 @@ describe("Integration:: contact us - public user", () => {
         contact: "true",
         email: "test@test.com",
         formType: "noSecurityCode",
+        fromPage: "https://gov.uk/sign-in",
       })
       .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
       .expect(302, done);

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -10,6 +10,7 @@ describe("contact us controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
   let res: Partial<Response>;
+  const FROM_PAGE = "https://gov.uk/sign-in";
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -45,7 +46,7 @@ describe("contact us controller", () => {
   describe("contactUsFormPost", () => {
     it("should redirect /contact-us-further-information page when 'A problem signing in to your account' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
 
       contactUsFormPost(req as Request, res as Response);
 
@@ -55,7 +56,7 @@ describe("contact us controller", () => {
     });
     it("should redirect /contact-us-further-information page when 'A problem creating an account' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
 
       contactUsFormPost(req as Request, res as Response);
 
@@ -65,7 +66,7 @@ describe("contact us controller", () => {
     });
     it("should redirect /contact-us-questions page when 'Another problem using your GOV.UK account' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SOMETHING_ELSE;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
 
       contactUsFormPost(req as Request, res as Response);
 
@@ -75,7 +76,7 @@ describe("contact us controller", () => {
     });
     it("should redirect /contact-us-questions page when 'GOV.UK email subscriptions' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.EMAIL_SUBSCRIPTIONS;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
 
       contactUsFormPost(req as Request, res as Response);
 
@@ -85,7 +86,7 @@ describe("contact us controller", () => {
     });
     it("should redirect /contact-us-questions page when 'A suggestion or feedback about using your GOV.UK account' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SUGGESTIONS_FEEDBACK;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
 
       contactUsFormPost(req as Request, res as Response);
 

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -14,7 +14,7 @@ describe("contact us controller", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
 
-    req = { body: {}, query: {}, get: sandbox.fake() };
+    req = { body: {}, query: {}, headers: {}, get: sandbox.fake() };
     res = { render: sandbox.fake(), redirect: sandbox.fake(), locals: {} };
   });
 
@@ -45,47 +45,52 @@ describe("contact us controller", () => {
   describe("contactUsFormPost", () => {
     it("should redirect /contact-us-further-information page when 'A problem signing in to your account' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
+      req.body.fromPage = "https://gov.uk/sign-in";
 
       contactUsFormPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-further-information?theme=signing_in"
+        "/contact-us-further-information?theme=signing_in&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-further-information page when 'A problem creating an account' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
+      req.body.fromPage = "https://gov.uk/sign-in";
 
       contactUsFormPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-further-information?theme=account_creation"
+        "/contact-us-further-information?theme=account_creation&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'Another problem using your GOV.UK account' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SOMETHING_ELSE;
+      req.body.fromPage = "https://gov.uk/sign-in";
 
       contactUsFormPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=something_else"
+        "/contact-us-questions?theme=something_else&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'GOV.UK email subscriptions' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.EMAIL_SUBSCRIPTIONS;
+      req.body.fromPage = "https://gov.uk/sign-in";
 
       contactUsFormPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=email_subscriptions"
+        "/contact-us-questions?theme=email_subscriptions&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'A suggestion or feedback about using your GOV.UK account' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SUGGESTIONS_FEEDBACK;
+      req.body.fromPage = "https://gov.uk/sign-in";
 
       contactUsFormPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=suggestions_feedback"
+        "/contact-us-questions?theme=suggestions_feedback&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
   });

--- a/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
@@ -53,6 +53,12 @@ describe("contact us further information controller", () => {
         }
       );
     });
+
+    it("should redirect to contact-us when no theme is present in request", () => {
+      furtherInformationGet(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith("/contact-us");
+    });
   });
 
   describe("signingInFurtherInformationPost", () => {

--- a/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
@@ -28,24 +28,28 @@ describe("contact us further information controller", () => {
   describe("furtherInformationGet", () => {
     it("should render signing in further information if a problem signing in to your account radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
+      req.query.fromPage = "https://gov.uk/sign-in";
       furtherInformationGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
         "contact-us/further-information/index.njk",
         {
           theme: "signing_in",
+          fromPage: "https://gov.uk/sign-in",
         }
       );
     });
 
     it("should render account creation further information if a creating an account radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
+      req.query.fromPage = "https://gov.uk/sign-in";
       furtherInformationGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
         "contact-us/further-information/index.njk",
         {
           theme: "account_creation",
+          fromPage: "https://gov.uk/sign-in",
         }
       );
     });
@@ -55,64 +59,71 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'You did not receive a security code' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.NO_SECURITY_CODE;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=signing_in&subtheme=no_security_code"
+        "/contact-us-questions?theme=signing_in&subtheme=no_security_code&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'The security code did not work' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.INVALID_SECURITY_CODE;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=signing_in&subtheme=invalid_security_code"
+        "/contact-us-questions?theme=signing_in&subtheme=invalid_security_code&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'You do not have access to the phone number' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.NO_PHONE_NUMBER_ACCESS;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=signing_in&subtheme=no_phone_number_access"
+        "/contact-us-questions?theme=signing_in&subtheme=no_phone_number_access&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'You’ve forgotten your password' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.FORGOTTEN_PASSWORD;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=signing_in&subtheme=forgotten_password"
+        "/contact-us-questions?theme=signing_in&subtheme=forgotten_password&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'Your account cannot be found' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.ACCOUNT_NOT_FOUND;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=signing_in&subtheme=account_not_found"
+        "/contact-us-questions?theme=signing_in&subtheme=account_not_found&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'There was a technical problem' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.TECHNICAL_ERROR;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=signing_in&subtheme=technical_error"
+        "/contact-us-questions?theme=signing_in&subtheme=technical_error&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'Something else' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.SOMETHING_ELSE;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=signing_in&subtheme=something_else"
+        "/contact-us-questions?theme=signing_in&subtheme=something_else&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
   });
@@ -121,46 +132,51 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'You did not receive a security code' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.body.subtheme = ZENDESK_THEMES.NO_SECURITY_CODE;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=account_creation&subtheme=no_security_code"
+        "/contact-us-questions?theme=account_creation&subtheme=no_security_code&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'The security code did not work' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.body.subtheme = ZENDESK_THEMES.INVALID_SECURITY_CODE;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=account_creation&subtheme=invalid_security_code"
+        "/contact-us-questions?theme=account_creation&subtheme=invalid_security_code&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'You do not have a UK mobile phone number' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.body.subtheme = ZENDESK_THEMES.NO_UK_MOBILE_NUMBER;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=account_creation&subtheme=no_uk_mobile_number"
+        "/contact-us-questions?theme=account_creation&subtheme=no_uk_mobile_number&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'There was a technical problem' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.body.subtheme = ZENDESK_THEMES.TECHNICAL_ERROR;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=account_creation&subtheme=technical_error"
+        "/contact-us-questions?theme=account_creation&subtheme=technical_error&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
     it("should redirect /contact-us-questions page when 'Something else' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.body.subtheme = ZENDESK_THEMES.SOMETHING_ELSE;
+      req.body.fromPage = "https://gov.uk/sign-in";
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=account_creation&subtheme=something_else"
+        "/contact-us-questions?theme=account_creation&subtheme=something_else&fromPage=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
   });

--- a/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
@@ -13,6 +13,7 @@ describe("contact us further information controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
   let res: Partial<Response>;
+  const FROM_PAGE = "https://gov.uk/sign-in";
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -28,28 +29,28 @@ describe("contact us further information controller", () => {
   describe("furtherInformationGet", () => {
     it("should render signing in further information if a problem signing in to your account radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       furtherInformationGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
         "contact-us/further-information/index.njk",
         {
           theme: "signing_in",
-          fromPage: "https://gov.uk/sign-in",
+          fromPage: FROM_PAGE,
         }
       );
     });
 
     it("should render account creation further information if a creating an account radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       furtherInformationGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
         "contact-us/further-information/index.njk",
         {
           theme: "account_creation",
-          fromPage: "https://gov.uk/sign-in",
+          fromPage: FROM_PAGE,
         }
       );
     });
@@ -65,7 +66,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'You did not receive a security code' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.NO_SECURITY_CODE;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
@@ -75,7 +76,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'The security code did not work' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.INVALID_SECURITY_CODE;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
@@ -85,7 +86,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'You do not have access to the phone number' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.NO_PHONE_NUMBER_ACCESS;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
@@ -95,7 +96,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'You’ve forgotten your password' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.FORGOTTEN_PASSWORD;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
@@ -105,7 +106,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'Your account cannot be found' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.ACCOUNT_NOT_FOUND;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
@@ -115,7 +116,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'There was a technical problem' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.TECHNICAL_ERROR;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
@@ -125,7 +126,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'Something else' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.subtheme = ZENDESK_THEMES.SOMETHING_ELSE;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
@@ -138,7 +139,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'You did not receive a security code' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.body.subtheme = ZENDESK_THEMES.NO_SECURITY_CODE;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
@@ -148,7 +149,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'The security code did not work' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.body.subtheme = ZENDESK_THEMES.INVALID_SECURITY_CODE;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
@@ -158,7 +159,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'You do not have a UK mobile phone number' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.body.subtheme = ZENDESK_THEMES.NO_UK_MOBILE_NUMBER;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
@@ -168,7 +169,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'There was a technical problem' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.body.subtheme = ZENDESK_THEMES.TECHNICAL_ERROR;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
@@ -178,7 +179,7 @@ describe("contact us further information controller", () => {
     it("should redirect /contact-us-questions page when 'Something else' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.body.subtheme = ZENDESK_THEMES.SOMETHING_ELSE;
-      req.body.fromPage = "https://gov.uk/sign-in";
+      req.body.fromPage = FROM_PAGE;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -36,6 +36,7 @@ describe("contact us questions controller", () => {
     it("should render contact-us-questions if a 'another problem using your account' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SOMETHING_ELSE;
       req.headers.referer = "/contact-us";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -43,11 +44,13 @@ describe("contact us questions controller", () => {
         subtheme: undefined,
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'GOV.UK email subscriptions' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.EMAIL_SUBSCRIPTIONS;
       req.headers.referer = "/contact-us";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -55,11 +58,13 @@ describe("contact us questions controller", () => {
         subtheme: undefined,
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.emailSubscriptions.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'A suggestion or feedback' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SUGGESTIONS_FEEDBACK;
       req.headers.referer = "/contact-us";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -67,6 +72,7 @@ describe("contact us questions controller", () => {
         subtheme: undefined,
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.suggestionOrFeedback.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
   });
@@ -76,6 +82,7 @@ describe("contact us questions controller", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.NO_SECURITY_CODE;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -83,12 +90,14 @@ describe("contact us questions controller", () => {
         subtheme: "no_security_code",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.INVALID_SECURITY_CODE;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -96,12 +105,14 @@ describe("contact us questions controller", () => {
         subtheme: "invalid_security_code",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'You do not have access to the phone number' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.NO_PHONE_NUMBER_ACCESS;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -109,12 +120,14 @@ describe("contact us questions controller", () => {
         subtheme: "no_phone_number_access",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noPhoneNumberAccess.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'You've forgotten your password' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.FORGOTTEN_PASSWORD;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -122,12 +135,14 @@ describe("contact us questions controller", () => {
         subtheme: "forgotten_password",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.forgottenPassword.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'Your account cannot be found' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.ACCOUNT_NOT_FOUND;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -135,12 +150,14 @@ describe("contact us questions controller", () => {
         subtheme: "account_not_found",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.accountNotFound.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.TECHNICAL_ERROR;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -148,12 +165,14 @@ describe("contact us questions controller", () => {
         subtheme: "technical_error",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.SOMETHING_ELSE;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -161,6 +180,7 @@ describe("contact us questions controller", () => {
         subtheme: "something_else",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
   });
@@ -170,6 +190,7 @@ describe("contact us questions controller", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.query.subtheme = ZENDESK_THEMES.NO_SECURITY_CODE;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -177,12 +198,14 @@ describe("contact us questions controller", () => {
         subtheme: "no_security_code",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.query.subtheme = ZENDESK_THEMES.INVALID_SECURITY_CODE;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -190,12 +213,14 @@ describe("contact us questions controller", () => {
         subtheme: "invalid_security_code",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'You do not have a UK number' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.query.subtheme = ZENDESK_THEMES.NO_UK_MOBILE_NUMBER;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -203,12 +228,14 @@ describe("contact us questions controller", () => {
         subtheme: "no_uk_mobile_number",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noUKMobile.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.query.subtheme = ZENDESK_THEMES.TECHNICAL_ERROR;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -216,12 +243,14 @@ describe("contact us questions controller", () => {
         subtheme: "technical_error",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.query.subtheme = ZENDESK_THEMES.SOMETHING_ELSE;
       req.headers.referer = "/contact-us-further-information";
+      req.query.fromPage = "https://gov.uk/sign-in";
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -229,6 +258,7 @@ describe("contact us questions controller", () => {
         subtheme: "something_else",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.accountCreation.title",
+        fromPage: "https://gov.uk/sign-in",
       });
     });
     describe("contactUsFormPost", () => {

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -14,6 +14,7 @@ describe("contact us questions controller", () => {
   let sandbox: sinon.SinonSandbox;
   let req: Partial<Request>;
   let res: Partial<Response>;
+  const FROM_PAGE = "https://gov.uk/sign-in";
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -36,7 +37,7 @@ describe("contact us questions controller", () => {
     it("should render contact-us-questions if a 'another problem using your account' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SOMETHING_ELSE;
       req.headers.referer = "/contact-us";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -44,13 +45,13 @@ describe("contact us questions controller", () => {
         subtheme: undefined,
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'GOV.UK email subscriptions' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.EMAIL_SUBSCRIPTIONS;
       req.headers.referer = "/contact-us";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -58,13 +59,13 @@ describe("contact us questions controller", () => {
         subtheme: undefined,
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.emailSubscriptions.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'A suggestion or feedback' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SUGGESTIONS_FEEDBACK;
       req.headers.referer = "/contact-us";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -72,7 +73,7 @@ describe("contact us questions controller", () => {
         subtheme: undefined,
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.suggestionOrFeedback.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should redirect to contact-us when no theme is present in request", () => {
@@ -87,7 +88,7 @@ describe("contact us questions controller", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.NO_SECURITY_CODE;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -95,14 +96,14 @@ describe("contact us questions controller", () => {
         subtheme: "no_security_code",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.INVALID_SECURITY_CODE;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -110,14 +111,14 @@ describe("contact us questions controller", () => {
         subtheme: "invalid_security_code",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'You do not have access to the phone number' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.NO_PHONE_NUMBER_ACCESS;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -125,14 +126,14 @@ describe("contact us questions controller", () => {
         subtheme: "no_phone_number_access",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noPhoneNumberAccess.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'You've forgotten your password' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.FORGOTTEN_PASSWORD;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -140,14 +141,14 @@ describe("contact us questions controller", () => {
         subtheme: "forgotten_password",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.forgottenPassword.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'Your account cannot be found' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.ACCOUNT_NOT_FOUND;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -155,14 +156,14 @@ describe("contact us questions controller", () => {
         subtheme: "account_not_found",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.accountNotFound.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.TECHNICAL_ERROR;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -170,14 +171,14 @@ describe("contact us questions controller", () => {
         subtheme: "technical_error",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.SIGNING_IN;
       req.query.subtheme = ZENDESK_THEMES.SOMETHING_ELSE;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -185,7 +186,7 @@ describe("contact us questions controller", () => {
         subtheme: "something_else",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
   });
@@ -195,7 +196,7 @@ describe("contact us questions controller", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.query.subtheme = ZENDESK_THEMES.NO_SECURITY_CODE;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -203,14 +204,14 @@ describe("contact us questions controller", () => {
         subtheme: "no_security_code",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.query.subtheme = ZENDESK_THEMES.INVALID_SECURITY_CODE;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -218,14 +219,14 @@ describe("contact us questions controller", () => {
         subtheme: "invalid_security_code",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'You do not have a UK number' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.query.subtheme = ZENDESK_THEMES.NO_UK_MOBILE_NUMBER;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -233,14 +234,14 @@ describe("contact us questions controller", () => {
         subtheme: "no_uk_mobile_number",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noUKMobile.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.query.subtheme = ZENDESK_THEMES.TECHNICAL_ERROR;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -248,14 +249,14 @@ describe("contact us questions controller", () => {
         subtheme: "technical_error",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.query.subtheme = ZENDESK_THEMES.SOMETHING_ELSE;
       req.headers.referer = "/contact-us-further-information";
-      req.query.fromPage = "https://gov.uk/sign-in";
+      req.query.fromPage = FROM_PAGE;
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
@@ -263,7 +264,7 @@ describe("contact us questions controller", () => {
         subtheme: "something_else",
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.accountCreation.title",
-        fromPage: "https://gov.uk/sign-in",
+        fromPage: FROM_PAGE,
       });
     });
     describe("contactUsFormPost", () => {

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -75,6 +75,11 @@ describe("contact us questions controller", () => {
         fromPage: "https://gov.uk/sign-in",
       });
     });
+    it("should redirect to contact-us when no theme is present in request", () => {
+      contactUsQuestionsGet(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith("/contact-us");
+    });
   });
 
   describe("contactUsQuestionsGetFromFurtherInformationSigningInPage", () => {

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -8,6 +8,7 @@ export interface ContactForm {
   feedbackContact: boolean;
   questions: Questions;
   themeQuestions: ThemeQuestions;
+  referer: string;
 }
 
 export interface OptionalData {


### PR DESCRIPTION
## What?

- Add the referer to the Zendesk body when it is present 
- Make the back button dynamic on the contact-us page so it can return the user to where they previously were 
- When theme isn't present in the requests to contact-us-further-information or contact-us-questions then redirect to contact-us.

## Why?

- So we can have a better idea of where users are facing issues 
- So user can return to the previous page if they were stuck 
- Because if a user goes to them 2 pages without a theme they can't do anything so we should redirect them to the contact-us page
