### PR TITLE
BAU: Scale down Fargate in Pre Prod environments

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -1,4 +1,6 @@
 environment         = "build"
 common_state_bucket = "digital-identity-dev-tfstate"
 
-frontend_auto_scaling_enabled = true
+frontend_auto_scaling_enabled   = true
+frontend_task_definition_cpu    = 512
+frontend_task_definition_memory = 1024

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -1,4 +1,6 @@
 environment         = "integration"
 common_state_bucket = "digital-identity-dev-tfstate"
 
-frontend_auto_scaling_enabled = true
+frontend_auto_scaling_enabled   = true
+frontend_task_definition_cpu    = 512
+frontend_task_definition_memory = 1024

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -1,4 +1,6 @@
 environment         = "staging"
 common_state_bucket = "di-auth-staging-tfstate"
 
-frontend_auto_scaling_enabled = true
+frontend_auto_scaling_enabled   = true
+frontend_task_definition_cpu    = 512
+frontend_task_definition_memory = 1024


### PR DESCRIPTION
## What?

Scale down Fargate in Pre Prod environments.

## Why?

CPU currently maxes at 7% and Memory is always static at 7% in build so there is lot's of headroom, more so in int and staging.
Let the environments scale out if needed as an optimisation.
Container size to be moved to prod after some time, aligning other environments first.

## Related PRs

#592 
#593 
#594 
