### PR TITLE
AUTH-1389: Remove CloudFoundry Provider and related variables

### DIFF
--- a/ci/tasks/deploy-frontend.yml
+++ b/ci/tasks/deploy-frontend.yml
@@ -13,9 +13,6 @@ params:
   DNS_DEPLOYER_ROLE_ARN: ((deployer-role-arn-production))
   DNS_STATE_BUCKET: ((dns-state-bucket))
   DNS_STATE_KEY: ((dns-state-key))
-  CF_USERNAME: ((cf-username))
-  CF_PASSWORD: ((cf-password))
-  CF_ORG_NAME: ((cf-org-name))
   GTM_ID: ((build-gtm-id))
   SESSION_EXPIRY: ((build-session-expiry))
   LOGGING_ENDPOINT_ARN: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -62,9 +59,6 @@ run:
 
       terraform apply -auto-approve \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
-        -var "cf_username=${CF_USERNAME}" \
-        -var "cf_password=${CF_PASSWORD}" \
-        -var "cf_org_name=${CF_ORG_NAME}" \
         -var "common_state_bucket=${STATE_BUCKET}" \
         -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
         -var "dns_state_key=${DNS_STATE_KEY}" \

--- a/ci/terraform/.terraform.lock.hcl
+++ b/ci/terraform/.terraform.lock.hcl
@@ -2,25 +2,24 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/cloudfoundry-community/cloudfoundry" {
-  version     = "0.14.2"
-  constraints = "0.14.2"
+  version = "0.15.0"
   hashes = [
-    "h1:qgPDV+Q6AfVnDRn4eP+0Jm9aHKACody/Oa3FuZRoifU=",
-    "zh:0a8184b3bb0b5d8934c1f9e988fcf0da13ce05f666d6b7861cf50b74496e5a23",
-    "zh:0afa174665bdd728e7a9951952a0ef91526677f9b8c57250e210e696ec84c861",
-    "zh:0dfdd0288641dcecd5d9c894546163b51fbd2f576a83c5013f82dbf86067a8c1",
-    "zh:310c32a75986e797525b89ae41a45021bd64ee46858c7e68f4504c763440da19",
-    "zh:5d99fbedaddfe12830efec6b2387552d1ea10bda22596fcd46bc75994cdfd4b5",
-    "zh:60ecd53ec4e6795f0392d8701015a6efefb0446174ad20cbe2cdc0ca9f984a9e",
-    "zh:6763498656278a703b6045ab401ebf55346341d8891c2a70c7916585b6577f33",
-    "zh:7aa63f571c434dd2cd76a7fd7140a928eb10e1f629c93627a0afd8c1c78d6808",
-    "zh:8dec45aa1705272975958a859dd53960638816d0ea793c671715c9c1a353b2d0",
-    "zh:957db10a90ae964c9ed05c2653d44e738beac61239e4a57c7c47378eba33dff7",
-    "zh:9effa3a98bcdf39f2db2be56ac34b2b901ca78740acc9f317c9a3e757a0f76b1",
-    "zh:a3c4d51590bce8fccc504c7e357b322a12702180c92a4d682d269983df29765a",
-    "zh:b11b17166836f86a5bca92a2776ba6ef57de0298072bd8c677c82744361d57cb",
-    "zh:c4a338ff3f5bf9514c64c6c0aa7883c43d14920b84d1faa54876ffd722bfc434",
-    "zh:fa9191416e2d73e3aaa835eb04643e179bf0f4d9d97fd3f03088e3a989606543",
+    "h1:OOFJT9vgnSFcxu994kaYH72AaR2lM+UE31SXKrwyzZM=",
+    "zh:143c1624ee5c2813c32126467fb9c56053bbfcae275d6ce61c7b59c259c4b8e0",
+    "zh:18a5cb24695a1521cb8ee1e488234c337228af1b471b30a284db41c4362c6149",
+    "zh:261595c1bd8105160e8c505d76be5f49d3bd12bb7aa6882ac6315cc5727aec55",
+    "zh:2e8627bf812848fe1b232e4fe91e21eaedc3759f8997ffc5a9f201757627e835",
+    "zh:4a19d909843952b9cbf6b0445c3627d22c5caaa2ad8db1eab2f382d5faff3402",
+    "zh:4e78b3de83b2686c66c2b2e0d8a7c910ed423fd5b7b853bcc0fd05b851c6bd28",
+    "zh:713e43a21a1d3aaddfa0bf841a2cc1e2c06160917bdd443e6eac99b620d668fa",
+    "zh:a36d3e5406f96abaf9a6eb89663b7fa504d0c68521a7334c498525e8018ad7f9",
+    "zh:aa3abf232a49f66031f2a1a032f53604a51d8c9b0a3a297591d7a57949943c40",
+    "zh:b2ccc93024f1ed6e18fd92e199be12ea148383a4f5d8c3ab9e632ae88b0f5263",
+    "zh:b85379c01fc963289203170731880fb89f10047d63c45566750826ad9aff39cb",
+    "zh:c5d59b6fe39f7f4f2c556209906aa9cbb31cc0630d225fb0abd48c6de1089f2e",
+    "zh:c956d630c087fc2ede5967e89249b2477a552185c2d4167292002fc5fd1b380c",
+    "zh:edf41138788f7b16ed572f1fad940ba75f3c7b9a7c06f6876c31bf281de1257a",
+    "zh:f873bbff4c7ae1c6b7c5ba0dd42552526435d9b1bd373b18ea4169e965e4d283",
   ]
 }
 
