### PR TITLE
AUT-301: Update contact-us link on terms and conditions page

### DIFF
--- a/src/components/common/footer/terms-conditions.njk
+++ b/src/components/common/footer/terms-conditions.njk
@@ -161,7 +161,7 @@
     {{'pages.termsAndConditions.section11.header' | translate}}
   </h2>
   <p class="govuk-body">
-    <a href="/support" class="govuk-link">{{'pages.termsAndConditions.section11.paragraph1.linkText' | translate}}</a>{{'pages.termsAndConditions.section11.paragraph1.text1' | translate}}
+    <a href="/contact-us" class="govuk-link">{{'pages.termsAndConditions.section11.paragraph1.linkText' | translate}}</a>{{'pages.termsAndConditions.section11.paragraph1.text1' | translate}}
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>{{'pages.termsAndConditions.section11.bulletPoint1' | translate}}</li>


### PR DESCRIPTION
## What?

Update contact-us link on terms and conditions page.

## Why?

The link currently goes to the 'Support' page when it should go to 'Contact Us' instead.
