### PR TITLE
Add spinner to IPV journey

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -81,6 +81,7 @@ export const API_ENDPOINTS = {
   RESET_PASSWORD: "/reset-password",
   IPV_AUTHORIZE: "/ipv-authorize",
   DOC_CHECKING_APP_AUTHORIZE: "/doc-checking-app-authorize",
+  IPV_PROCESSING_IDENTITY: "/processing-identity",
 };
 
 export const ERROR_MESSAGES = {
@@ -163,6 +164,8 @@ export const OIDC_ERRORS = {
 };
 
 export const IPV_ERROR_CODES = {
-  AccountNotCreated_IPV: "AccountNotCreated_IPV",
+  ACCOUNT_NOT_CREATED: "Account not created",
+  IDENTITY_PROCESSING_TIMEOUT: "Identity check timeout",
 };
+
 export const COOKIES_PREFERENCES_SET = "cookies_preferences_set";

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -155,3 +155,30 @@
 .govuk-input--disabled {
   background-color: govuk-colour("light-grey", $legacy: "grey-3");
 }
+
+.ccms-loader {
+  border: 12px solid #DEE0E2;
+  border-radius: 50%;
+  border-top-color: #005EA5;
+  width: 80px;
+  height: 80px;
+  -webkit-animation: spin 2s linear infinite;
+  animation: spin 2s linear infinite;
+}
+@-webkit-keyframes spin {
+  0% { -webkit-transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); }
+}
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.centre{
+  margin-left:auto;
+  margin-right:auto;
+}
+
+.text-centre{
+  text-align: center;
+}

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block head %}
+
   <!--[if !IE 8]><!-->
     <link href="/public/style.css" rel="stylesheet">
   <!--<![endif]-->
@@ -18,6 +19,8 @@
   <!--[if lt IE 9]>
     <script src="/html5-shiv/html5shiv.js"></script>
   <![endif]-->
+
+{% block headMetaData %}{% endblock %}
 
 {% endblock %}
 

