### PR TITLE
AUTH-1473: log invalid session as 'info' not 'error'

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -83,6 +83,11 @@ export const ERROR_MESSAGES = {
   PAGE_NOT_FOUND: "Request page not found",
 };
 
+export const ERROR_LOG_LEVEL = {
+  ERROR: "Error",
+  INFO: "Info",
+};
+
 export const SERVICE_TYPE = {
   MANDATORY: "MANDATORY",
   OPTIONAL: "OPTIONAL",

--- a/src/middleware/log-error-middleware.ts
+++ b/src/middleware/log-error-middleware.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from "express";
+import { ERROR_LOG_LEVEL } from "../app.constants";
 
 export function logErrorMiddleware(
   error: any,
@@ -6,9 +7,16 @@ export function logErrorMiddleware(
   res: Response,
   next: NextFunction
 ): void {
-  req.log.error({
-    err: { data: error.data, status: error.status, stack: error.stack },
-    msg: `Error:${error.message}`,
-  });
+  if (error.level && error.level === ERROR_LOG_LEVEL.INFO) {
+    req.log.info({
+      err: { data: error.data, status: error.status },
+      msg: `${error.message}`,
+    });
+  } else {
+    req.log.error({
+      err: { data: error.data, status: error.status, stack: error.stack },
+      msg: `${ERROR_LOG_LEVEL.ERROR}:${error.message}`,
+    });
+  }
   next(error);
 }

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from "express";
-import { ERROR_MESSAGES, PATH_NAMES } from "../app.constants";
+import { ERROR_LOG_LEVEL, ERROR_MESSAGES, PATH_NAMES } from "../app.constants";
 import xss from "xss";
+import { ErrorWithLevel } from "../utils/error";
 
 export function initialiseSessionMiddleware(
   req: Request,
@@ -63,5 +64,7 @@ export function validateSessionMiddleware(
   });
 
   res.status(401);
-  next(new Error(ERROR_MESSAGES.INVALID_SESSION));
+  next(
+    new ErrorWithLevel(ERROR_MESSAGES.INVALID_SESSION, ERROR_LOG_LEVEL.INFO)
+  );
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -15,3 +15,11 @@ export class ApiError extends Error {
     this.status = status;
   }
 }
+
+export class ErrorWithLevel extends Error {
+  level: string;
+  constructor(message: string, level: string) {
+    super(message);
+    this.level = level;
+  }
+}

--- a/test/unit/middleware/log-error-middleware.test.ts
+++ b/test/unit/middleware/log-error-middleware.test.ts
@@ -1,0 +1,58 @@
+import { NextFunction, Request, Response } from "express";
+import { expect, sinon } from "../../utils/test-utils";
+import { describe } from "mocha";
+import { logErrorMiddleware } from "../../../src/middleware/log-error-middleware";
+import { mockRequest, mockResponse } from "mock-req-res";
+import { ErrorWithLevel } from "../../../src/utils/error";
+import { ERROR_LOG_LEVEL } from "../../../src/app.constants";
+
+describe("logErrorMiddleware", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    req = mockRequest({
+      session: { client: {}, user: {} },
+      log: { error: sinon.fake(), info: sinon.fake() },
+    });
+    res = mockResponse();
+    next = sinon.fake();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("logErrorMiddleware", () => {
+    it("should log an error", () => {
+      logErrorMiddleware(
+        new Error("An Error"),
+        req as Request,
+        res as Response,
+        next
+      );
+
+      expect(req.log.error).to.be.called.calledOnce;
+      expect(req.log.error).to.be.called.calledWith({ 
+        err: { data: undefined, status: undefined, stack: sinon.match.any }, msg: 'Error:An Error' 
+      });
+      expect(next).to.be.calledOnce;
+    });
+
+    it("should log info only", () => {
+      logErrorMiddleware(
+        new ErrorWithLevel("Actually Info", ERROR_LOG_LEVEL.INFO),
+        req as Request,
+        res as Response,
+        next
+      );
+
+      expect(req.log.info).to.be.called.calledOnce;
+      expect(req.log.info).to.be.called.calledWith({ 
+        err: { data: undefined, status: undefined }, msg: 'Actually Info' 
+      });
+      expect(next).to.be.calledOnce;
+    });
+  });
+});


### PR DESCRIPTION
## What?

Log invalid session as 'info' not 'error'.

- Extend Error class to add a level field.
- When level is info do not log 'Error' or the stacktrace.

## Why?

Invalid sessions are not errors and occur because users leave their browsers open for longer than 60 min.  

This change removes error noise from the logs, so people are less likely to think there is an actual problem.
