### PR TITLE
AUTH-1446 - Default to null if supportInternationalNumbers is set to false

### DIFF
--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -13,11 +13,11 @@ import { SendNotificationServiceInterface } from "../common/send-notification/ty
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { prependInternationalPrefix } from "../../utils/phone-number";
-import {supportInternationalNumbers} from "../../config";
+import { supportInternationalNumbers } from "../../config";
 
 export function enterPhoneNumberGet(req: Request, res: Response): void {
   res.render("enter-phone-number/index.njk", {
-    supportInternationalNumbers: supportInternationalNumbers(),
+    supportInternationalNumbers: supportInternationalNumbers() ? true : null,
   });
 }
 
@@ -31,9 +31,11 @@ export function enterPhoneNumberPost(
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
     let phoneNumber;
 
-    if (hasInternationalPhoneNumber &&
-        hasInternationalPhoneNumber === "true" &&
-        supportInternationalNumbers()) {
+    if (
+      hasInternationalPhoneNumber &&
+      hasInternationalPhoneNumber === "true" &&
+      supportInternationalNumbers()
+    ) {
       phoneNumber = prependInternationalPrefix(
         req.body.internationalPhoneNumber
       );


### PR DESCRIPTION
## What?

- Default to null if supportInternationalNumbers is set to false

## Why?

- So it correctly renders the correct content when there has been a validation failure