### PR TITLE
AUT-212: ECS rollout configuration tweaks in build and integration only

### DIFF
--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -11,11 +11,12 @@ resource "aws_lb" "frontend_alb" {
 }
 
 resource "aws_alb_target_group" "frontend_alb_target_group" {
-  name        = "${var.environment}-frontend-target"
-  port        = 80
-  protocol    = "HTTP"
-  vpc_id      = local.vpc_id
-  target_type = "ip"
+  name                 = "${var.environment}-frontend-target"
+  port                 = 80
+  protocol             = "HTTP"
+  vpc_id               = local.vpc_id
+  target_type          = "ip"
+  deregistration_delay = var.deregistration_delay
 
   health_check {
     healthy_threshold   = "3"

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,2 +1,4 @@
-environment         = "build"
-common_state_bucket = "digital-identity-dev-tfstate"
+environment                       = "build"
+common_state_bucket               = "digital-identity-dev-tfstate"
+health_check_grace_period_seconds = 15
+deregistration_delay              = 30

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -152,6 +152,7 @@ resource "aws_ecs_service" "frontend_ecs_service" {
 
   deployment_minimum_healthy_percent = var.deployment_min_healthy_percent
   deployment_maximum_percent         = var.deployment_max_percent
+  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
 
   network_configuration {
     security_groups = [

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,2 +1,4 @@
-environment         = "integration"
-common_state_bucket = "digital-identity-dev-tfstate"
+environment                       = "integration"
+common_state_bucket               = "digital-identity-dev-tfstate"
+health_check_grace_period_seconds = 15
+deregistration_delay              = 30

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -126,6 +126,14 @@ variable "deployment_max_percent" {
   default = 150
 }
 
+variable "health_check_grace_period_seconds" {
+  default = 0
+}
+
+variable "deregistration_delay" {
+  default = 300
+}
+
 variable "sidecar_image_uri" {
   default = ""
 }


### PR DESCRIPTION
## What?

ECS rollout configuration tweaks in build and integration only.

Set health_check_grace_period_seconds to 15s. Current default is 0.
Set ALB deregistration_delay to 30s. Current default is 300s.
Changes to be extended to staging and prod after checks in build and integration.

## Why?

We currently have these two configuration values set to their defaults.

Currently waiting 300s for the apps to drain during a rollout as the deregistration delay is set to the default. Frontend transactions complete in a matter of seconds so there is no reason to wait for 5 mins. This will reduce rollout timeout.

See the ECS service event log when a rollout happens, it takes 5 mins between deregistration (when the ALB stops sending traffice to the app) and finally stopping the app. Nothing happens during this time.

2022-05-06 11:48:26 +0100
service has stopped 2 running tasks:

2022-05-06 11:43:24 +0100
service has begun draining connections on 2 tasks.

2022-05-06 11:43:24 +0100
service deregistered 2 targets in target-group

Frontend apps start quickly but a small grace period makes sense just in case to allow for connections (to redis for example).

## Related PRs

This is the Frontend version of the Account Management PR:

https://github.com/alphagov/di-authentication-account-management/pull/454
