### PR TITLE
AUTH-1427: Add missing permissions for Cloudwatch

### DIFF
--- a/ci/terraform/cloudwatch.tf
+++ b/ci/terraform/cloudwatch.tf
@@ -23,7 +23,9 @@ data "aws_iam_policy_document" "cloudwatch" {
     actions = [
       "kms:Encrypt*",
       "kms:Decrypt*",
-      "kms:Describe*"
+      "kms:Describe*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
     ]
     effect = "Allow"
     principals {


### PR DESCRIPTION
## What?

- Add the `kms:ReEncrypt*` and `kms:GenerateDataKey*` actions to the cloudwatch policy.

## Why?

It seems these are now required to create encrypted log groups.

## Related PRs

https://github.com/alphagov/di-authentication-account-management/pull/407