### PR TITLE
AUT-259 - Update the Zendesk form

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -141,6 +141,7 @@ export function contactUsQuestionsFormPost(
       questions: questions,
       themeQuestions: themeQuestions,
       referer: req.body.referer,
+      securityCodeSentMethod: req.body.securityCodeSentMethod,
     });
 
     return res.redirect(PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS);
@@ -192,7 +193,7 @@ export function getQuestionsFromFormType(
     },
     invalidSecurityCode: {
       optionalDescription: req.t(
-        "pages.contactUsQuestions.invalidSecurityCode.section1.header"
+        "pages.contactUsQuestions.invalidSecurityCode.section2.header"
       ),
     },
     noPhoneNumberAccess: {
@@ -202,7 +203,7 @@ export function getQuestionsFromFormType(
     },
     noSecurityCode: {
       optionalDescription: req.t(
-        "pages.contactUsQuestions.noSecurityCode.section1.header"
+        "pages.contactUsQuestions.noSecurityCode.section2.header"
       ),
     },
     noUKMobile: {

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -128,6 +128,7 @@ export function contactUsQuestionsFormPost(
         issueDescription: req.body.issueDescription,
         additionalDescription: req.body.additionalDescription,
         optionalDescription: req.body.optionalDescription,
+        moreDetailDescription: req.body.moreDetailDescription,
       },
       themes: { theme: req.body.theme, subtheme: req.body.subtheme },
       subject: "GOV.UK Accounts Feedback",
@@ -192,7 +193,7 @@ export function getQuestionsFromFormType(
       ),
     },
     invalidSecurityCode: {
-      optionalDescription: req.t(
+      moreDetailDescription: req.t(
         "pages.contactUsQuestions.invalidSecurityCode.section2.header"
       ),
     },
@@ -202,12 +203,12 @@ export function getQuestionsFromFormType(
       ),
     },
     noSecurityCode: {
-      optionalDescription: req.t(
+      moreDetailDescription: req.t(
         "pages.contactUsQuestions.noSecurityCode.section2.header"
       ),
     },
     noUKMobile: {
-      optionalDescription: req.t(
+      moreDetailDescription: req.t(
         "pages.contactUsQuestions.noUKMobile.section1.header"
       ),
     },

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -1,10 +1,20 @@
-import { body } from "express-validator";
+import { body, check } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import { ZENDESK_THEMES } from "../../app.constants";
 
 export function validateContactUsQuestionsRequest(): ValidationChainFunc {
   return [
+    body("securityCodeSentMethod")
+      .if(body("theme").equals("account_creation"))
+      .if(check("radio_buttons").notEmpty())
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.securityCodeSentMethod.errorMessage",
+          { value }
+        );
+      }),
     body("issueDescription")
       .optional()
       .notEmpty()

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -36,6 +36,15 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
           { value }
         );
       }),
