### PR TITLE
AUTH-1360: support international phone numbers

### DIFF
--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -23,6 +23,22 @@ function initFeedbackRadioButtons() {
   });
 }
 
+function initEnterPhoneNumber() {
+  var phoneNumberInput = document.querySelector('#phoneNumber');
+  if (phoneNumberInput) {
+    var intPhoneNumberCheckbox = document.querySelector('#hasInternationalPhoneNumber');
+    intPhoneNumberCheckbox.addEventListener("click", function(event) {  
+      if (event.currentTarget.checked) {
+        phoneNumberInput.disabled = true;
+        phoneNumberInput.classList.add("govuk-input--disabled");
+      } else {
+        phoneNumberInput.disabled = false;
+        phoneNumberInput.classList.remove("govuk-input--disabled");
+      }
+    });
+  }
+}
+
 (function (w) {
   "use strict";
   function appInit(trackingId, analyticsCookieDomain) {
@@ -37,6 +53,7 @@ function initFeedbackRadioButtons() {
   }
 
   initFeedbackRadioButtons();
+  initEnterPhoneNumber();
 
   if (w.GOVUK && w.GOVUK.Modules && w.GOVUK.Modules.ShowPassword) {
     var modules = document.querySelectorAll('[data-module="show-password"]');

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -151,3 +151,7 @@
     color: $govuk-link-active-colour;
   }
 }
+
+.govuk-input--disabled {
+  background-color: govuk-colour("light-grey", $legacy: "grey-3");
+}

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -12,6 +12,7 @@ import { UpdateProfileServiceInterface } from "../common/update-profile/types";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { prependInternationalPrefix } from "../../utils/phone-number";
 
 export function enterPhoneNumberGet(req: Request, res: Response): void {
   res.render("enter-phone-number/index.njk");
@@ -22,9 +23,18 @@ export function enterPhoneNumberPost(
   profileService: UpdateProfileServiceInterface = updateProfileService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const phoneNumber = req.body.phoneNumber;
+    const hasInternationalPhoneNumber = req.body.hasInternationalPhoneNumber;
     const { email } = req.session.user;
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+    let phoneNumber;
+
+    if (hasInternationalPhoneNumber && hasInternationalPhoneNumber === "true") {
+      phoneNumber = prependInternationalPrefix(
+        req.body.internationalPhoneNumber
+      );
+    } else {
+      phoneNumber = req.body.phoneNumber;
+    }
 
     req.session.user.phoneNumber = redactPhoneNumber(phoneNumber);
 

--- a/src/components/enter-phone-number/enter-phone-number-validation.ts
+++ b/src/components/enter-phone-number/enter-phone-number-validation.ts
@@ -2,6 +2,8 @@ import { body } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import {
+  containsLeadingPlusNumbersOrSpacesOnly,
+  containsInternationalMobileNumber,
   containsNumbersOrSpacesOnly,
   containsUKMobileNumber,
   lengthInRangeWithoutSpaces,
@@ -10,17 +12,20 @@ import {
 export function validateEnterPhoneNumberRequest(): ValidationChainFunc {
   return [
     body("phoneNumber")
+      .if(body("hasInternationalPhoneNumber").not().equals("true"))
       .notEmpty()
       .withMessage((value, { req }) => {
         return req.t(
-          "pages.enterPhoneNumber.phoneNumber.validationError.required",
+          "pages.enterPhoneNumber.ukPhoneNumber.validationError.required",
           { value }
         );
       })
       .custom((value, { req }) => {
         if (!containsNumbersOrSpacesOnly(value)) {
           throw new Error(
-            req.t("pages.enterPhoneNumber.phoneNumber.validationError.numeric")
+            req.t(
+              "pages.enterPhoneNumber.ukPhoneNumber.validationError.numeric"
+            )
           );
         }
         return true;
@@ -28,7 +33,7 @@ export function validateEnterPhoneNumberRequest(): ValidationChainFunc {
       .custom((value, { req }) => {
         if (!lengthInRangeWithoutSpaces(value, 10, 11)) {
           throw new Error(
-            req.t("pages.enterPhoneNumber.phoneNumber.validationError.length")
+            req.t("pages.enterPhoneNumber.ukPhoneNumber.validationError.length")
           );
         }
         return true;
@@ -37,7 +42,46 @@ export function validateEnterPhoneNumberRequest(): ValidationChainFunc {
         if (!containsUKMobileNumber(value)) {
           throw new Error(
             req.t(
-              "pages.enterPhoneNumber.phoneNumber.validationError.international"
+              "pages.enterPhoneNumber.ukPhoneNumber.validationError.international"
+            )
+          );
+        }
+        return true;
+      }),
+    body("internationalPhoneNumber")
+      .if(body("hasInternationalPhoneNumber").notEmpty().equals("true"))
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.enterPhoneNumber.internationalPhoneNumber.validationError.required",
+          { value }
+        );
+      })
+      .custom((value, { req }) => {
+        if (!containsLeadingPlusNumbersOrSpacesOnly(value)) {
+          throw new Error(
+            req.t(
+              "pages.enterPhoneNumber.internationalPhoneNumber.validationError.plusNumericOnly"
+            )
+          );
+        }
+        return true;
+      })
+      .custom((value, { req }) => {
+        if (!lengthInRangeWithoutSpaces(value, 5, 16)) {
+          throw new Error(
+            req.t(
+              "pages.enterPhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
+            )
+          );
+        }
+        return true;
+      })
+      .custom((value, { req }) => {
+        if (!containsInternationalMobileNumber(value)) {
+          throw new Error(
+            req.t(
+              "pages.enterPhoneNumber.internationalPhoneNumber.validationError.internationalFormat"
             )
           );
         }

--- a/src/components/enter-phone-number/index.njk
+++ b/src/components/enter-phone-number/index.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.enterPhoneNumber.title' | translate %}
 {% block content %}
@@ -16,11 +17,10 @@
   <input type="hidden" name="_csrf" value="{{csrfToken}}" />
 
   <p class="govuk-body">{{'pages.enterPhoneNumber.info.paragraph1' | translate}}</p>
-  <p class="govuk-body">{{'pages.enterPhoneNumber.info.paragraph2' | translate}}</p>
 
   {{ govukInput({
   label: {
-  text: 'pages.enterPhoneNumber.phoneNumber.label' | translate
+  text: 'pages.enterPhoneNumber.ukPhoneNumber.label' | translate
   },
   classes: "govuk-!-width-two-thirds",
   id: "phoneNumber",
@@ -32,6 +32,39 @@
   } if (errors['phoneNumber'])})
   }}
 
+  {% set internationalNumberHtml %}
+  {{ govukInput({
+    id: "internationalPhoneNumber",
+    name: "internationalPhoneNumber",
+    type: "tel",
+    autocomplete: "tel",
+    classes: "govuk-!-width-two-thirds",
+    label: {
+      text: 'pages.enterPhoneNumber.internationalPhoneNumber.label' | translate
+    },
+    hint: {
+      text: 'pages.enterPhoneNumber.internationalPhoneNumber.hint' | translate
+    },
+    errorMessage: {
+    text: errors['internationalPhoneNumber'].text
+    } if (errors['internationalPhoneNumber'])
+  }) }}
+  {% endset -%}
+
+  {{ govukCheckboxes({
+    items: [
+      {
+        value: "true",
+        id: "hasInternationalPhoneNumber",
+        name: "hasInternationalPhoneNumber",
+        text: 'pages.enterPhoneNumber.internationalPhoneNumber.checkBoxLabel' | translate,
+        conditional: {
+          html: internationalNumberHtml
+        },
+        checked: hasInternationalPhoneNumber === 'true'
+      }
+    ]
+  }) }}
 
   {{ govukButton({
   "text": button_text|default('general.continue.label' | translate, true),
@@ -42,4 +75,3 @@
 </form>
 
 {% endblock %}
-

--- a/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
@@ -44,7 +44,7 @@ describe("enter phone number controller", () => {
   });
 
   describe("enterPhoneNumberPost", () => {
-    it("should redirect to /check-your-phone when success", async () => {
+    it("should redirect to /check-your-phone when success with valid UK number", async () => {
       const fakeNotificationService: SendNotificationServiceInterface = {
         sendNotification: sinon.fake.returns({
           success: true,
@@ -70,6 +70,34 @@ describe("enter phone number controller", () => {
       expect(fakeNotificationService.sendNotification).to.have.been.calledOnce;
       expect(res.redirect).to.have.calledWith(PATH_NAMES.CHECK_YOUR_PHONE);
       expect(req.session.user.phoneNumber).to.be.eq("*******3990");
+    });
+
+    it("should redirect to /check-your-phone when success with valid international number", async () => {
+      const fakeNotificationService: SendNotificationServiceInterface = {
+        sendNotification: sinon.fake.returns({
+          success: true,
+        }),
+      };
+
+      const fakeProfileService: UpdateProfileServiceInterface = {
+        updateProfile: sinon.fake.returns({
+          success: true,
+        }),
+      };
+
+      res.locals.sessionId = "123456-djjad";
+      req.body.phoneNumber = "+33645453322";
+      req.session.user.email = "test@test.com";
+
+      await enterPhoneNumberPost(fakeNotificationService, fakeProfileService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(fakeProfileService.updateProfile).to.have.been.calledOnce;
+      expect(fakeNotificationService.sendNotification).to.have.been.calledOnce;
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.CHECK_YOUR_PHONE);
+      expect(req.session.user.phoneNumber).to.be.eq("********3322");
     });
 
     it("should throw error when API call to /update-profile throws error", async () => {

--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -73,7 +73,7 @@ describe("Integration::enter phone number", () => {
       .expect(500, done);
   });
 
-  it("should return validation error when phone number not entered", (done) => {
+  it("should return validation error when uk phone number not entered", (done) => {
     request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
@@ -91,7 +91,7 @@ describe("Integration::enter phone number", () => {
       .expect(400, done);
   });
 
-  it("should return validation error when phone number entered is not valid", (done) => {
+  it("should return validation error when uk phone number entered is not valid", (done) => {
     request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
@@ -109,7 +109,7 @@ describe("Integration::enter phone number", () => {
       .expect(400, done);
   });
 
-  it("should return validation error when phone number entered contains text", (done) => {
+  it("should return validation error when uk phone number entered contains text", (done) => {
     request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
@@ -127,7 +127,7 @@ describe("Integration::enter phone number", () => {
       .expect(400, done);
   });
 
-  it("should return validation error when phone number entered less than 12 characters", (done) => {
+  it("should return validation error when uk phone number entered less than 12 characters", (done) => {
     request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
@@ -145,7 +145,7 @@ describe("Integration::enter phone number", () => {
       .expect(400, done);
   });
 
-  it("should return validation error when phone number entered greater than 12 characters", (done) => {
+  it("should return validation error when uk phone number entered greater than 12 characters", (done) => {
     request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
       .type("form")
@@ -179,6 +179,128 @@ describe("Integration::enter phone number", () => {
       .send({
         _csrf: token,
         phoneNumber: "07738394991",
+      })
+      .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
+      .expect(302, done);
+  });
+
+  it("should return validation error when international phone number not entered", (done) => {
+    request(app)
+      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        hasInternationalPhoneNumber: true,
+        internationalPhoneNumber: "",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#internationalPhoneNumber-error").text()).to.contains(
+          "Enter a phone number"
+        );
+        expect($("#phoneNumber-error").text()).to.contains("");
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when international phone number entered is not valid", (done) => {
+    request(app)
+      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        hasInternationalPhoneNumber: true,
+        internationalPhoneNumber: "123456789",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#internationalPhoneNumber-error").text()).to.contains(
+          "Enter a phone number in the correct format"
+        );
+        expect($("#phoneNumber-error").text()).to.contains("");
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when international phone number entered contains text", (done) => {
+    request(app)
+      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        hasInternationalPhoneNumber: true,
+        internationalPhoneNumber: "123456789dd",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#internationalPhoneNumber-error").text()).to.contains(
+          "Enter a phone number using only numbers or the + symbol"
+        );
+        expect($("#phoneNumber-error").text()).to.contains("");
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when international phone number entered less than 8 characters", (done) => {
+    request(app)
+      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        hasInternationalPhoneNumber: true,
+        internationalPhoneNumber: "1234567",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#internationalPhoneNumber-error").text()).to.contains(
+          "Enter a phone number in the correct format"
+        );
+        expect($("#phoneNumber-error").text()).to.contains("");
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when international phone number entered greater than 16 characters", (done) => {
+    request(app)
+      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        hasInternationalPhoneNumber: true,
+        internationalPhoneNumber: "12345678901234567",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#internationalPhoneNumber-error").text()).to.contains(
+          "Enter a phone number in the correct format"
+        );
+        expect($("#phoneNumber-error").text()).to.contains("");
+      })
+      .expect(400, done);
+  });
+
+  it("should redirect to /check-your-phone page when valid international phone number entered", (done) => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.UPDATE_PROFILE)
+      .once()
+      .reply(HTTP_STATUS_CODES.NO_CONTENT)
+      .post("/send-notification")
+      .once()
+      .reply(HTTP_STATUS_CODES.NO_CONTENT);
+
+    request(app)
+      .post(PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        hasInternationalPhoneNumber: true,
+        internationalPhoneNumber: "+33645453322",
       })
       .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
       .expect(302, done);

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -271,16 +271,25 @@
       "title": "Enter your mobile phone number",
       "header": "Enter your mobile phone number",
       "info": {
-        "paragraph1": "We will send a 6 digit security code to the number you give us.",
-        "paragraph2": "You must use a UK mobile phone number."
+        "paragraph1": "We will send a 6 digit security code to the number you give us."
       },
-      "phoneNumber": {
-        "label": "UK phone number",
+      "ukPhoneNumber": {
+        "label": "UK mobile phone number",
         "validationError": {
           "required": "Enter a phone number",
           "international": "Enter a UK mobile phone number",
           "length": "Enter a UK mobile phone number, like 07700 900000",
           "numeric": "Enter a UK mobile phone number using numbers only"
+        }
+      },
+      "internationalPhoneNumber": {
+        "checkBoxLabel": "I have an international mobile number",
+        "label": "International mobile number",
+        "hint": "Include the country code, for example +3537777666555",
+        "validationError": {
+          "required": "Enter a phone number",
+          "plusNumericOnly": "Enter a phone number using only numbers or the + symbol",
+          "international": "Enter a phone number in the correct format"
         }
       }
     },
@@ -1150,133 +1159,128 @@
           "header": "What were you trying to do?",
           "errorMessage": "Enter what you were trying to do"
         },
-        "section2": {
-          "header": "What happened?",
-          "paragraph1": "For example, was there a technical problem?",
-          "errorMessage": "Enter what happened"
-        }
-      },
-      "emailSubscriptions": {
-        "title": "Your GOV.UK email subscriptions",
-        "header": "Your GOV.UK email subscriptions",
-        "section1": {
-          "header": "What were you trying to do and what happened?",
-          "errorMessage": "Enter what you were trying to do and what happened"
+        "emailSubscriptions": {
+          "title": "Your GOV.UK email subscriptions",
+          "header": "Your GOV.UK email subscriptions",
+          "section1": {
+            "header": "What were you trying to do and what happened?",
+            "errorMessage": "Enter what you were trying to do and what happened"
+          },
+          "section2": {
+            "header": "Anything else you want to tell us",
+            "paragraph1": "For example, if you want to add more detail or give feedback"
+          }
         },
-        "section2": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give feedback"
-        }
-      },
-      "suggestionOrFeedback": {
-        "title": "A suggestion or feedback about using your GOV.UK account",
-        "header": "A suggestion or feedback about using your GOV.UK account",
-        "section1": {
-          "header": "Your suggestion or feedback",
-          "errorMessage": "Enter your suggestion or feedback"
-        }
-      },
-      "technicalError": {
-        "title": "There was a technical error",
-        "header": "There was a technical error",
-        "section1": {
-          "header": "What were you trying to do?",
-          "errorMessage": "Enter what you were trying to do"
+        "suggestionOrFeedback": {
+          "title": "A suggestion or feedback about using your GOV.UK account",
+          "header": "A suggestion or feedback about using your GOV.UK account",
+          "section1": {
+            "header": "Your suggestion or feedback",
+            "errorMessage": "Enter your suggestion or feedback"
+          }
         },
-        "section2": {
-          "header": "What happened?",
-          "paragraph1": "Included details of the error",
-          "errorMessage": "Enter what happened"
+        "technicalError": {
+          "title": "There was a technical error",
+          "header": "There was a technical error",
+          "section1": {
+            "header": "What were you trying to do?",
+            "errorMessage": "Enter what you were trying to do"
+          },
+          "section2": {
+            "header": "What happened?",
+            "paragraph1": "Included details of the error",
+            "errorMessage": "Enter what happened"
+          },
+          "section3": {
+            "header": "If possible, tell us the URL of the page the error happened on?"
+          }
         },
-        "section3": {
-          "header": "If possible, tell us the URL of the page the error happened on?"
-        }
-      },
-      "noSecurityCode": {
-        "title": "You did not receive a security code",
-        "header": "You did not receive a security code",
-        "section1": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
-        }
-      },
-      "invalidSecurityCode": {
-        "title": "The security code does not work",
-        "header": "The security code does not work",
-        "section1": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
-        }
-      },
-      "noUKMobile": {
-        "title": "You do not have a UK mobile phone number",
-        "header": "You do not have a UK mobile phone number",
-        "section1": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
-        }
-      },
-      "forgottenPassword": {
-        "title": "You’ve forgotten your password",
-        "header": "You’ve forgotten your password",
-        "section1": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
-        }
-      },
-      "noPhoneNumberAccess": {
-        "title": "You do not have access to the phone number you used when you created your account",
-        "header": "You do not have access to the phone number you used when you created your account",
-        "section1": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
-        }
-      },
-      "accountCreationProblem": {
-        "title": "Another problem creating an account",
-        "header": "Another problem creating an account",
-        "section1": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback",
-          "errorMessage": "Enter what happened"
-        }
-      },
-      "signignInProblem": {
-        "title": "Another problem signing in to your account",
-        "header": "Another problem signing in to your account",
-        "section1": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback",
-          "errorMessage": "Enter what happened"
-        }
-      },
-      "accountNotFound": {
-        "title": "Your account cannot be found",
-        "header": "Your account cannot be found",
-        "section1": {
-          "header": "What service were you trying to use?",
-          "paragraph1": "For example, your GOV.UK email subscriptions, your personal tax account or Universal Credit",
-          "errorMessage": "Enter what service you were trying to use"
+        "noSecurityCode": {
+          "title": "You did not receive a security code",
+          "header": "You did not receive a security code",
+          "section1": {
+            "header": "Anything else you want to tell us",
+            "paragraph1": "For example, if you want to add more detail or give us feedback"
+          }
         },
-        "section2": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
+        "invalidSecurityCode": {
+          "title": "The security code does not work",
+          "header": "The security code does not work",
+          "section1": {
+            "header": "Anything else you want to tell us",
+            "paragraph1": "For example, if you want to add more detail or give us feedback"
+          }
+        },
+        "noUKMobile": {
+          "title": "You do not have a UK mobile phone number",
+          "header": "You do not have a UK mobile phone number",
+          "section1": {
+            "header": "Anything else you want to tell us",
+            "paragraph1": "For example, if you want to add more detail or give us feedback"
+          }
+        },
+        "forgottenPassword": {
+          "title": "You’ve forgotten your password",
+          "header": "You’ve forgotten your password",
+          "section1": {
+            "header": "Anything else you want to tell us",
+            "paragraph1": "For example, if you want to add more detail or give us feedback"
+          }
+        },
+        "noPhoneNumberAccess": {
+          "title": "You do not have access to the phone number you used when you created your account",
+          "header": "You do not have access to the phone number you used when you created your account",
+          "section1": {
+            "header": "Anything else you want to tell us",
+            "paragraph1": "For example, if you want to add more detail or give us feedback"
+          }
+        },
+        "accountCreationProblem": {
+          "title": "Another problem creating an account",
+          "header": "Another problem creating an account",
+          "section1": {
+            "header": "Anything else you want to tell us",
+            "paragraph1": "For example, if you want to add more detail or give us feedback",
+            "errorMessage": "Enter what happened"
+          }
+        },
+        "signignInProblem": {
+          "title": "Another problem signing in to your account",
+          "header": "Another problem signing in to your account",
+          "section1": {
+            "header": "Anything else you want to tell us",
+            "paragraph1": "For example, if you want to add more detail or give us feedback",
+            "errorMessage": "Enter what happened"
+          }
+        },
+        "accountNotFound": {
+          "title": "Your account cannot be found",
+          "header": "Your account cannot be found",
+          "section1": {
+            "header": "What service were you trying to use?",
+            "paragraph1": "For example, your GOV.UK email subscriptions, your personal tax account or Universal Credit",
+            "errorMessage": "Enter what service you were trying to use"
+          },
+          "section2": {
+            "header": "Anything else you want to tell us",
+            "paragraph1": "For example, if you want to add more detail or give us feedback"
+          }
         }
+      },
+      "contactUsSubmitSuccess": {
+        "title": "Your message has been submitted",
+        "header": "Your message has been submitted",
+        "paragraph1": "Thank you for your message.",
+        "paragraph2": "We’ll try to get back to you in 2 working days.",
+        "paragraph3": {
+          "linkHref": "https://www.gov.uk",
+          "linkText": "Return to the GOV.UK homepage"
+        }
+      },
+      "termsConditionsNotAccepted": {
+        "title": "placeholder",
+        "header": "placeholder"
       }
-    },
-    "contactUsSubmitSuccess": {
-      "title": "Your message has been submitted",
-      "header": "Your message has been submitted",
-      "paragraph1": "Thank you for your message.",
-      "paragraph2": "We’ll try to get back to you in 2 working days.",
-      "paragraph3": {
-        "linkHref": "https://www.gov.uk",
-        "linkText": "Return to the GOV.UK homepage"
-      }
-    },
-    "termsConditionsNotAccepted": {
-      "title": "placeholder",
-      "header": "placeholder"
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -271,16 +271,25 @@
       "title": "Enter your mobile phone number",
       "header": "Enter your mobile phone number",
       "info": {
-        "paragraph1": "We will send a 6 digit security code to the number you give us.",
-        "paragraph2": "You must use a UK mobile phone number."
+        "paragraph1": "We will send a 6 digit security code to the number you give us."
       },
-      "phoneNumber": {
-        "label": "UK phone number",
+      "ukPhoneNumber": {
+        "label": "UK mobile phone number",
         "validationError": {
           "required": "Enter a phone number",
           "international": "Enter a UK mobile phone number",
           "length": "Enter a UK mobile phone number, like 07700 900000",
           "numeric": "Enter a UK mobile phone number using numbers only"
+        }
+      },
+      "internationalPhoneNumber": {
+        "checkBoxLabel": "I have an international mobile number",
+        "label": "International mobile number",
+        "hint": "Include the country code, for example +3537777666555",
+        "validationError": {
+          "required": "Enter a phone number",
+          "plusNumericOnly": "Enter a phone number using only numbers or the + symbol",
+          "internationalFormat": "Enter a phone number in the correct format"
         }
       }
     },

--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -4,8 +4,16 @@ export function containsUKMobileNumber(value: string): boolean {
   return isValidPhoneNumber(value, "GB");
 }
 
+export function containsInternationalMobileNumber(value: string): boolean {
+  return isValidPhoneNumber(prependInternationalPrefix(value));
+}
+
 export function containsNumbersOrSpacesOnly(value: string): boolean {
   return value ? /^[\d\s]+$/.test(value) : false;
+}
+
+export function containsLeadingPlusNumbersOrSpacesOnly(value: string): boolean {
+  return value ? /^\+?[\d\s]+$/.test(value) : false;
 }
 
 export function lengthInRangeWithoutSpaces(
@@ -15,4 +23,8 @@ export function lengthInRangeWithoutSpaces(
 ): boolean {
   const length = value.replace(/\s+/g, "").length;
   return length >= min && length <= max;
+}
+
+export function prependInternationalPrefix(value: string): string {
+  return value.startsWith("+") ? value : "+".concat(value);
 }

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -10,7 +10,9 @@ export function containsNumbersOnly(value: string): boolean {
 }
 
 export function redactPhoneNumber(value: string): string | undefined {
-  return value ? "*******" + value.trim().slice(7) : undefined;
+  return value
+    ? "*".repeat(value.length - 4) + value.trim().slice(value.length - 4)
+    : undefined;
 }
 
 export function generateNonce(): string {

--- a/test/unit/utils/phone-number.test.ts
+++ b/test/unit/utils/phone-number.test.ts
@@ -1,9 +1,11 @@
 import { expect } from "chai";
 import { describe } from "mocha";
 import {
+  containsInternationalMobileNumber,
   containsNumbersOrSpacesOnly,
   containsUKMobileNumber,
   lengthInRangeWithoutSpaces,
+  prependInternationalPrefix,
 } from "../../../src/utils/phone-number";
 
 describe("phone-number", () => {
@@ -131,6 +133,94 @@ describe("phone-number", () => {
     it("should return true with numbers and spaces in range", () => {
       expect(lengthInRangeWithoutSpaces(" 123 45 678 901 ", 11, 11)).to.equal(
         true
+      );
+    });
+  });
+
+  describe("test international uk mobile numbers", () => {
+    it("should return true with valid uk mobile domestic", () => {
+      expect(containsUKMobileNumber("07911123456")).to.equal(true);
+    });
+
+    it("should return true with valid uk mobile", () => {
+      expect(containsUKMobileNumber("00447911123456")).to.equal(true);
+    });
+
+    it("should return true with valid uk mobile in E164", () => {
+      expect(containsUKMobileNumber("+447911123456")).to.equal(true);
+    });
+
+    it("should return true with valid uk mobile in E164 with zero", () => {
+      expect(containsUKMobileNumber("+4407911123456")).to.equal(true);
+    });
+
+    it("should return false with valid uk mobile without lib country code", () => {
+      expect(containsInternationalMobileNumber("07911123456")).to.equal(false);
+    });
+
+    it("should return false with valid uk mobile without lib country code", () => {
+      expect(containsInternationalMobileNumber("00447911123456")).to.equal(
+        false
+      );
+    });
+
+    it("should return true with valid uk mobile in E164 without lib country code", () => {
+      expect(containsInternationalMobileNumber("+447911123456")).to.equal(true);
+    });
+
+    it("should return true with valid uk mobile in E164 without lib country code with zero", () => {
+      expect(containsInternationalMobileNumber("+4407911123456")).to.equal(
+        true
+      );
+    });
+  });
+
+  describe("test international French mobile numbers", () => {
+    it("should return false with valid French mobile without lib country code", () => {
+      expect(containsInternationalMobileNumber("0645453322")).to.equal(false);
+    });
+
+    it("should return false with valid French mobile without lib country code", () => {
+      expect(containsInternationalMobileNumber("0033645453322")).to.equal(
+        false
+      );
+    });
+
+    it("should return true with valid French mobile in E164 without lib country code", () => {
+      expect(containsInternationalMobileNumber("+33645453322")).to.equal(true);
+    });
+
+    it("should return true with valid French mobile in E164 without lib country code with zero", () => {
+      expect(containsInternationalMobileNumber("+330645453322")).to.equal(true);
+    });
+  });
+
+  describe("test international Spanish mobile numbers", () => {
+    it("should return false with valid Spanish mobile without lib country code", () => {
+      expect(containsInternationalMobileNumber("608453322")).to.equal(false);
+    });
+
+    it("should return false with valid Spanish mobile without lib country code", () => {
+      expect(containsInternationalMobileNumber("0034608453322")).to.equal(
+        false
+      );
+    });
+
+    it("should return true with valid Spanish mobile in E164 without lib country code", () => {
+      expect(containsInternationalMobileNumber("+34608453322")).to.equal(true);
+    });
+  });
+
+  describe("prependInternationalPrefix", () => {
+    it("should prepend + to an international number without the prefix", () => {
+      expect(prependInternationalPrefix("34608453322")).to.equal(
+        "+34608453322"
+      );
+    });
+
+    it("should not prepend + to an international number with the prefix", () => {
+      expect(prependInternationalPrefix("+34608453322")).to.equal(
+        "+34608453322"
       );
     });
   });

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -42,8 +42,12 @@ describe("string-helpers", () => {
   });
 
   describe("obfuscatePhoneNumber", () => {
-    it("should return obfuscated phone number when valid phone number", () => {
+    it("should return obfuscated phone number when valid uk phone number", () => {
       expect(redactPhoneNumber("07700900796")).to.equal("*******0796");
+    });
+
+    it("should return obfuscated phone number when valid international phone number", () => {
+      expect(redactPhoneNumber("+330645453322")).to.equal("*********3322");
     });
 
     it("should return undefined when phone number is is empty", () => {


### PR DESCRIPTION

## What?

Support international phone numbers.

- Add option for the user to add an international phone number instead of a UK number.
- A checkbox shows and hides a new international phone number input as required.
- Validation rules are slightly different for international numbers.  International numbers are entered in E164 format with or without the leading '+'.

## Why?

Users without a UK mobile number have been unable to create accounts thus far.