### PR TITLE
AUTH-1366 - Use query referer as referer if present

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -39,6 +39,10 @@ export function contactUsGet(req: Request, res: Response): void {
   }
   let referer = req.headers.referer;
 
+  if (req.query.referer) {
+    referer = req.query.referer as string;
+  }
+
   if (req.headers.referer && req.headers.referer.includes("referer")) {
     const urlObj = new URL(req.headers.referer);
     referer = urlObj.searchParams.get("referer");


### PR DESCRIPTION

## What?

- Use query referer as referer if present

## Why?

- So we are able to use the referer present on the contact-us link in the emails
