### PR TITLE
AUT-213: remove memory override as combo not supported

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,5 +1,4 @@
 environment         = "build"
 common_state_bucket = "digital-identity-dev-tfstate"
 
-frontend_auto_scaling_enabled   = true
-frontend_task_definition_memory = 1024
+frontend_auto_scaling_enabled = true

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,5 +1,4 @@
 environment         = "integration"
 common_state_bucket = "digital-identity-dev-tfstate"
 
-frontend_auto_scaling_enabled   = true
-frontend_task_definition_memory = 1024
+frontend_auto_scaling_enabled = true

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -1,5 +1,4 @@
 environment         = "staging"
 common_state_bucket = "di-auth-staging-tfstate"
 
-frontend_auto_scaling_enabled   = true
-frontend_task_definition_memory = 1024
+frontend_auto_scaling_enabled = true


### PR DESCRIPTION
## What?

Remove memory override as combo not supported

## Why?

1 CPU and 1 GB memory is not supported by Fargate so leaving at 2GB memory for the moment

## Related PRs

#593 
