### PR TITLE
AUTH-1427: Add staging environment overrides

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,4 +1,2 @@
 environment         = "build"
 common_state_bucket = "digital-identity-dev-tfstate"
-
-paas_frontend_cdn_route_destination = "d158sddez3vxwe.cloudfront.net"

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,4 +1,2 @@
 environment         = "integration"
 common_state_bucket = "digital-identity-dev-tfstate"
-
-paas_frontend_cdn_route_destination = "d3a5c9upzkx78l.cloudfront.net"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,5 +1,3 @@
 environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
 ecs_desired_count   = 4
-
-paas_frontend_cdn_route_destination = "d2fete2ah9wab4.cloudfront.net"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -12,8 +12,6 @@ image_digest            = "sha256:dfbe4c6ccbbaf4c8ae7589a31d0bf73940cef19b8cfcb3
 session_expiry          = 300000
 gtm_id                  = ""
 
-paas_frontend_cdn_route_destination = "d2eyuvxr6b3efm.cloudfront.net"
-
 basic_auth_username  = ""
 basic_auth_password  = ""
 sidecar_image_uri    = "706615647326.dkr.ecr.eu-west-2.amazonaws.com/basic-auth-sidecar-image-repository"

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -1,0 +1,2 @@
+environment         = "staging"
+common_state_bucket = "di-auth-staging-tfstate"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -126,11 +126,6 @@ variable "deployment_max_percent" {
   default = 150
 }
 
-variable "paas_frontend_cdn_route_destination" {
-  type        = string
-  description = "The Cloudfront instance to forward all PaaS requests to"
-}
-
 variable "sidecar_image_uri" {
   default = ""
 }


### PR DESCRIPTION
## What?

- Add a new tfvars file containing valid values for the staging environment.
- Remove the now defunct `paas_frontend_cdn_route_destination` variable.

## Why?

We are adding a staging environment to integration test with the other components of GOV.UK Sign in

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/1581
https://github.com/alphagov/di-authentication-account-management/pull/400
https://github.com/alphagov/di-infrastructure/pull/216