### PR TITLE
Check client on session so doesn't throw error

### DIFF
--- a/src/middleware/cross-domain-tracking-middleware.ts
+++ b/src/middleware/cross-domain-tracking-middleware.ts
@@ -6,7 +6,7 @@ export function crossDomainTrackingMiddleware(
   res: Response,
   next: NextFunction
 ): void {
-  if (req.query._ga && req.session) {
+  if (req.query._ga && req.session.client) {
     req.session.client.crossDomainGaTrackingId = xss(req.query._ga as string);
   }
 


### PR DESCRIPTION
There has been an issue in the logs that has manifested when users are trying to go to pages without a valid session where ga crossdomain tracking is required.