--- a/src/components/prove-identity-callback/index.njk
+++ b/src/components/prove-identity-callback/index.njk
@@ -1,0 +1,12 @@
+{% extends "common/layout/base.njk" %}
+{% set pageTitleName = 'pages.proveIdentityCheck.title' | translate | replace("[serviceName]", serviceName) %}
+
+{% block headMetaData %}
+    <meta http-equiv="refresh" content="5">
+{% endblock %}
+
+{% block content %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.proveIdentityCheck.header' | translate | replace("[serviceName]", serviceName) }}</h1>
+    <div class="ccms-loader centre"></div>
+    <p class="govuk-body text-centre">loading</p>
+{% endblock %}

--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -1,17 +1,55 @@
 import { Request, Response } from "express";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { ExpressRouteFunc } from "../../types";
+import {
+  IdentityProcessingStatus,
+  ProveIdentityCallbackServiceInterface,
+} from "./types";
+import { proveIdentityCallbackService } from "./prove-identity-callback-service";
+import { IPV_ERROR_CODES, OIDC_ERRORS } from "../../app.constants";
+import { createServiceRedirectErrorUrl } from "../../utils/error";
 
-export function proveIdentityCallbackGet(req: Request, res: Response): void {
-  const { clientSessionId } = res.locals;
+export function proveIdentityCallbackGet(
+  service: ProveIdentityCallbackServiceInterface = proveIdentityCallbackService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+    const clientName = req.session.client.name;
+    const email = req.session.user.email;
 
-  const redirectPath = getNextPathAndUpdateJourney(
-    req,
-    req.path,
-    USER_JOURNEY_EVENTS.PROVE_IDENTITY_CALLBACK,
-    {},
-    clientSessionId
-  );
+    const response = await service.processIdentity(
+      email,
+      req.ip,
+      sessionId,
+      clientSessionId,
+      persistentSessionId
+    );
 
-  res.redirect(redirectPath);
+    if (response.data.status === IdentityProcessingStatus.PROCESSING) {
+      return res.render("prove-identity-callback/index.njk", {
+        serviceName: clientName,
+      });
+    }
+
+    let redirectPath;
+
+    if (response.data.status === IdentityProcessingStatus.COMPLETED) {
+      redirectPath = getNextPathAndUpdateJourney(
+        req,
+        req.path,
+        USER_JOURNEY_EVENTS.PROVE_IDENTITY_CALLBACK,
+        {},
+        clientSessionId
+      );
+    } else {
+      redirectPath = createServiceRedirectErrorUrl(
+        req.session.client.redirectUri,
+        OIDC_ERRORS.ACCESS_DENIED,
+        IPV_ERROR_CODES.IDENTITY_PROCESSING_TIMEOUT
+      );
+    }
+
+    return res.redirect(redirectPath);
+  };
 }

--- a/src/components/prove-identity-callback/prove-identity-callback-routes.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-routes.ts
@@ -4,6 +4,8 @@ import * as express from "express";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
 import { proveIdentityCallbackGet } from "./prove-identity-callback-controller";
+import { asyncHandler } from "../../utils/async";
+import { processIdentityRateLimitMiddleware } from "../../middleware/process-identity-rate-limit-middleware";
 
 const router = express.Router();
 
@@ -11,7 +13,8 @@ router.get(
   PATH_NAMES.PROVE_IDENTITY_CALLBACK,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  proveIdentityCallbackGet
+  processIdentityRateLimitMiddleware,
+  asyncHandler(proveIdentityCallbackGet())
 );
 
 export { router as proveIdentityCallbackRouter };

--- a/src/components/prove-identity-callback/prove-identity-callback-service.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-service.ts
@@ -1,0 +1,41 @@
+import {
+  createApiResponse,
+  getRequestConfig,
+  Http,
+  http,
+} from "../../utils/http";
+import { API_ENDPOINTS } from "../../app.constants";
+import { ApiResponseResult } from "../../types";
+import {
+  ProcessIdentityResponse,
+  ProveIdentityCallbackServiceInterface,
+} from "./types";
+
+export function proveIdentityCallbackService(
+  axios: Http = http
+): ProveIdentityCallbackServiceInterface {
+  const identityProcessed = async function (
+    email: string,
+    sourceIp: string,
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string
+  ): Promise<ApiResponseResult<ProcessIdentityResponse>> {
+    const response = await axios.client.post<ProcessIdentityResponse>(
+      API_ENDPOINTS.IPV_PROCESSING_IDENTITY,
+      { email: email },
+      getRequestConfig({
+        sourceIp: sourceIp,
+        sessionId: sessionId,
+        clientSessionId: clientSessionId,
+        persistentSessionId: persistentSessionId,
+      })
+    );
+
+    return createApiResponse<ProcessIdentityResponse>(response);
+  };
+
+  return {
+    processIdentity: identityProcessed,
+  };
+}

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
@@ -4,7 +4,11 @@ import { describe } from "mocha";
 import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
 
-import { PATH_NAMES } from "../../../app.constants";
+import {
+  IPV_ERROR_CODES,
+  OIDC_ERRORS,
+  PATH_NAMES,
+} from "../../../app.constants";
 import {
   mockRequest,
   mockResponse,
@@ -12,6 +16,10 @@ import {
   ResponseOutput,
 } from "mock-req-res";
 import { proveIdentityCallbackGet } from "../prove-identity-callback-controller";
+import {
+  IdentityProcessingStatus,
+  ProveIdentityCallbackServiceInterface,
+} from "../types";
 
 describe("prove identity callback controller", () => {
   let req: RequestOutput;
@@ -20,7 +28,13 @@ describe("prove identity callback controller", () => {
   beforeEach(() => {
     req = mockRequest({
       path: PATH_NAMES.PROVE_IDENTITY_CALLBACK,
-      session: { client: {}, user: {} },
+      session: {
+        client: {
+          redirectUri: "http://someservice.com/auth",
+          clientName: "test service",
+        },
+        user: { email: "test@test.com" },
+      },
       log: { info: sinon.fake() },
     });
     res = mockResponse();
@@ -31,10 +45,65 @@ describe("prove identity callback controller", () => {
   });
 
   describe("proveIdentityCallbackGet", () => {
-    it("should redirect to auth code", () => {
-      proveIdentityCallbackGet(req as Request, res as Response);
+    it("should redirect to auth code when identity processing complete", async () => {
+      const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
+        processIdentity: sinon.fake.returns({
+          success: true,
+          data: {
+            status: IdentityProcessingStatus.COMPLETED,
+          },
+        }),
+      };
+      await proveIdentityCallbackGet(fakeProveIdentityService)(
+        req as Request,
+        res as Response
+      );
 
       expect(res.redirect).to.have.been.calledWith(PATH_NAMES.AUTH_CODE);
+    });
+
+    it("should render index when identity is being processed ", async () => {
+      const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
+        processIdentity: sinon.fake.returns({
+          success: true,
+          data: {
+            status: IdentityProcessingStatus.PROCESSING,
+          },
+        }),
+      };
+
+      await proveIdentityCallbackGet(fakeProveIdentityService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.render).to.have.been.calledWith(
+        "prove-identity-callback/index.njk"
+      );
+    });
+
+    it("should redirect back to service when identity processing has errored", async () => {
+      const fakeProveIdentityService: ProveIdentityCallbackServiceInterface = {
+        processIdentity: sinon.fake.returns({
+          success: true,
+          data: {
+            status: IdentityProcessingStatus.ERROR,
+          },
+        }),
+      };
+
+      await proveIdentityCallbackGet(fakeProveIdentityService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.been.calledWith(
+        `http://someservice.com/auth?error=${
+          OIDC_ERRORS.ACCESS_DENIED
+        }&error_description=${encodeURIComponent(
+          IPV_ERROR_CODES.IDENTITY_PROCESSING_TIMEOUT
+        )}`
+      );
     });
   });
 });

--- a/src/components/prove-identity-callback/types.ts
+++ b/src/components/prove-identity-callback/types.ts
@@ -1,0 +1,21 @@
+import { ApiResponseResult, DefaultApiResponse } from "../../types";
+
+export interface ProveIdentityCallbackServiceInterface {
+  processIdentity: (
+    email: string,
+    sourceIp: string,
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string
+  ) => Promise<ApiResponseResult<ProcessIdentityResponse>>;
+}
+
+export interface ProcessIdentityResponse extends DefaultApiResponse {
+  status: IdentityProcessingStatus;
+}
+
+export enum IdentityProcessingStatus {
+  COMPLETED = "COMPLETED",
+  ERROR = "ERROR",
+  PROCESSING = "PROCESSING",
+}

--- a/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
+++ b/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
@@ -2,24 +2,18 @@ import { Request, Response } from "express";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { IPV_ERROR_CODES, OIDC_ERRORS, PATH_NAMES } from "../../app.constants";
+import { createServiceRedirectErrorUrl } from "../../utils/error";
 
-function getUseAlternativePYIMethodError(redirectUri: string) {
-  const redirect = new URL(redirectUri);
-  redirect.searchParams.append("error", OIDC_ERRORS.ACCESS_DENIED);
-  redirect.searchParams.append(
-    "error_description",
-    IPV_ERROR_CODES.AccountNotCreated_IPV
-  );
-  return redirect.href;
-}
 export function proveIdentityWelcomeGet(req: Request, res: Response): void {
   res.render(
     req.session.user.isAuthenticated
       ? "prove-identity-welcome/index-existing-session.njk"
       : "prove-identity-welcome/index.njk",
     {
-      redirectUri: getUseAlternativePYIMethodError(
-        req.session.client.redirectUri
+      redirectUri: createServiceRedirectErrorUrl(
+        req.session.client.redirectUri,
+        OIDC_ERRORS.ACCESS_DENIED,
+        IPV_ERROR_CODES.ACCOUNT_NOT_CREATED
       ),
     }
   );
@@ -30,7 +24,11 @@ export function proveIdentityWelcomePost(req: Request, res: Response): void {
 
   if (redirect) {
     return res.redirect(
-      getUseAlternativePYIMethodError(req.session.client.redirectUri)
+      createServiceRedirectErrorUrl(
+        req.session.client.redirectUri,
+        OIDC_ERRORS.ACCESS_DENIED,
+        IPV_ERROR_CODES.ACCOUNT_NOT_CREATED
+      )
     );
   }
 

--- a/src/components/prove-identity-welcome/tests/prove-identity-welcome-controller.test.ts
+++ b/src/components/prove-identity-welcome/tests/prove-identity-welcome-controller.test.ts
@@ -76,7 +76,11 @@ describe("prove your identity welcome controller", () => {
       proveIdentityWelcomePost(req as Request, res as Response);
 
       expect(res.redirect).to.have.been.calledWith(
-        `http://someservice.com/auth?error=${OIDC_ERRORS.ACCESS_DENIED}&error_description=${IPV_ERROR_CODES.AccountNotCreated_IPV}`
+        `http://someservice.com/auth?error=${
+          OIDC_ERRORS.ACCESS_DENIED
+        }&error_description=${encodeURIComponent(
+          IPV_ERROR_CODES.ACCOUNT_NOT_CREATED
+        )}`
       );
     });
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1340,6 +1340,12 @@
         "paragraph1":"If you don't have a passport, ",
         "linkText": "you can prove your identity another way"
       }
+    },
+    "proveIdentityCheck": {
+      "title": "Return you to the [serviceName] service",
+      "header": "Return you to the [serviceName] service",
+      "paragraph1": "loading",
+      "paragraph2": "We're still trying"
     }
   }
 }

--- a/src/middleware/process-identity-rate-limit-middleware.ts
+++ b/src/middleware/process-identity-rate-limit-middleware.ts
@@ -1,0 +1,28 @@
+import { NextFunction, Request, Response } from "express";
+import { createServiceRedirectErrorUrl } from "../utils/error";
+import { IPV_ERROR_CODES, OIDC_ERRORS } from "../app.constants";
+import { addSecondsToDate } from "../utils/date";
+
+export function processIdentityRateLimitMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const requestStart = req.session.user.identityProcessStart;
+  const now = new Date();
+  if (requestStart) {
+    if (now.getTime() > requestStart.getTime()) {
+      return res.redirect(
+        createServiceRedirectErrorUrl(
+          req.session.client.redirectUri,
+          OIDC_ERRORS.ACCESS_DENIED,
+          IPV_ERROR_CODES.IDENTITY_PROCESSING_TIMEOUT
+        )
+      );
+    }
+  } else {
+    req.session.user.identityProcessStart = addSecondsToDate(60);
+  }
+
+  next();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface UserSession {
   isIdentityRequired?: boolean;
   isUpliftRequired?: boolean;
   docCheckingAppUser?: boolean;
+  identityProcessStart?: Date;
 }
 
 export interface UserSessionClient {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,3 @@
+export function addSecondsToDate(seconds: number): Date {
+  return new Date(new Date().getTime() + 1000 * seconds);
+}

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -24,3 +24,23 @@ export class ErrorWithLevel extends Error {
     this.level = level;
   }
 }
+
+export function createServiceRedirectErrorUrl(
+  redirectUri: string,
+  error: string,
+  errorDescription: string
+): string {
+  const redirect = new URL(redirectUri);
+  const params = {
+    error: error,
+    error_description: errorDescription,
+  };
+
+  return (
+    redirect +
+    "?" +
+    Object.entries(params)
+      .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+      .join("&")
+  );
+}

--- a/test/unit/middleware/process-identity-rate-limit-middleware.test.ts
+++ b/test/unit/middleware/process-identity-rate-limit-middleware.test.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { NextFunction } from "express";
+import { sinon } from "../../utils/test-utils";
+import { PATH_NAMES } from "../../../src/app.constants";
+import { mockRequest, mockResponse } from "mock-req-res";
+import { processIdentityRateLimitMiddleware } from "../../../src/middleware/process-identity-rate-limit-middleware";
+import { addSecondsToDate } from "../../../src/utils/date";
+
+describe("process identity rate limit middleware", () => {
+  it("Should call next when first request", () => {
+    const req = mockRequest({
+      path: PATH_NAMES.PROVE_IDENTITY_CALLBACK,
+      session: { user: {} },
+    });
+    const res = mockResponse();
+    const nextFunction: NextFunction = sinon.fake();
+
+    processIdentityRateLimitMiddleware(req, res, nextFunction);
+
+    expect(res.redirect).to.not.have.been.called;
+    expect(nextFunction).to.have.been.called;
+  });
+
+  it("Should call next when request is in time period", () => {
+    const req = mockRequest({
+      path: PATH_NAMES.PROVE_IDENTITY_CALLBACK,
+      session: {
+        user: {
+          identityProcessStart: addSecondsToDate(60),
+        },
+      },
+    });
+    const res = mockResponse();
+    const nextFunction: NextFunction = sinon.fake();
+
+    processIdentityRateLimitMiddleware(req, res, nextFunction);
+
+    expect(res.redirect).to.not.have.been.called;
+    expect(nextFunction).to.have.been.called;
+  });
+
+  it("Should call redirect to service when request is not time period", () => {
+    const req = mockRequest({
+      path: PATH_NAMES.PROVE_IDENTITY_CALLBACK,
+      session: {
+        user: {
+          identityProcessStart: addSecondsToDate(-60),
+        },
+        client: { redirectUri: "https://some-service.com/auth" },
+      },
+    });
+    const res = mockResponse();
+    const nextFunction: NextFunction = sinon.fake();
+
+    processIdentityRateLimitMiddleware(req, res, nextFunction);
+
+    expect(res.redirect).to.have.been.called;
+    expect(nextFunction).to.not.have.been.called;
+  });
+});


### PR DESCRIPTION
## What?

Add spinner to IPV journey

## Why?

Due to the nature of SPOT and performance issues a spinner has been added to IPV journey to allow the response from SPOT to be processed before begin redirected back to the RP.
