### PR TITLE
AUT-416: Add 'Choose how to get security codes' screen.

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -44,6 +44,7 @@ export const PATH_NAMES = {
   PROVE_IDENTITY_CALLBACK: "/ipv-callback",
   HEALTHCHECK: "/healthcheck",
   PROVE_IDENTITY_WELCOME: "/prove-identity-welcome",
+  GET_SECURITY_CODES: "/get-security-codes",
 };
 
 export const HTTP_STATUS_CODES = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,7 @@ import {
   getRedisPort,
   getSessionExpiry,
   getSessionSecret,
+  supportMFAOptions,
 } from "./config";
 import { logErrorMiddleware } from "./middleware/log-error-middleware";
 import { enterEmailRouter } from "./components/enter-email/enter-email-routes";
@@ -68,6 +69,7 @@ import { proveIdentityWelcomeRouter } from "./components/prove-identity-welcome/
 import { proveIdentityCallbackRouter } from "./components/prove-identity-callback/prove-identity-callback-routes";
 import { docCheckingAppRouter } from "./components/doc-checking-app/doc-checking-app-routes";
 import { docCheckingAppCallbackRouter } from "./components/doc-checking-app-callback/doc-checking-app-callback-routes";
+import { multiFactorAuthenticationRouter } from "./components/multi-factor-authentication/multi-factor-authentication-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -83,6 +85,9 @@ function registerRoutes(app: express.Application, appEnvIsProduction: boolean) {
   app.use(resetPasswordCheckEmailRouter);
   app.use(checkYourEmailRouter);
   app.use(createPasswordRouter);
+  if (supportMFAOptions()) {
+    app.use(multiFactorAuthenticationRouter);
+  }
   app.use(enterPhoneNumberRouter);
   app.use(registerAccountCreatedRouter);
   app.use(footerRouter);

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -5,6 +5,7 @@ import { CreatePasswordServiceInterface } from "./types";
 import { BadRequestError } from "../../utils/error";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { getNextPathAndUpdateJourney } from "../common/constants";
+import { supportMFAOptions } from "../../config";
 
 export function createPasswordGet(req: Request, res: Response): void {
   res.render("create-password/index.njk");
@@ -36,6 +37,7 @@ export function createPasswordPost(
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
           requiresTwoFactorAuth: true,
+          supportMFAOptions: supportMFAOptions(),
         },
         res.locals.sessionId
       )

--- a/src/components/multi-factor-authentication/get-security-codes.njk
+++ b/src/components/multi-factor-authentication/get-security-codes.njk
@@ -1,0 +1,62 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% set pageTitleName = 'pages.getSecurityCodes.title' | translate %}
+
+{% block content %}
+
+{% include "common/errors/errorSummary.njk" %}
+
+{% set authAppDetailsTextHtml %}
+  <p class="govuk-body">{{'pages.getSecurityCodes.authAppDetails.paragraph1' | translate}}</p>
+  <p class="govuk-body">{{'pages.getSecurityCodes.authAppDetails.paragraph2' | translate}}</p>
+{% endset %}
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.getSecurityCodes.header' | translate}}</h1>
+
+<p class="govuk-body">{{'pages.getSecurityCodes.summary' | translate}}</p>
+
+<form action="/get-security-codes" method="post" novalidate>
+
+<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+{{ govukRadios({
+  idPrefix: "mfa-options",
+  name: "mfaOptions",
+  attributes: {
+    "id": "radio-mfa-options"
+  },
+  items: [
+    {
+      text: 'pages.getSecurityCodes.secondFactorRadios.textMessageText' | translate,
+      id: "mfa-options-text-message",
+      value: "SMS"
+    },
+    {
+      text: 'pages.getSecurityCodes.secondFactorRadios.authAppText' | translate,
+      id: "mfa-options-auth-app",
+      value: "AUTH_APP"
+    }
+  ],
+  errorMessage: {
+  text: errors['mfaOptions'].text
+  } if (errors['mfaOptions'])
+}) }}
+
+{{ govukDetails({
+  summaryText: 'pages.getSecurityCodes.authAppDetails.summaryText' | translate,
+  html: authAppDetailsTextHtml
+}) }}
+
+{{ govukButton({
+  "text": 'pages.getSecurityCodes.continueButtonText' | translate,
+  "type": "Submit",
+  "preventDoubleClick": true
+}) }}
+
+</form>
+
+{% endblock %}

--- a/src/components/multi-factor-authentication/multi-factor-authentication-controller.ts
+++ b/src/components/multi-factor-authentication/multi-factor-authentication-controller.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from "express";
+import { getNextPathAndUpdateJourney } from "../common/constants";
+import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+
+export function getSecurityCodesGet(_req: Request, res: Response): void {
+  res.render("multi-factor-authentication/get-security-codes.njk");
+}
+
+export function getSecurityCodesPost(req: Request, res: Response): void {
+  res.redirect(
+    getNextPathAndUpdateJourney(
+      req,
+      req.path,
+      req.body.mfaOptions === "AUTH_APP"
+        ? USER_JOURNEY_EVENTS.MFA_OPTION_AUTH_APP_SELECTED
+        : USER_JOURNEY_EVENTS.MFA_OPTION_SMS_SELECTED,
+      null,
+      res.locals.sessionId
+    )
+  );
+}

--- a/src/components/multi-factor-authentication/multi-factor-authentication-routes.ts
+++ b/src/components/multi-factor-authentication/multi-factor-authentication-routes.ts
@@ -1,0 +1,28 @@
+import { PATH_NAMES } from "../../app.constants";
+import * as express from "express";
+import {
+  getSecurityCodesGet,
+  getSecurityCodesPost,
+} from "./multi-factor-authentication-controller";
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import { validateMultiFactorAuthenticationRequest } from "./multi-factor-authentication-validation";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.GET_SECURITY_CODES,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  getSecurityCodesGet
+);
+
+router.post(
+  PATH_NAMES.GET_SECURITY_CODES,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  validateMultiFactorAuthenticationRequest(),
+  getSecurityCodesPost
+);
+
+export { router as multiFactorAuthenticationRouter };

