### PR TITLE
AUTH-1427: Parameterise ALB allowlist

### DIFF
--- a/ci/tasks/deploy-frontend.yml
+++ b/ci/tasks/deploy-frontend.yml
@@ -23,6 +23,7 @@ params:
   BASIC_AUTH_USERNAME: ((no-basic-auth-username))
   BASIC_AUTH_PASSWORD: ((no-basic-auth-password))
   SUPPORT_INTERNATIONAL_NUMBERS: "0"
+  INCOMING_TRAFFIC_CIDR_BLOCKS: '["0.0.0.0/0"]'
 inputs:
   - name: frontend-src
   - name: frontend-image
@@ -81,6 +82,7 @@ run:
         -var "support_international_numbers=${SUPPORT_INTERNATIONAL_NUMBERS}" \
         -var "basic_auth_username=${NORMALISED_BASIC_AUTH_USERNAME}" \
         -var "basic_auth_password=${NORMALISED_BASIC_AUTH_PASSWORD}" \
+        -var "incoming_traffic_cidr_blocks=${INCOMING_TRAFFIC_CIDR_BLOCKS}" \
         -var-file ${DEPLOY_ENVIRONMENT}.tfvars \
 
       terraform output --json > ../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/security-groups.tf
+++ b/ci/terraform/security-groups.tf
@@ -61,7 +61,7 @@ resource "aws_security_group_rule" "allow_alb_http_ingress_from_anywhere" {
   protocol    = "tcp"
   from_port   = 80
   to_port     = 80
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks = var.incoming_traffic_cidr_blocks
 }
 
 resource "aws_security_group_rule" "allow_alb_https_ingress_from_anywhere" {
@@ -72,7 +72,7 @@ resource "aws_security_group_rule" "allow_alb_https_ingress_from_anywhere" {
   protocol    = "tcp"
   from_port   = 443
   to_port     = 443
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks = var.incoming_traffic_cidr_blocks
 }
 
 resource "aws_security_group_rule" "allow_alb_application_egress_to_task_group" {

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -141,3 +141,9 @@ variable "basic_auth_username" {
 variable "basic_auth_password" {
   default = ""
 }
+
+variable "incoming_traffic_cidr_blocks" {
+  default     = ["0.0.0.0/0"]
+  type        = list(string)
+  description = "The list of CIDR blocks allowed to send requests to the ALB"
+}


### PR DESCRIPTION
## What?

- Make the CIDR block used for to match incoming traffic to the ALB parameterised. The default should be anywhere (`["0.0.0.0/0"]`)

## Why?

This will allow us to override in the pipeline for staging and other environments.