### PR TITLE
AUT-213: rollout auto scaling to int and staging

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,4 +1,5 @@
 environment         = "build"
 common_state_bucket = "digital-identity-dev-tfstate"
 
-frontend_auto_scaling_enabled = true
+frontend_auto_scaling_enabled   = true
+frontend_task_definition_memory = 1024

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,2 +1,5 @@
 environment         = "integration"
 common_state_bucket = "digital-identity-dev-tfstate"
+
+frontend_auto_scaling_enabled   = true
+frontend_task_definition_memory = 1024

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -1,2 +1,5 @@
 environment         = "staging"
 common_state_bucket = "di-auth-staging-tfstate"
+
+frontend_auto_scaling_enabled   = true
+frontend_task_definition_memory = 1024


### PR DESCRIPTION

## What?

Rollout auto scaling to int and staging.

Reduce memory in build, int and staging to 1GB as a first step.  

We should be able to reduce both CPU and memory down further later on and scale out instead given the existing headroom.

## Why?

Reduce memory to 1GB as memory is constant regardless of load and is only running at about 7%.

Scaling up and down has been proven in build using the performance tests.

## Related PRs

#591 
#592 
