### PR TITLE
Change to post form on account created page

### DIFF
--- a/src/components/account-created/account-created-controller.ts
+++ b/src/components/account-created/account-created-controller.ts
@@ -5,6 +5,13 @@ import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 export function accountCreatedGet(req: Request, res: Response): void {
   const { serviceType, name } = req.session.client;
 
+  res.render("account-created/index.njk", {
+    serviceType,
+    name,
+  });
+}
+
+export function accountCreatedPost(req: Request, res: Response): void {
   const nextPath = getNextPathAndUpdateJourney(
     req,
     req.path,
@@ -15,9 +22,5 @@ export function accountCreatedGet(req: Request, res: Response): void {
     res.locals.sessionId
   );
 
-  res.render("account-created/index.njk", {
-    linkUrl: nextPath,
-    serviceType,
-    name,
-  });
+  res.redirect(nextPath);
 }

--- a/src/components/account-created/account-created-routes.ts
+++ b/src/components/account-created/account-created-routes.ts
@@ -1,7 +1,10 @@
 import { PATH_NAMES } from "../../app.constants";
 
 import * as express from "express";
-import { accountCreatedGet } from "./account-created-controller";
+import {
+  accountCreatedGet,
+  accountCreatedPost,
+} from "./account-created-controller";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 
@@ -12,6 +15,13 @@ router.get(
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
   accountCreatedGet
+);
+
+router.post(
+  PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  accountCreatedPost
 );
 
 export { router as registerAccountCreatedRouter };

--- a/src/components/account-created/index.njk
+++ b/src/components/account-created/index.njk
@@ -10,21 +10,22 @@
 
 <p class="govuk-body">{{'pages.accountCreated.text' | translate}}</p>
 
- {{ govukButton({
-  "text": button_text|default('pages.accountCreated.continue' | translate, true),
-  "href": linkUrl,
-     "attributes": {
-         "id": "track-link"
-     },
-  "preventDoubleClick": true
-  }) }}
+<form id="form-tracking" action="/account-created" method="post" novalidate>
+<input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
+<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+    {{ govukButton({
+        "text": button_text|default('pages.accountCreated.continue' | translate, true),
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
 
 {% if serviceType === 'OPTIONAL' %}
     <h1 class="govuk-body govuk-bold">{{'pages.accountCreated.progressSaved' | translate}}</h1>
 
     {{ govukButton({
         "text": button_text|default('pages.accountCreated.continue' | translate, true),
-        "href": linkUrl
+        "preventDoubleClick": true
     }) }}
 
     <br>
@@ -33,5 +34,5 @@
         {{'pages.accountCreated.signOut' | translate}}
     </a>
 {% endif %}
-
+</form>
 {% endblock %}

--- a/src/components/account-created/tests/account-created-controller.test.ts
+++ b/src/components/account-created/tests/account-created-controller.test.ts
@@ -4,7 +4,10 @@ import { describe } from "mocha";
 import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
 
-import { accountCreatedGet } from "../account-created-controller";
+import {
+  accountCreatedGet,
+  accountCreatedPost,
+} from "../account-created-controller";
 import { PATH_NAMES } from "../../../app.constants";
 import {
   mockRequest,
@@ -19,7 +22,7 @@ describe("account created controller", () => {
 
   beforeEach(() => {
     req = mockRequest({
-      path: PATH_NAMES.ACCOUNT_NOT_FOUND,
+      path: PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL,
       session: { client: {}, user: {} },
       log: { info: sinon.fake() },
     });
@@ -30,14 +33,27 @@ describe("account created controller", () => {
     sinon.restore();
   });
 
-  describe("registerAccountCreatedGet", () => {
+  describe("accountCreatedGet", () => {
     it("should render account created page", () => {
       req.session.client.serviceType = "MANDATORY";
       req.session.client.name = "test client name";
 
       accountCreatedGet(req as Request, res as Response);
 
-      expect(res.render).to.have.calledWith("account-created/index.njk");
+      expect(res.render).to.have.been.calledWith("account-created/index.njk");
+    });
+  });
+  describe("accountCreatedPost", () => {
+    it("should redirect to auth code", () => {
+      accountCreatedPost(req as Request, res as Response);
+
+      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.AUTH_CODE);
+    });
+    it("should redirect to share-info when consent is required", () => {
+      req.session.user.isConsentRequired = true;
+      accountCreatedPost(req as Request, res as Response);
+
+      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.SHARE_INFO);
     });
   });
 });


### PR DESCRIPTION
## What?

Change account created page to be a form post.

## Why?

This is to stop issues with users clicking the link more than once which causes error's downstream.
