### PR TITLE
BAU: align prod frontend redis size with other redis

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,3 +1,4 @@
 environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
 ecs_desired_count   = 4
+redis_node_size     = "cache.m4.xlarge"


### PR DESCRIPTION
## What?

Align prod frontend redis size with other redis.

Set to 'cache.m4.xlarge'.

## Why?

Other prod redis instances have this size.
