### PR TITLE
AUTH-1477: drain in-flight password resets

### DIFF
--- a/src/components/enter-password/index-account-exists.njk
+++ b/src/components/enter-password/index-account-exists.njk
@@ -25,9 +25,6 @@
 
 <p class="govuk-body">{{'pages.enterPasswordAccountExists.info' | translate}}</p>
     {{ govukInputWithShowPassword('pages.enterPasswordAccountExists.password.label' | translate, "password", errors) }}
-<p class="govuk-body">
-    <a href="/reset-password-check-email" class="govuk-link" rel="noreferrer noopener">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>
-</p>
 
 {{ govukButton({
     "text": button_text|default('general.continue.label' | translate, true),

--- a/src/components/enter-password/index-account-locked.njk
+++ b/src/components/enter-password/index-account-locked.njk
@@ -21,7 +21,6 @@
 
 <ul class="govuk-list govuk-list--bullet">
     <li>{{'pages.accountLocked.bulletPointSection.first' | translate}}<a href="/enter-password" class="govuk-link">{{'pages.accountLocked.bulletPointSection.firstLink' | translate}}</a></li>
-    <li><a href="/reset-password-check-email" class="govuk-link">{{'pages.accountLocked.bulletPointSection.second' | translate}}</a></li>
 </ul>
 
 {% endblock %}

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -19,10 +19,6 @@
 
 {{ govukInputWithShowPassword('pages.enterPassword.password.label' | translate, "password", errors) }}
 
-<p class="govuk-body">
-    <a href="/reset-password-check-email" class="govuk-link" rel="noreferrer noopener">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>
-</p>
-
 {{ govukButton({
     "text": button_text|default('general.continue.label' | translate, true),
     "type": "Submit",


### PR DESCRIPTION


## What?

Removes the password reset option to allow time for in-flight resets to expire.
The option will be put back again when password reset using an OTP is released straight after.

## Why?

When password resets using an OTP replace resets using a link there could be a short window where valid links have been sent, but the screens needed to action them have been removed.  In order to avoid this scenario the option to reset passwords will be removed just for long enough for all in-flight reset links to expire.  This means that all users having requested a link will be able to use them before the option disappears.

After 15 mins password resets with an OTP will be deployed, see related PR below.

## Related PRs

#562
