### PR TITLE
Add state param to RP error redirects

### DIFF
--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -69,6 +69,7 @@ export function landingGet(
       startAuthResponse.data.user.consentRequired;
     req.session.client.prompt = loginPrompt;
     req.session.client.redirectUri = startAuthResponse.data.client.redirectUri;
+    req.session.client.state = startAuthResponse.data.client.state;
 
     req.session.user.isIdentityRequired =
       startAuthResponse.data.user.identityRequired;

--- a/src/components/landing/types.ts
+++ b/src/components/landing/types.ts
@@ -11,6 +11,7 @@ export interface ClientInfo {
   serviceType: string;
   cookieConsentShared: boolean;
   redirectUri: string;
+  state: string;
 }
 
 export interface UserSessionInfo {

--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -46,7 +46,8 @@ export function proveIdentityCallbackGet(
       redirectPath = createServiceRedirectErrorUrl(
         req.session.client.redirectUri,
         OIDC_ERRORS.ACCESS_DENIED,
-        IPV_ERROR_CODES.IDENTITY_PROCESSING_TIMEOUT
+        IPV_ERROR_CODES.IDENTITY_PROCESSING_TIMEOUT,
+        req.session.client.state
       );
     }
 

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-controller.test.ts
@@ -25,6 +25,8 @@ describe("prove identity callback controller", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
 
+  const STATE = "ndhd7d7d";
+
   beforeEach(() => {
     req = mockRequest({
       path: PATH_NAMES.PROVE_IDENTITY_CALLBACK,
@@ -32,6 +34,7 @@ describe("prove identity callback controller", () => {
         client: {
           redirectUri: "http://someservice.com/auth",
           clientName: "test service",
+          state: STATE,
         },
         user: { email: "test@test.com" },
       },
@@ -102,7 +105,7 @@ describe("prove identity callback controller", () => {
           OIDC_ERRORS.ACCESS_DENIED
         }&error_description=${encodeURIComponent(
           IPV_ERROR_CODES.IDENTITY_PROCESSING_TIMEOUT
-        )}`
+        )}&state=${encodeURIComponent(STATE)}`
       );
     });
   });

--- a/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
+++ b/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
@@ -13,7 +13,8 @@ export function proveIdentityWelcomeGet(req: Request, res: Response): void {
       redirectUri: createServiceRedirectErrorUrl(
         req.session.client.redirectUri,
         OIDC_ERRORS.ACCESS_DENIED,
-        IPV_ERROR_CODES.ACCOUNT_NOT_CREATED
+        IPV_ERROR_CODES.ACCOUNT_NOT_CREATED,
+        req.session.client.state
       ),
     }
   );
@@ -27,7 +28,8 @@ export function proveIdentityWelcomePost(req: Request, res: Response): void {
       createServiceRedirectErrorUrl(
         req.session.client.redirectUri,
         OIDC_ERRORS.ACCESS_DENIED,
-        IPV_ERROR_CODES.ACCOUNT_NOT_CREATED
+        IPV_ERROR_CODES.ACCOUNT_NOT_CREATED,
+        req.session.client.state
       )
     );
   }

--- a/src/components/prove-identity-welcome/tests/prove-identity-welcome-controller.test.ts
+++ b/src/components/prove-identity-welcome/tests/prove-identity-welcome-controller.test.ts
@@ -25,11 +25,16 @@ describe("prove your identity welcome controller", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
 
+  const STATE = "ndhd7d7d";
+
   beforeEach(() => {
     req = mockRequest({
       path: PATH_NAMES.PROVE_IDENTITY_WELCOME,
       session: {
-        client: { redirectUri: "http://someservice.com/auth" },
+        client: {
+          redirectUri: "http://someservice.com/auth",
+          state: STATE,
+        },
         user: {},
       },
       log: { info: sinon.fake() },
@@ -80,7 +85,7 @@ describe("prove your identity welcome controller", () => {
           OIDC_ERRORS.ACCESS_DENIED
         }&error_description=${encodeURIComponent(
           IPV_ERROR_CODES.ACCOUNT_NOT_CREATED
-        )}`
+        )}&state=${encodeURIComponent(STATE)}`
       );
     });
 

--- a/src/middleware/process-identity-rate-limit-middleware.ts
+++ b/src/middleware/process-identity-rate-limit-middleware.ts
@@ -16,7 +16,8 @@ export function processIdentityRateLimitMiddleware(
         createServiceRedirectErrorUrl(
           req.session.client.redirectUri,
           OIDC_ERRORS.ACCESS_DENIED,
-          IPV_ERROR_CODES.IDENTITY_PROCESSING_TIMEOUT
+          IPV_ERROR_CODES.IDENTITY_PROCESSING_TIMEOUT,
+          req.session.client.state
         )
       );
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,4 +54,5 @@ export interface UserSessionClient {
   scopes?: string[];
   prompt?: string;
   redirectUri?: string;
+  state?: string;
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -28,12 +28,14 @@ export class ErrorWithLevel extends Error {
 export function createServiceRedirectErrorUrl(
   redirectUri: string,
   error: string,
-  errorDescription: string
+  errorDescription: string,
+  state: string
 ): string {
   const redirect = new URL(redirectUri);
   const params = {
     error: error,
     error_description: errorDescription,
+    state: state,
   };
 
   return (


### PR DESCRIPTION
## What?

Add state param to RP error redirects

## Why?

As state is mandatory it needs to be returned on errors that redirect back to the RP.
