### PR TITLE
AUTH-1494: fix typo on privacy notice

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -943,7 +943,7 @@
         "paragraph3": "You can also make a complaint to the Information Commissioner, who is an independent regulator.",
         "address2": {
           "line1": "Information Commissioner's Office",
-          "line2": "Wycliffe Housee",
+          "line2": "Wycliffe House",
           "line3": "Water Lane",
           "line4": "Wilmslow",
           "line5": "Cheshire SK9 5AF",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -943,7 +943,7 @@
         "paragraph3": "You can also make a complaint to the Information Commissioner, who is an independent regulator.",
         "address2": {
           "line1": "Information Commissioner's Office",
-          "line2": "Wycliffe Housee",
+          "line2": "Wycliffe House",
           "line3": "Water Lane",
           "line4": "Wilmslow",
           "line5": "Cheshire SK9 5AF",


### PR DESCRIPTION
## What?

Fix typo on privacy notice

## Why?

Incorrect address.