@@ -29,6 +28,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 3.56.0"
   hashes = [
     "h1:H6JCnoa3swF3rgHL0ys9KNArffU+IEGPvhQ6JnfQY/c=",
+    "h1:kFpEsbiU2cfwl0IL8/pCfF2fcUXjAfJagipLjQO2qUU=",
     "zh:241a4203078ea35f63202b613f0e4b428a842734ded62d9f487cdf7c2a66d639",
     "zh:2c1cbf3cd03a2a7ff267be09cedf1698738c372b1411ca74cfcb3bf4b0846f27",
     "zh:318ad2331f60e03d284f90f728486b9df7ac9570af641c43b56216357e624b52",
@@ -47,6 +47,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.1.0"
   constraints = ">= 3.1.0"
   hashes = [
+    "h1:9cCiLO/Cqr6IUvMDSApCkQItooiYNatZpEXmcu0nnng=",
     "h1:rKYu5ZUbXwrLG1w81k7H3nce/Ys6yAxXhWcbtk36HjY=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
     "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,4 +1,3 @@
-redis_service_plan  = "tiny-ha-5_x"
 environment         = "build"
 common_state_bucket = "digital-identity-dev-tfstate"
 

--- a/ci/terraform/cf-data.tf
+++ b/ci/terraform/cf-data.tf
@@ -1,8 +1,0 @@
-data "cloudfoundry_org" "org" {
-  name = var.cf_org_name
-}
-
-data "cloudfoundry_space" "space" {
-  name = var.environment
-  org  = data.cloudfoundry_org.org.id
-}

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,4 +1,3 @@
-redis_service_plan  = "tiny-ha-5_x"
 environment         = "integration"
 common_state_bucket = "digital-identity-dev-tfstate"
 

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,4 +1,3 @@
-redis_service_plan  = "large-ha-5_x"
 environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
 ecs_desired_count   = 4

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -1,7 +1,5 @@
-redis_service_plan      = "tiny-5_x"
 environment             = "sandpit"
 common_state_bucket     = "digital-identity-dev-tfstate"
-cf_org_name             = "gds-digital-identity-authentication"
 aws_region              = "eu-west-2"
 account_management_fqdn = "acc-mgmt-fg.sandpit.auth.ida.digital.cabinet-office.gov.uk"
 oidc_api_fqdn           = "api.sandpit.auth.ida.digital.cabinet-office.gov.uk"

--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -10,10 +10,6 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.1.0"
     }
-    cloudfoundry = {
-      source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.14.2"
-    }
   }
 
   backend "s3" {
@@ -26,13 +22,6 @@ provider "aws" {
   assume_role {
     role_arn = var.deployer_role_arn
   }
-}
-
-provider "cloudfoundry" {
-  api_url      = "https://api.london.cloud.service.gov.uk"
-  user         = var.cf_username
-  password     = var.cf_password
-  app_logs_max = 250
 }
 
 data "aws_availability_zones" "available" {}

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -6,26 +6,8 @@ variable "deployer_role_arn" {
   default = null
 }
 
-variable "cf_username" {
-  description = "deployer username"
-}
-
-variable "cf_password" {
-  description = "deployer password org"
-}
-
-variable "cf_org_name" {
-  description = "target org"
-}
-
 variable "environment" {
   description = "the name of the environment being deployed (e.g. sandpit, build), this also matches the PaaS space name"
-}
-
-variable "redis_service_plan" {
-  type        = string
-  default     = "tiny-5_x"
-  description = "The PaaS service plan (instance size) to use for Redis. For a full list of options, run 'cf marketplace -e redis'"
 }
 
 variable "common_state_bucket" {


### PR DESCRIPTION
## What?

- Remove the `cf-data.tf` file containing CloudFoundry data sources
- Remove the cloudfoundry provider configuration
- Manually remove cloudfoundry provider version info from HCL lock file
- Remove Terraform variables used for CloudFoundry authentication
- Remove Terraform variable used for Redis service plan
- Update deployment task to no longer pass above variables

## Why?

We are no longer managing any CloudFoundry (PaaS) resources using Terraform as we have moved the frontend to ECS. This PR removes all, now defunct, CloudFoundry related configuration from Terraform.
