### PR TITLE
AUT-213: add auto scaling config for frontend

### DIFF
--- a/ci/terraform/auto-scaling.tf
+++ b/ci/terraform/auto-scaling.tf
@@ -1,0 +1,45 @@
+
+resource "aws_appautoscaling_target" "frontend_auto_scaling_target" {
+  count              = var.frontend_auto_scaling_enabled ? 1 : 0
+  min_capacity       = var.frontend_auto_scaling_min_count
+  max_capacity       = var.frontend_auto_scaling_max_count
+  resource_id        = "service/${var.environment}-app-cluster/${aws_ecs_service.frontend_ecs_service.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = "ecs"
+}
+
+resource "aws_appautoscaling_policy" "frontend_auto_scaling_policy_memory" {
+  count              = var.frontend_auto_scaling_enabled ? 1 : 0
+  name               = "${var.environment}-frontend_auto_scaling_policy_memory"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.frontend_auto_scaling_target[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.frontend_auto_scaling_target[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.frontend_auto_scaling_target[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageMemoryUtilization"
+    }
+    target_value       = var.frontend_auto_scaling_policy_memory_target
+    scale_out_cooldown = var.frontend_auto_scaling_policy_scale_out_cooldown
+    scale_in_cooldown  = var.frontend_auto_scaling_policy_scale_in_cooldown
+  }
+}
+
+resource "aws_appautoscaling_policy" "frontend_auto_scaling_policy_cpu" {
+  count              = var.frontend_auto_scaling_enabled ? 1 : 0
+  name               = "${var.environment}-frontend_auto_scaling_policy_cpu"
+  policy_type        = "TargetTrackingScaling"
+  resource_id        = aws_appautoscaling_target.frontend_auto_scaling_target[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.frontend_auto_scaling_target[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.frontend_auto_scaling_target[0].service_namespace
+
+  target_tracking_scaling_policy_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ECSServiceAverageCPUUtilization"
+    }
+    target_value       = var.frontend_auto_scaling_policy_cpu_target
+    scale_out_cooldown = var.frontend_auto_scaling_policy_scale_out_cooldown
+    scale_in_cooldown  = var.frontend_auto_scaling_policy_scale_in_cooldown
+  }
+}

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -180,8 +180,8 @@ resource "aws_ecs_task_definition" "frontend_task_definition" {
   task_role_arn            = aws_iam_role.ecs_task_role.arn
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = 1024
-  memory                   = 2048
+  cpu                      = var.frontend_task_definition_cpu
+  memory                   = var.frontend_task_definition_memory
   container_definitions = var.basic_auth_password == "" ? jsonencode([local.frontend_container_definition]) : jsonencode([
     local.frontend_container_definition,
     local.sidecar_container_definition,

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -12,7 +12,11 @@ image_digest            = "sha256:dfbe4c6ccbbaf4c8ae7589a31d0bf73940cef19b8cfcb3
 session_expiry          = 300000
 gtm_id                  = ""
 
-basic_auth_username  = ""
-basic_auth_password  = ""
-sidecar_image_uri    = "706615647326.dkr.ecr.eu-west-2.amazonaws.com/basic-auth-sidecar-image-repository"
-sidecar_image_digest = "sha256:b676bdc0aa24f1bf02364a1afeaa0649f585ce572849746769b3104f63b71976"
+basic_auth_username             = ""
+basic_auth_password             = ""
+sidecar_image_uri               = "706615647326.dkr.ecr.eu-west-2.amazonaws.com/basic-auth-sidecar-image-repository"
+sidecar_image_digest            = "sha256:b676bdc0aa24f1bf02364a1afeaa0649f585ce572849746769b3104f63b71976"
+support_international_numbers   = 0
+frontend_task_definition_cpu    = 256
+frontend_task_definition_memory = 512
+frontend_auto_scaling_enabled   = true

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -71,6 +71,50 @@ variable "ecs_desired_count" {
   default = 2
 }
 
+variable "frontend_task_definition_cpu" {
+  type    = number
+  default = 1024
+}
+
+variable "frontend_task_definition_memory" {
+  type    = number
+  default = 2048
+}
+
+variable "frontend_auto_scaling_enabled" {
+  default = false
+}
+
+variable "frontend_auto_scaling_min_count" {
+  type    = number
+  default = 2
+}
+
+variable "frontend_auto_scaling_max_count" {
+  type    = number
+  default = 4
+}
+
+variable "frontend_auto_scaling_policy_memory_target" {
+  type    = number
+  default = 75
+}
+
+variable "frontend_auto_scaling_policy_cpu_target" {
+  type    = number
+  default = 65
+}
+
+variable "frontend_auto_scaling_policy_scale_out_cooldown" {
+  type    = number
+  default = 120
+}
+
+variable "frontend_auto_scaling_policy_scale_in_cooldown" {
+  type    = number
+  default = 300
+}
+
 variable "app_port" {
   type    = number
   default = 3000


### PR DESCRIPTION

## What?

Add auto scaling config for frontend.

Variables created to override min and max counts, cpu and memory trigger thresholds, and cpu and memory for the app.
Includes scale out and scale in cooldown periods too.

Applies only in sandpit, switched off in all other environments.

## Why?

The frontend apps should be able to scale according to demand.

## Related PRs

https://github.com/alphagov/di-authentication-account-management/pull/461
