### PR TITLE
AUTH-1389: Remove PaaS Redis resource

### DIFF
--- a/ci/terraform/redis.tf
+++ b/ci/terraform/redis.tf
@@ -2,16 +2,6 @@ locals {
   redis_port_number = 6379
 }
 
-data "cloudfoundry_service" "redis" {
-  name = "redis"
-}
-
-resource "cloudfoundry_service_instance" "redis" {
-  name         = "${var.environment}-frontend-redis"
-  space        = data.cloudfoundry_space.space.id
-  service_plan = data.cloudfoundry_service.redis.service_plans[var.redis_service_plan]
-}
-
 resource "aws_elasticache_subnet_group" "frontend_redis_session_store" {
   name       = "${var.environment}-frontend-redis-subnet"
   subnet_ids = local.private_subnet_ids


### PR DESCRIPTION
## What?

- Remove the Redis instance from PaaS

## Why?

We are no longer running Frontend in PaaS so we do not need the Redis instance

*N.B. the CloudFoundry Terraform provider will be removed in a follow-up PR, once this PR has been merged and Terraform has destroyed the Redis resource. The follow up PR will also remove any, now, defunct variables and update the deployment task appropriately*