### PR TITLE
BAU: Add a new environment variable to inject a hostname to NGINX

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -126,6 +126,10 @@ locals {
         name  = "NGINX_PORT"
         value = "8080"
       },
+      {
+        name  = "NGINX_HOST"
+        value = local.frontend_fqdn
+      },
     ]
   }
 }


### PR DESCRIPTION
## What?

- Add a NGINX_HOST environment variable injecting the frontend domain name into the NGINX basic auth sidecar.

## Why?

We're getting some unusual re-writing of requests that redirect to localhost.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/204