### PR TITLE
Update ipv welcome page to use same route for all users

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -43,7 +43,6 @@ export const PATH_NAMES = {
   DOC_CHECKING_APP_CALLBACK: "/doc-checking-app-callback",
   PROVE_IDENTITY_CALLBACK: "/ipv-callback",
   HEALTHCHECK: "/healthcheck",
-  PROVE_IDENTITY_WELCOME_SESSION_EXISTS: "/prove-identity-welcome-session",
   PROVE_IDENTITY_WELCOME: "/prove-identity-welcome",
 };
 

--- a/src/components/prove-identity-welcome/index-existing-session.njk
+++ b/src/components/prove-identity-welcome/index-existing-session.njk
@@ -37,7 +37,7 @@
 
     <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph4' | translate}}</p>
 
-    <form id="form-tracking" action="/prove-identity-welcome-session" method="post" novalidate>
+    <form id="form-tracking" action="/prove-identity-welcome?auth=true" method="post" novalidate>
 
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
@@ -46,7 +46,7 @@
             "type": "Submit",
             "preventDoubleClick": true
         }) }}
-    <p class="govuk-body"> {{'pages.proveIdentityWelcome.existingSession.paragraph1' | translate}}<a href="{{ redirectUri }}">{{'pages.proveIdentityWelcome.existingSession.linkText' | translate}}</a>.</p>
+    <p class="govuk-body"> {{'pages.proveIdentityWelcome.existingSession.paragraph1' | translate}}<a class="govuk-link" href="{{ redirectUri }}">{{'pages.proveIdentityWelcome.existingSession.linkText' | translate}}</a>.</p>
     </form>
 {% endblock %}
 

--- a/src/components/prove-identity-welcome/prove-identity-welcome-routes.ts
+++ b/src/components/prove-identity-welcome/prove-identity-welcome-routes.ts
@@ -27,11 +27,4 @@ router.post(
   proveIdentityWelcomePost
 );
 
-router.post(
-  PATH_NAMES.PROVE_IDENTITY_WELCOME_SESSION_EXISTS,
-  validateSessionMiddleware,
-  allowUserJourneyMiddleware,
-  proveIdentityWelcomePost
-);
-
 export { router as proveIdentityWelcomeRouter };

--- a/src/components/prove-identity-welcome/prove-identity-welcome-validation.ts
+++ b/src/components/prove-identity-welcome/prove-identity-welcome-validation.ts
@@ -1,10 +1,11 @@
-import { body } from "express-validator";
+import { body, check } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 
 export function validateProveIdentityWelcomeRequest(): ValidationChainFunc {
   return [
     body("chooseWayPyi")
+      .if(check("auth").isEmpty())
       .notEmpty()
       .withMessage((value, { req }) => {
         return req.t("pages.proveIdentityWelcome.section3.errorMessage", {


### PR DESCRIPTION
## What?

Update prove your identity welcome page for an existing session so the continue button works.

## Why?

The continue button failed because there was a separate post route which is not in the state machine which wouldn't allow a user to continue. The page has been changed to point to the same post route as an non logged in user.