### PR TITLE
AUTH-1376: update content for the signed-out page

### DIFF
--- a/src/components/signed-out/index.njk
+++ b/src/components/signed-out/index.njk
@@ -4,16 +4,13 @@
 {% set pageTitleName = 'pages.signedOut.title' | translate %}
 {% block content %}
 
-{% include "common/errors/errorSummary.njk" %}
-
 <input type="hidden" name="_csrf" value="{{csrfToken}}" />
 
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.signedOut.header' | translate }}</h1>
 
-{{ govukButton({
-  "text": button_text|default('pages.signedOut.buttonText' | translate, true),
-  "type": "Submit",
-  "href": 'pages.signedOut.buttonHref' | translate
-}) }}
+<p class="govuk-body">
+  <a href="{{'pages.signedOut.govukLinkHref' | translate}}" class="govuk-link">{{'pages.signedOut.govukLinkText' | translate}}</a> {{'pages.signedOut.paragraph1' | translate}} 
+  <a href="{{signinLink}}" class="govuk-link">{{'pages.signedOut.signInLinkText' | translate}}</a> {{'pages.signedOut.paragraph2' | translate}}
+</p>
 
 {% endblock %}

--- a/src/components/signed-out/signed-out-controller.ts
+++ b/src/components/signed-out/signed-out-controller.ts
@@ -27,5 +27,7 @@ export function signedOutGet(req: Request, res: Response): void {
     });
   }
 
-  res.render("signed-out/index.njk");
+  res.render("signed-out/index.njk", {
+    signinLink: res.locals.accountManagementUrl,
+  });
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,7 +74,7 @@ export async function getRedisConfig(appEnv: string): Promise<RedisConfig> {
 }
 
 export function getAccountManagementUrl(): string {
-  return process.env.ACCOUNT_MANAGEMENT_URL;
+  return process.env.ACCOUNT_MANAGEMENT_URL || "http://localhost:6001";
 }
 
 export function getZendeskUser(): string {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -405,10 +405,13 @@
       "phoneNumber": "We'll send a new code to [mobile]."
     },
     "signedOut": {
-      "title": "You have been signed out",
-      "header": "You have been signed out",
-      "buttonHref": "https://www.gov.uk/",
-      "buttonText": "Return to the GOV.UK homepage"
+      "title": "You have signed out",
+      "header": "You have signed out",
+      "govukLinkHref": "https://www.gov.uk/",
+      "govukLinkText": "Go to the GOV.UK homepage",
+      "paragraph1": "or",
+      "signInLinkText": "sign in",
+      "paragraph2": "to your GOV.UK account."
     },
     "shareInfo": {
       "title": "Share information from your GOV.UK account",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -405,10 +405,13 @@
       "phoneNumber": "We'll send a new code to [mobile]."
     },
     "signedOut": {
-      "title": "You have been signed out",
-      "header": "You have been signed out",
-      "buttonHref": "https://www.gov.uk/",
-      "buttonText": "Return to the GOV.UK homepage"
+      "title": "You have signed out",
+      "header": "You have signed out",
+      "govukLinkHref": "https://www.gov.uk/",
+      "govukLinkText": "Go to the GOV.UK homepage",
+      "paragraph1": "or",
+      "signInLinkText": "sign in",
+      "paragraph2": "to your GOV.UK account."
     },
     "shareInfo": {
       "title": "Share information from your GOV.UK account",

--- a/yarn.lock
+++ b/yarn.lock
@@ -374,9 +374,9 @@
     "@types/node" "*"
 
 "@types/chai-as-promised@^7.1.5":
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.4.tgz#caf64e76fb056b8c8ced4b761ed499272b737601"
-  integrity sha512-1y3L1cHePcIm5vXkh1DSGf/zQq5n5xDKG1fpCvf18+uOkpce0Z1ozNFPkyWsVswK7ntN1sZBw3oU6gmN+pDUcA==
+  version "7.1.5"
+  resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz#6e016811f6c7a64f2eed823191c3a6955094e255"
+  integrity sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==
   dependencies:
     "@types/chai" "*"
 


### PR DESCRIPTION
## What?

Update content for the signed-out page in frontend.

## Why?

Content is not appropriate for some user scenarios.

- Not all users will come via the GOV.UK homepage.
- Include a 'sign in' option for when this makes more sense.
