### PR TITLE
BAU: Allow Notify test number

### DIFF
--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -1,7 +1,11 @@
 import { isValidPhoneNumber } from "libphonenumber-js/mobile";
 
+const ALLOWED_TEST_NUMBERS = ["07700900222"];
+
 export function containsUKMobileNumber(value: string): boolean {
-  return isValidPhoneNumber(value, "GB");
+  return (
+    ALLOWED_TEST_NUMBERS.includes(value) || isValidPhoneNumber(value, "GB")
+  );
 }
 
 export function containsInternationalMobileNumber(value: string): boolean {

--- a/test/unit/utils/phone-number.test.ts
+++ b/test/unit/utils/phone-number.test.ts
@@ -53,6 +53,10 @@ describe("phone-number", () => {
     it("should return false when premium rate number entered", () => {
       expect(containsUKMobileNumber("0909 8790000")).to.equal(false);
     });
+
+    it("should return true with a notify test number", () => {
+      expect(containsUKMobileNumber("07700900222")).to.equal(true);
+    });
   });
 
   describe("containsNumbersOrSpacesOnly", () => {


### PR DESCRIPTION
## What?

- Allow the test number `07700900222`, this is a Notify test number, but does not pass UI validation as it is not valid number.

## Why?

Required for end-to-end testing.