### PR TITLE
BAU: force minimist to 1.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,5 +125,8 @@
     "ts-node": "^10.5.0",
     "typescript": "^4.5.4",
     "uglify-js": "^3.14.5"
+  },
+  "resolutions": {
+      "minimist": "1.2.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2923,10 +2923,10 @@ minimatch@3.0.4, minimatch@^3.0.3, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@1.2.6, minimist@^1.2.0, minimist@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mkdirp@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## What?

Force minimist to 1.2.6.
Minimist is a dev-only dependency.

## Why?

Fix advisory on 1.2.5

## Related

https://github.com/advisories/GHSA-xvch-5gv4-984h