### PR TITLE
AUTH-1473: Log backend Error 1000 Session Id missing or invalid as info

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -53,6 +53,10 @@ export const HTTP_STATUS_CODES = {
   REDIRECT: 303,
 };
 
+export const API_ERROR_CODES = {
+  SESSION_ID_MISSING_OR_INVALID: 1000,
+};
+
 export enum LOCALE {
   EN = "en",
   CY = "cy",

--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -3,6 +3,8 @@ import {
   COOKIE_CONSENT,
   COOKIES_PREFERENCES_SET,
   PATH_NAMES,
+  ERROR_LOG_LEVEL,
+  API_ERROR_CODES,
 } from "../../app.constants";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { BadRequestError } from "../../utils/error";
@@ -44,10 +46,18 @@ export function landingGet(
     );
 
     if (!startAuthResponse.success) {
-      throw new BadRequestError(
+      const startError = new BadRequestError(
         startAuthResponse.data.message,
         startAuthResponse.data.code
       );
+      if (
+        startAuthResponse.data.code &&
+        startAuthResponse.data.code ===
+          API_ERROR_CODES.SESSION_ID_MISSING_OR_INVALID
+      ) {
+        startError.level = ERROR_LOG_LEVEL.INFO;
+      }
+      throw startError;
     }
 
     req.session.client.serviceType = startAuthResponse.data.client.serviceType;

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,5 +1,6 @@
 export class BadRequestError extends Error {
   private status: number;
+  level?: string;
   constructor(message: string, code: number | string) {
     super(`${code}:${message}`);
     this.status = 400;

--- a/test/unit/middleware/log-error-middleware.test.ts
+++ b/test/unit/middleware/log-error-middleware.test.ts
@@ -34,8 +34,9 @@ describe("logErrorMiddleware", () => {
       );
 
       expect(req.log.error).to.be.called.calledOnce;
-      expect(req.log.error).to.be.called.calledWith({ 
-        err: { data: undefined, status: undefined, stack: sinon.match.any }, msg: 'Error:An Error' 
+      expect(req.log.error).to.be.called.calledWith({
+        err: { data: undefined, status: undefined, stack: sinon.match.any },
+        msg: "Error:An Error",
       });
       expect(next).to.be.calledOnce;
     });
@@ -49,8 +50,9 @@ describe("logErrorMiddleware", () => {
       );
 
       expect(req.log.info).to.be.called.calledOnce;
-      expect(req.log.info).to.be.called.calledWith({ 
-        err: { data: undefined, status: undefined }, msg: 'Actually Info' 
+      expect(req.log.info).to.be.called.calledWith({
+        err: { data: undefined, status: undefined },
+        msg: "Actually Info",
       });
       expect(next).to.be.calledOnce;
     });


### PR DESCRIPTION
## What?

Log backend Error 1000 Session Id missing or invalid as info.

'log-error-middleware.test.ts' changes are just formatting.

## Why?

All backend 4xx errors are being logged as info so gradually extending this to the frontend to reduce noise in the logs.

## Related PRs

#550 