+    body("moreDetailDescription")
+      .optional()
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.optionalDescriptionErrorMessage.message",
+          { value }
+        );
+      }),
     body("contact")
       .notEmpty()
       .withMessage((value, { req }) => {

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -87,6 +87,11 @@ export function contactUsService(
       htmlBody.push(`<p>${descriptions.optionalDescription}</p>`);
     }
 
+    if (descriptions.moreDetailDescription) {
+      htmlBody.push(`<span>[${questions.moreDetailDescription}]</span>`);
+      htmlBody.push(`<p>${descriptions.moreDetailDescription}</p>`);
+    }
+
     htmlBody.push(`<span>[Session ID]</span>`);
     htmlBody.push(`<p>${optionalData.sessionId}</p>`);
 

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -26,7 +26,8 @@ export function contactUsService(
             contactForm.optionalData,
             contactForm.questions,
             contactForm.themeQuestions,
-            contactForm.referer
+            contactForm.referer,
+            contactForm.securityCodeSentMethod
           ),
         },
         group_id: getZendeskGroupIdPublic(),
@@ -49,7 +50,8 @@ export function contactUsService(
     optionalData: OptionalData,
     questions: Questions,
     themeQuestions: ThemeQuestions,
-    referer: string
+    referer: string,
+    securityCodeSentMethod: string
   ) {
     const htmlBody = [];
 
@@ -59,6 +61,15 @@ export function contactUsService(
     if (themeQuestions.subthemeQuestion) {
       htmlBody.push(`<span>[Tell us what happened?]</span>`);
       htmlBody.push(`<p>${themeQuestions.subthemeQuestion}</p>`);
+    }
+
+    if (securityCodeSentMethod) {
+      let securityCodeMethod = "Email";
+      if (securityCodeSentMethod == "text_message") {
+        securityCodeMethod = "Text message";
+      }
+      htmlBody.push(`<span>[How was the security code sent?]</span>`);
+      htmlBody.push(`<p>${securityCodeMethod}</p>`);
     }
 
     if (descriptions.issueDescription) {

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.invalidSecurityCode.header' | translate }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+<form action="/contact-us-questions?radio_buttons=true" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
@@ -11,13 +11,42 @@
 <input type="hidden" name="formType" value="invalidSecurityCode"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
+{% if theme == 'account_creation' %}
+    {{ govukRadios({
+        idPrefix: "securityCodeSentMethod",
+        name: "securityCodeSentMethod",
+        fieldset: {
+            legend: {
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.header' | translate,
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: [
+            {
+                value: "email",
+                checked: securityCodeSentMethod === 'email',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
+            },
+            {
+                value: "text_message",
+                checked: securityCodeSentMethod === 'text_message',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
+            }
+        ],
+          errorMessage: {
+          text: errors['securityCodeSentMethod'].text
+          } if (errors['securityCodeSentMethod'])
+    }) }}
+{% endif %}
+
 {{ govukTextarea({
     label: {
-      text: 'pages.contactUsQuestions.invalidSecurityCode.section1.header' | translate,
+      text: 'pages.contactUsQuestions.invalidSecurityCode.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.invalidSecurityCode.section1.paragraph1' | translate
+        text: 'pages.contactUsQuestions.invalidSecurityCode.section2.hintText' | translate
       },
     id: "optionalDescription",
     name: "optionalDescription",

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -48,12 +48,12 @@
     hint: {
         text: 'pages.contactUsQuestions.invalidSecurityCode.section2.hintText' | translate
       },
-    id: "optionalDescription",
-    name: "optionalDescription",
-    value: optionalDescription,
+    id: "moreDetailDescription",
+    name: "moreDetailDescription",
+    value: moreDetailDescription,
     errorMessage: {
-        text: errors['optionalDescription'].text
-    } if (errors['optionalDescription'])
+        text: errors['moreDetailDescription'].text
+    } if (errors['moreDetailDescription'])
 }) }}
 
 {{ govukWarningText({

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.noSecurityCode.header' | translate }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+<form action="/contact-us-questions?radio_buttons=true" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
@@ -11,13 +11,43 @@
 <input type="hidden" name="formType" value="noSecurityCode"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
+{% if theme == 'account_creation' %}
+    {{ govukRadios({
+        idPrefix: "securityCodeSentMethod",
+        name: "securityCodeSentMethod",
+        fieldset: {
+            legend: {
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.header' | translate,
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: [
+            {
+                value: "email",
+                checked: securityCodeSentMethod === 'email',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
+            },
+            {
+                value: "text_message",
+                checked: securityCodeSentMethod === 'text_message',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
+            }
+        ],
+          errorMessage: {
+          text: errors['securityCodeSentMethod'].text
+          } if (errors['securityCodeSentMethod'])
+    }) }}
+{% endif %}
+
+
 {{ govukTextarea({
     label: {
-      text: 'pages.contactUsQuestions.noSecurityCode.section1.header' | translate,
+      text: 'pages.contactUsQuestions.noSecurityCode.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.noSecurityCode.section1.paragraph1' | translate
+        text: 'pages.contactUsQuestions.noSecurityCode.section2.hintText' | translate
       },
     id: "optionalDescription",
     name: "optionalDescription",

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -49,12 +49,12 @@
     hint: {
         text: 'pages.contactUsQuestions.noSecurityCode.section2.hintText' | translate
       },
-    id: "optionalDescription",
-    name: "optionalDescription",
-    value: optionalDescription,
+    id: "moreDetailDescription",
+    name: "moreDetailDescription",
+    value: moreDetailDescription,
     errorMessage: {
-        text: errors['optionalDescription'].text
-    } if (errors['optionalDescription'])
+        text: errors['moreDetailDescription'].text
+    } if (errors['moreDetailDescription'])
 }) }}
 
 {{ govukWarningText({

--- a/src/components/contact-us/questions/_no-uk-mobile-questions.njk
+++ b/src/components/contact-us/questions/_no-uk-mobile-questions.njk
@@ -19,12 +19,12 @@
     hint: {
         text: 'pages.contactUsQuestions.noUKMobile.section1.paragraph1' | translate
       },
-    id: "optionalDescription",
-    name: "optionalDescriptione",
-    value: optionalDescription,
+    id: "moreDetailDescription",
+    name: "moreDetailDescription",
+    value: moreDetailDescription,
     errorMessage: {
-        text: errors['optionalDescription'].text
-    } if (errors['optionalDescription'])
+        text: errors['moreDetailDescription'].text
+    } if (errors['moreDetailDescription'])
 }) }}
 
 {{ govukWarningText({

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -156,20 +156,19 @@ describe("Integration:: contact us - public user", () => {
 
   it("should return validation error when user has not selected how the security code was sent whilst creating an account", (done) => {
     request(app)
-      .post("/contact-us-questions")
+      .post("/contact-us-questions?radio_buttons=true")
       .type("form")
       .set("Cookie", cookies)
       .send({
         _csrf: token,
         theme: "account_creation",
         subtheme: "no_security_code",
-        issueDescription: "issue",
-        additionalDescription: "additional",
+        moreDetailDescription: "issue",
         contact: "false",
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#securityCodeSentMethod").text()).to.contains(
+        expect($("#securityCodeSentMethod-error").text()).to.contains(
           "Select whether the code was sent by email or text message"
         );
       })

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -154,6 +154,28 @@ describe("Integration:: contact us - public user", () => {
       .expect(400, done);
   });
 
+  it("should return validation error when user has not selected how the security code was sent whilst creating an account", (done) => {
+    request(app)
+      .post("/contact-us-questions")
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        theme: "account_creation",
+        subtheme: "no_security_code",
+        issueDescription: "issue",
+        additionalDescription: "additional",
+        contact: "false",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#securityCodeSentMethod").text()).to.contains(
+          "Select whether the code was sent by email or text message"
+        );
+      })
+      .expect(400, done);
+  });
+
   it("should redirect to success page when form submitted", (done) => {
     nock(zendeskApiUrl).post("/tickets.json").once().reply(200);
 

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -21,6 +21,7 @@ export interface Questions {
   issueDescription?: string;
   additionalDescription?: string;
   optionalDescription?: string;
+  moreDetailDescription?: string;
 }
 
 export interface ThemeQuestions {
@@ -32,6 +33,7 @@ export interface Descriptions {
   issueDescription?: string;
   additionalDescription?: string;
   optionalDescription?: string;
+  moreDetailDescription?: string;
 }
 
 export interface Themes {

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -9,6 +9,7 @@ export interface ContactForm {
   questions: Questions;
   themeQuestions: ThemeQuestions;
   referer: string;
+  securityCodeSentMethod?: string;
 }
 
 export interface OptionalData {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1223,20 +1223,38 @@
           "header": "If possible, tell us the URL of the page the error happened on?"
         }
       },
+      "securityCodeSentMethod": {
+        "header": "How was the security code sent?",
+        "radio1": "Email",
+        "radio2": "Text message",
+        "errorMessage": "Select whether the code was sent by email or text message"
+      },
       "noSecurityCode": {
         "title": "You did not receive a security code",
         "header": "You did not receive a security code",
         "section1": {
+          "header": "How was the security code sent?",
+          "radio1": "Email",
+          "radio2": "Text message",
+          "errorMessage": "Select whether the code was sent by email or text message"
+        },
+        "section2": {
           "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
+          "hintText": "You can add more detail, such as what happened when you entered the security code or what you were trying to do, or give us feedback"
         }
       },
       "invalidSecurityCode": {
         "title": "The security code does not work",
         "header": "The security code does not work",
         "section1": {
+          "header": "How was the security code sent?",
+          "radio1": "Email",
+          "radio2": "Text message",
+          "errorMessage": "Select whether the code was sent by email or text message"
+        },
+        "section2": {
           "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
+          "hintText": "You can add more detail, such as what happened when you entered the security code or what you were trying to do, or give us feedback"
         }
       },
       "noUKMobile": {
@@ -1340,6 +1358,12 @@
         "paragraph1":"If you don't have a passport, ",
         "linkText": "you can prove your identity another way"
       }
+    },
+    "proveIdentityCheck": {
+      "title": "Return you to the [serviceName] service",
+      "header": "Return you to the [serviceName] service",
+      "paragraph1": "loading",
+      "paragraph2": "We're still trying"
     }
   }
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1262,8 +1262,11 @@
         "header": "You do not have a UK mobile phone number",
         "section1": {
           "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
+          "paragraph1": "You can add more detail, such as what you were trying to do, or give us feedback"
         }
+      },
+      "optionalDescriptionErrorMessage": {
+        "message": "Enter more detail"
       },
       "forgottenPassword": {
         "title": "You’ve forgotten your password",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1262,8 +1262,11 @@
         "header": "You do not have a UK mobile phone number",
         "section1": {
           "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
+          "paragraph1": "You can add more detail, such as what you were trying to do, or give us feedback"
         }
+      },
+      "optionalDescriptionErrorMessage": {
+        "message": "Enter more detail"
       },
       "forgottenPassword": {
         "title": "You’ve forgotten your password",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1223,20 +1223,38 @@
           "header": "If possible, tell us the URL of the page the error happened on?"
         }
       },
+      "securityCodeSentMethod": {
+        "header": "How was the security code sent?",
+        "radio1": "Email",
+        "radio2": "Text message",
+        "errorMessage": "Select whether the code was sent by email or text message"
+      },
       "noSecurityCode": {
         "title": "You did not receive a security code",
         "header": "You did not receive a security code",
         "section1": {
+          "header": "How was the security code sent?",
+          "radio1": "Email",
+          "radio2": "Text message",
+          "errorMessage": "Select whether the code was sent by email or text message"
+        },
+        "section2": {
           "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
+          "hintText": "You can add more detail, such as what happened when you entered the security code or what you were trying to do, or give us feedback"
         }
       },
       "invalidSecurityCode": {
         "title": "The security code does not work",
         "header": "The security code does not work",
         "section1": {
+          "header": "How was the security code sent?",
+          "radio1": "Email",
+          "radio2": "Text message",
+          "errorMessage": "Select whether the code was sent by email or text message"
+        },
+        "section2": {
           "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback"
+          "hintText": "You can add more detail, such as what happened when you entered the security code or what you were trying to do, or give us feedback"
         }
       },
       "noUKMobile": {


### PR DESCRIPTION
## What?


- Add a new question `How was the security code sent?` which can either be answered Email or Text Message. 

This will change the following forms -

**Account creation routes only**
1. You did not receive a security code 
2. The security code did not work 


- Change the hint text 
- Make the `Anything else you want to us` question mandatory. If the question has been left blank then an error message 'Enter more detail' will be displayed.

This will change the following forms -

**Account creation and Sign in routes**
1. You did not receive a security code
2. The security code did not work 

**Account creation routes only**
4. You do not have a UK mobile phone number

## Why?

- We are trying to get more information from users to identify the cause of their issues. 
