### PR TITLE
BAU - Remove norefer from feedback link

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -10,7 +10,7 @@
     "errorSummaryTitle": "There is a problem",
     "phaseBanner": {
       "tag": "beta",
-      "content": "This is a new service – your <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">feedback</a> will help us to improve it."
+      "content": "This is a new service – your <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">feedback</a> will help us to improve it."
     },
     "yes": "Yes",
     "no": "No",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -10,7 +10,7 @@
     "errorSummaryTitle": "There is a problem",
     "phaseBanner": {
       "tag": "beta",
-      "content": "This is a new service – your <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">feedback</a> will help us to improve it."
+      "content": "This is a new service – your <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">feedback</a> will help us to improve it."
     },
     "yes": "Yes",
     "no": "No",


### PR DESCRIPTION
## What?

- Remove norefer from feedback link

## Why?

- We want to pass the referer on so we know what page the user clicked the feedback link from
