### PR TITLE
Add error handling to account not found

### DIFF
--- a/src/components/account-not-found/account-not-found-controller.ts
+++ b/src/components/account-not-found/account-not-found-controller.ts
@@ -4,7 +4,10 @@ import { ExpressRouteFunc } from "../../types";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { BadRequestError } from "../../utils/error";
-import { getNextPathAndUpdateJourney } from "../common/constants";
+import {
+  getErrorPathByCode,
+  getNextPathAndUpdateJourney,
+} from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 
 export function accountNotFoundGet(req: Request, res: Response): void {
@@ -33,6 +36,12 @@ export function accountNotFoundPost(
     );
 
     if (!result.success) {
+      const path = getErrorPathByCode(result.data.code);
+
+      if (path) {
+        return res.redirect(path);
+      }
+
       throw new BadRequestError(result.data.message, result.data.code);
     }
 

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -97,6 +97,9 @@ const authStateMachine = createMachine(
           optionalPaths: [
             PATH_NAMES.ENTER_EMAIL_SIGN_IN,
             PATH_NAMES.SIGN_IN_OR_CREATE,
+            PATH_NAMES.SECURITY_CODE_WAIT,
+            PATH_NAMES.SECURITY_CODE_INVALID,
+            PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED,
           ],
         },
       },


### PR DESCRIPTION
Add missing error handling to account not found so works as expected when errors come back from the send notification handler.
