### PR TITLE
Update landing component to support skipping authentication

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -54,6 +54,7 @@ const authStateMachine = createMachine(
       isAuthenticated: false,
       isIdentityRequired: false,
       prompt: OIDC_PROMPT.NONE,
+      skipAuthentication: false,
     },
     states: {
       [PATH_NAMES.START]: {
@@ -72,6 +73,10 @@ const authStateMachine = createMachine(
             { target: [PATH_NAMES.AUTH_CODE], cond: "isAuthenticated" },
           ],
           [USER_JOURNEY_EVENTS.LANDING]: [
+            {
+              target: [PATH_NAMES.DOC_CHECKING_APP],
+              cond: "skipAuthentication",
+            },
             {
               target: [PATH_NAMES.PROVE_IDENTITY_WELCOME],
               cond: "isIdentityRequired",
@@ -428,6 +433,9 @@ const authStateMachine = createMachine(
       requiresLogin: (context) =>
         context.isAuthenticated === true &&
         context.prompt === OIDC_PROMPT.LOGIN,
+      skipAuthentication: (context) =>
+        context.skipAuthentication === true &&
+        context.isAuthenticated === false,
     },
   }
 );

--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -76,6 +76,8 @@ export function landingGet(
       startAuthResponse.data.user.authenticated;
     req.session.user.isUpliftRequired =
       startAuthResponse.data.user.upliftRequired;
+    req.session.user.docCheckingAppUser =
+      startAuthResponse.data.user.docCheckingAppUser;
 
     const nextState = req.session.user.isAuthenticated
       ? USER_JOURNEY_EVENTS.EXISTING_SESSION
@@ -91,6 +93,7 @@ export function landingGet(
         isIdentityRequired: req.session.user.isIdentityRequired,
         isAuthenticated: req.session.user.isAuthenticated,
         prompt: req.session.client.prompt,
+        skipAuthentication: req.session.user.docCheckingAppUser,
       },
       sessionId
     );

--- a/src/components/landing/types.ts
+++ b/src/components/landing/types.ts
@@ -20,6 +20,7 @@ export interface UserSessionInfo {
   authenticated: boolean;
   cookieConsent?: string;
   gaCrossDomainTrackingId?: string;
+  docCheckingAppUser: boolean;
 }
 
 export interface LandingServiceInterface {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface UserSession {
   isLatestTermsAndConditionsAccepted?: boolean;
   isIdentityRequired?: boolean;
   isUpliftRequired?: boolean;
+  docCheckingAppUser?: boolean;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What?

Update landing component to add new state for doc checking app.

## Why?

To allow the skipping of authentication as this is not required for the document checking app journey. 