--- a/src/components/multi-factor-authentication/multi-factor-authentication-validation.ts
+++ b/src/components/multi-factor-authentication/multi-factor-authentication-validation.ts
@@ -1,0 +1,18 @@
+import { body } from "express-validator";
+import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
+import { ValidationChainFunc } from "../../types";
+
+export function validateMultiFactorAuthenticationRequest(): ValidationChainFunc {
+  return [
+    body("mfaOptions")
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t("pages.getSecurityCodes.secondFactorRadios.errorMessage", {
+          value,
+        });
+      }),
+    validateBodyMiddleware(
+      "multi-factor-authentication/get-security-codes.njk"
+    ),
+  ];
+}

--- a/src/components/multi-factor-authentication/tests/multi-factor-authentication-controller.test.ts
+++ b/src/components/multi-factor-authentication/tests/multi-factor-authentication-controller.test.ts
@@ -1,0 +1,67 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import { PATH_NAMES } from "../../../app.constants";
+import {
+  getSecurityCodesGet,
+  getSecurityCodesPost,
+} from "../multi-factor-authentication-controller";
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
+
+describe("mutil-factor-authentication controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = mockRequest({
+      path: PATH_NAMES.GET_SECURITY_CODES,
+      session: { client: {}, user: {} },
+      log: { info: sinon.fake() },
+      t: sinon.fake(),
+      i18n: { language: "en" },
+    });
+    res = mockResponse();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("getSecurityCodesGet", () => {
+    it("should render get-security-codes page", () => {
+      getSecurityCodesGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "multi-factor-authentication/get-security-codes.njk"
+      );
+    });
+  });
+
+  describe("getSecurityCodesPost", () => {
+    it("should redirect to /enter-phone-number when text message selected", async () => {
+      req.body.mfaOptions = "SMS";
+
+      getSecurityCodesPost(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith(
+        PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER
+      );
+    });
+
+    it("should redirect to /enter-phone-number even when auth app selected until add code screen implemented", async () => {
+      req.body.mfaOptions = "AUTH_APP";
+
+      getSecurityCodesPost(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith(
+        PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER
+      );
+    });
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,10 @@ export function supportInternationalNumbers(): boolean {
   return process.env.SUPPORT_INTERNATIONAL_NUMBERS === "1";
 }
 
+export function supportMFAOptions(): boolean {
+  return process.env.SUPPORT_MFA_OPTIONS === "1";
+}
+
 export async function getRedisConfig(appEnv: string): Promise<RedisConfig> {
   const hostKey = `${appEnv}-${process.env.REDIS_KEY}-redis-master-host`;
   const portKey = `${appEnv}-${process.env.REDIS_KEY}-redis-port`;

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1367,6 +1367,22 @@
       "header": "Return you to the [serviceName] service",
       "paragraph1": "loading",
       "paragraph2": "We're still trying"
+    },
+    "getSecurityCodes": {
+      "title": "Choose how to get security codes",
+      "header": "Choose how to get security codes",
+      "summary": "To finish creating your account, you need to choose a way to prove it's you when you sign in.",
+      "secondFactorRadios": {
+        "textMessageText": "Text message",
+        "authAppText": "Authenticator app for smartphone, tablet or computer",
+        "errorMessage": "Select how you want to get security codes"
+      },
+      "authAppDetails": {
+        "summaryText": "What is an authenticator app?",
+        "paragraph1": "An authenticator app creates a security code that helps confirm it's you when you sign in.",
+        "paragraph2": "You can use an authenticator app on your smartphone, tablet or desktop computer.  Download an authenticator app for your smartphone or tablet from your app store or search online for an authenticator app for your computer."
+      },
+      "continueButtonText": "Continue"
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1367,6 +1367,22 @@
       "header": "Return you to the [serviceName] service",
       "paragraph1": "loading",
       "paragraph2": "We're still trying"
+    },
+    "getSecurityCodes": {
+      "title": "Choose how to get security codes",
+      "header": "Choose how to get security codes",
+      "summary": "To finish creating your account, you need to choose a way to prove it's you when you sign in.",
+      "secondFactorRadios": {
+        "textMessageText": "Text message",
+        "authAppText": "Authenticator app for smartphone, tablet or computer",
+        "errorMessage": "Select how you want to get security codes"
+      },
+      "authAppDetails": {
+        "summaryText": "What is an authenticator app?",
+        "paragraph1": "An authenticator app creates a security code that helps confirm it's you when you sign in.",
+        "paragraph2": "You can use an authenticator app on your smartphone, tablet or desktop computer.  Download an authenticator app for your smartphone or tablet from your app store or search online for an authenticator app for your computer."
+      },
+      "continueButtonText": "Continue"
     }
   }
 }


### PR DESCRIPTION

## What?

Add 'Choose how to get security codes' screen.

- Add the new screen.
- Add new environment config flag to switch mfa options on and off.
- Screen is currently switched-off in all environments, switch it on locally to test.
- Update state machine to navigate to the new page if the option is on.
- Currently goes to the 'Enter Phone Number' screen regardless of the option chosen as the 'Set up an authenticator app' screen is not yet available.
- There are separate tickets to update the create account drop-out flows, so the state machine has not been changed for this scenario.


## Why?

Users will be given a choice between using SMS and an authenticator app as a second factor.