### PR TITLE
BAU: additional alphanumeric password validation

### DIFF
--- a/src/components/create-password/create-password-validation.ts
+++ b/src/components/create-password/create-password-validation.ts
@@ -1,5 +1,9 @@
 import { body } from "express-validator";
-import { containsNumber } from "../../utils/strings";
+import {
+  containsLettersOnly,
+  containsNumber,
+  containsNumbersOnly,
+} from "../../utils/strings";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import { isCommonPassword } from "../../utils/password-validation";
@@ -13,15 +17,6 @@ export function validateCreatePasswordRequest(): ValidationChainFunc {
           value,
         });
       })
-      .isLength({ min: 8 })
-      .withMessage((value, { req }) => {
-        return req.t(
-          "pages.createPassword.password.validationError.minLength",
-          {
-            value,
-          }
-        );
-      })
       .isLength({ max: 256 })
       .withMessage((value, { req }) => {
         return req.t(
@@ -32,7 +27,12 @@ export function validateCreatePasswordRequest(): ValidationChainFunc {
         );
       })
       .custom((value, { req }) => {
-        if (!containsNumber(value)) {
+        if (
+          !containsNumber(value) ||
+          containsNumbersOnly(value) ||
+          value.length < 8 ||
+          containsLettersOnly(value)
+        ) {
           throw new Error(
             req.t("pages.createPassword.password.validationError.alphaNumeric")
           );

--- a/src/components/create-password/tests/create-password-integration.test.ts
+++ b/src/components/create-password/tests/create-password-integration.test.ts
@@ -124,13 +124,13 @@ describe("Integration::register create password", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include a number"
+          "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
       .expect(400, done);
   });
 
-  it("should return validation error when password not valid", (done) => {
+  it("should return validation error when no numbers present in password", (done) => {
     request(app)
       .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
       .type("form")
@@ -143,7 +143,26 @@ describe("Integration::register create password", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include a number"
+          "Your password must be at least 8 characters long and must include letters and numbers"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when password all numeric", (done) => {
+    request(app)
+      .post(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "222222222222222",
+        "confirm-password": "222222222222222",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#password-error").text()).to.contains(
+          "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
       .expect(400, done);

--- a/src/components/reset-password/reset-password-validation.ts
+++ b/src/components/reset-password/reset-password-validation.ts
@@ -1,5 +1,9 @@
 import { body } from "express-validator";
-import { containsNumber } from "../../utils/strings";
+import {
+  containsLettersOnly,
+  containsNumber,
+  containsNumbersOnly,
+} from "../../utils/strings";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import { isCommonPassword } from "../../utils/password-validation";
@@ -13,12 +17,6 @@ export function validateResetPasswordRequest(): ValidationChainFunc {
           value,
         });
       })
-      .isLength({ min: 8 })
-      .withMessage((value, { req }) => {
-        return req.t("pages.resetPassword.password.validationError.minLength", {
-          value,
-        });
-      })
       .isLength({ max: 256 })
       .withMessage((value, { req }) => {
         return req.t("pages.resetPassword.password.validationError.maxLength", {
@@ -26,19 +24,24 @@ export function validateResetPasswordRequest(): ValidationChainFunc {
         });
       })
       .custom((value, { req }) => {
-        if (isCommonPassword(value)) {
+        if (
+          !containsNumber(value) ||
+          containsNumbersOnly(value) ||
+          value.length < 8 ||
+          containsLettersOnly(value)
+        ) {
           throw new Error(
-            req.t(
-              "pages.createPassword.password.validationError.commonPassword"
-            )
+            req.t("pages.resetPassword.password.validationError.alphaNumeric")
           );
         }
         return true;
       })
       .custom((value, { req }) => {
-        if (!containsNumber(value)) {
+        if (isCommonPassword(value)) {
           throw new Error(
-            req.t("pages.resetPassword.password.validationError.alphaNumeric")
+            req.t(
+              "pages.createPassword.password.validationError.commonPassword"
+            )
           );
         }
         return true;

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -117,7 +117,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include a number"
+          "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
       .expect(400, done);
@@ -163,7 +163,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       .expect(400, done);
   });
 
-  it("should return validation error when password not valid", (done) => {
+  it("should return validation error when no numbers present in password", (done) => {
     request(app)
       .post(ENDPOINT)
       .type("form")
@@ -176,7 +176,26 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#password-error").text()).to.contains(
-          "Your password must be at least 8 characters long and must include a number"
+          "Your password must be at least 8 characters long and must include letters and numbers"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when password all numeric", (done) => {
+    request(app)
+      .post(ENDPOINT)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        password: "222222222222222",
+        "confirm-password": "222222222222222",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#password-error").text()).to.contains(
+          "Your password must be at least 8 characters long and must include letters and numbers"
         );
       })
       .expect(400, done);

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -249,13 +249,12 @@
       "header": "Create your password",
       "password": {
         "label": "Enter a password",
-        "hint": "It must be at least 8 characters long and must include at least one number",
+        "hint": "Your password must be at least 8 characters long and must include letters and numbers",
         "validationError": {
           "required": "Enter your password",
-          "minLength": "Your password must be at least 8 characters long and must include a number",
           "maxLength": "Your password must be less than 256 characters",
           "commonPassword": "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers.",
-          "alphaNumeric": "Your password must be at least 8 characters long and must include a number"
+          "alphaNumeric": "Your password must be at least 8 characters long and must include letters and numbers"
         }
       },
       "confirmPassword": {
@@ -972,13 +971,12 @@
       "header": "Reset your password",
       "password": {
         "label": "Enter a new password",
-        "hint": "It must be at least 8 characters long and must include at least one number.",
+        "hint": "Your password must be at least 8 characters long and must include letters and numbers",
         "validationError": {
           "required": "Enter your password",
-          "minLength": "Your password must be at least 8 characters long and must include a number",
           "maxLength": "Your password must be less than 256 characters",
           "samePassword": "Your account is already using that password. Enter a different password",
-          "alphaNumeric": "Your password must be at least 8 characters long and must include a number"
+          "alphaNumeric": "Your password must be at least 8 characters long and must include letters and numbers"
         }
       },
       "confirmPassword": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -266,13 +266,12 @@
       "header": "Create your password",
       "password": {
         "label": "Enter a password",
-        "hint": "It must be at least 8 characters long and must include at least one number",
+        "hint": "Your password must be at least 8 characters long and must include letters and numbers",
         "validationError": {
           "required": "Enter your password",
-          "minLength": "Your password must be at least 8 characters long and must include a number",
           "maxLength": "Your password must be less than 256 characters",
           "commonPassword": "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers.",
-          "alphaNumeric": "Your password must be at least 8 characters long and must include a number"
+          "alphaNumeric": "Your password must be at least 8 characters long and must include letters and numbers"
         }
       },
       "confirmPassword": {
@@ -989,13 +988,12 @@
       "header": "Reset your password",
       "password": {
         "label": "Enter a new password",
-        "hint": "It must be at least 8 characters long and must include at least one number.",
+        "hint": "Your password must be at least 8 characters long and must include letters and numbers",
         "validationError": {
           "required": "Enter your password",
-          "minLength": "Your password must be at least 8 characters long and must include a number",
           "maxLength": "Your password must be less than 256 characters",
           "samePassword": "Your account is already using that password. Enter a different password",
-          "alphaNumeric": "Your password must be at least 8 characters long and must include a number"
+          "alphaNumeric": "Your password must be at least 8 characters long and must include letters and numbers"
         }
       },
       "confirmPassword": {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -9,6 +9,10 @@ export function containsNumbersOnly(value: string): boolean {
   return value ? /^\d+$/.test(value) : false;
 }
 
+export function containsLettersOnly(value: string): boolean {
+  return value ? /^[a-zA-Z]+$/.test(value) : false;
+}
+
 export function redactPhoneNumber(value: string): string | undefined {
   return value
     ? "*".repeat(value.length - 4) + value.trim().slice(value.length - 4)

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -1,6 +1,11 @@
 import { expect } from "chai";
 import { describe } from "mocha";
-import { containsNumber, redactPhoneNumber } from "../../../src/utils/strings";
+import {
+  containsLettersOnly,
+  containsNumber,
+  containsNumbersOnly,
+  redactPhoneNumber,
+} from "../../../src/utils/strings";
 
 describe("string-helpers", () => {
   describe("containsNumber", () => {
@@ -23,21 +28,41 @@ describe("string-helpers", () => {
 
   describe("hasNumbersOnly", () => {
     it("should return false when string contains text characters", () => {
-      expect(containsNumber("test")).to.equal(false);
+      expect(containsNumbersOnly("test")).to.equal(false);
     });
 
     it("should return false when string is empty", () => {
-      expect(containsNumber("")).to.equal(false);
+      expect(containsNumbersOnly("")).to.equal(false);
     });
 
     it("should return false when string is null", () => {
-      expect(containsNumber(null)).to.equal(false);
+      expect(containsNumbersOnly(null)).to.equal(false);
     });
     it("should return false when string contains alphanumeric characters", () => {
-      expect(containsNumber("test123456")).to.equal(true);
+      expect(containsNumbersOnly("test123456")).to.equal(false);
     });
     it("should return true when string contains numeric characters only", () => {
-      expect(containsNumber("123456")).to.equal(true);
+      expect(containsNumbersOnly("123456")).to.equal(true);
+    });
+  });
+
+  describe("hasLettersOnly", () => {
+    it("should return false when string contains only numbers", () => {
+      expect(containsLettersOnly("1234")).to.equal(false);
+    });
+
+    it("should return false when string is empty", () => {
+      expect(containsLettersOnly("")).to.equal(false);
+    });
+
+    it("should return false when string is null", () => {
+      expect(containsLettersOnly(null)).to.equal(false);
+    });
+    it("should return false when string contains alphanumeric characters", () => {
+      expect(containsLettersOnly("test123456")).to.equal(false);
+    });
+    it("should return true when string contains letters characters only", () => {
+      expect(containsLettersOnly("abcdefg")).to.equal(true);
     });
   });
 


### PR DESCRIPTION
## What?

Additional alphanumeric password validation.
Apply the same validation order in both create password and reset password so that the common password check is last.

## Why?

Forbid numeric-only passwords longer than 10 characters.
