### PR TITLE
AUT-424 - Update user support form with new page

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -118,6 +118,7 @@ export const ZENDESK_THEMES = {
   NO_UK_MOBILE_NUMBER: "no_uk_mobile_number",
   FORGOTTEN_PASSWORD: "forgotten_password",
   NO_PHONE_NUMBER_ACCESS: "no_phone_number_access",
+  PROVING_IDENTITY: "proving_identity",
 };
 
 export enum NOTIFICATION_TYPE {

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -25,6 +25,8 @@ const themeToPageTitle = {
     "pages.contactUsQuestions.anotherProblem.title",
   [ZENDESK_THEMES.SUGGESTIONS_FEEDBACK]:
     "pages.contactUsQuestions.suggestionOrFeedback.title",
+  [ZENDESK_THEMES.PROVING_IDENTITY]:
+    "pages.contactUsQuestions.provingIdentity.title",
 };
 
 const somethingElseSubThemeToPageTitle = {
@@ -233,6 +235,14 @@ export function getQuestionsFromFormType(
         "pages.contactUsQuestions.technicalError.section3.header"
       ),
     },
+    provingIdentity: {
+      issueDescription: req.t(
+        "pages.contactUsQuestions.provingIdentity.section1.header"
+      ),
+      additionalDescription: req.t(
+        "pages.contactUsQuestions.provingIdentity.section2.header"
+      ),
+    },
   };
 
   return formTypeToQuestions[formType];
@@ -246,9 +256,10 @@ export function getQuestionFromThemes(
   const themesToQuestions: { [key: string]: any } = {
     account_creation: req.t("pages.contactUsPublic.section3.radio1"),
     signing_in: req.t("pages.contactUsPublic.section3.radio2"),
-    something_else: req.t("pages.contactUsPublic.section3.radio3"),
-    email_subscriptions: req.t("pages.contactUsPublic.section3.radio4"),
-    suggestions_feedback: req.t("pages.contactUsPublic.section3.radio5"),
+    proving_identity: req.t("pages.contactUsPublic.section3.radio3"),
+    something_else: req.t("pages.contactUsPublic.section3.radio4"),
+    email_subscriptions: req.t("pages.contactUsPublic.section3.radio5"),
+    suggestions_feedback: req.t("pages.contactUsPublic.section3.radio6"),
   };
   const signinSubthemeToQuestions: { [key: string]: any } = {
     no_security_code: req.t(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -86,6 +86,9 @@ export function getErrorMessageForIssueDescription(
   if (theme === ZENDESK_THEMES.SUGGESTIONS_FEEDBACK) {
     return "pages.contactUsQuestions.suggestionOrFeedback.section1.errorMessage";
   }
+  if (theme === ZENDESK_THEMES.PROVING_IDENTITY) {
+    return "pages.contactUsQuestions.provingIdentity.section1.errorMessage";
+  }
   if (subtheme === ZENDESK_THEMES.ACCOUNT_NOT_FOUND) {
     return "pages.contactUsQuestions.accountNotFound.section1.errorMessage";
   }
@@ -115,6 +118,9 @@ export function getErrorMessageForAdditionalDescription(
   }
   if (theme === ZENDESK_THEMES.SOMETHING_ELSE) {
     return "pages.contactUsQuestions.anotherProblem.section2.errorMessage";
+  }
+  if (theme === ZENDESK_THEMES.PROVING_IDENTITY) {
+    return "pages.contactUsQuestions.provingIdentity.section2.errorMessage";
   }
   if (subtheme === ZENDESK_THEMES.TECHNICAL_ERROR) {
     return "pages.contactUsQuestions.technicalError.section2.errorMessage";

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -56,16 +56,20 @@
                 text: 'pages.contactUsPublic.section3.radio2' | translate
             },
             {
-                value: "something_else",
+                value: "proving_identity",
                 text: 'pages.contactUsPublic.section3.radio3' | translate
             },
             {
-                value: "email_subscriptions",
+                value: "something_else",
                 text: 'pages.contactUsPublic.section3.radio4' | translate
             },
             {
-                value: "suggestions_feedback",
+                value: "email_subscriptions",
                 text: 'pages.contactUsPublic.section3.radio5' | translate
+            },
+            {
+                value: "suggestions_feedback",
+                text: 'pages.contactUsPublic.section3.radio6' | translate
             }
         ],
           errorMessage: {

--- a/src/components/contact-us/questions/_proving-identity-problem-questions.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-questions.njk
@@ -1,0 +1,55 @@
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+  {{ 'pages.contactUsQuestions.provingIdentity.header' | translate }}
+</h1>
+
+<form action="/contact-us-questions" method="post" novalidate>
+
+<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+<input type="hidden" name="theme" value="{{theme}}"/>
+<input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="formType" value="provingIdentity"/>
+<input type="hidden" name="referer" value="{{referer}}"/>
+
+{{ govukTextarea({
+    label: {
+      text: 'pages.contactUsQuestions.provingIdentity.section1.header' | translate,
+      classes: "govuk-label--s"
+    },
+    id: "issueDescription",
+    name: "issueDescription",
+    value: issueDescription,
+    errorMessage: {
+        text: errors['issueDescription'].text
+    } if (errors['issueDescription'])
+}) }}
+
+{{ govukTextarea({
+    label: {
+      text: 'pages.contactUsQuestions.provingIdentity.section2.header' | translate,
+      classes: "govuk-label--s"
+    },
+    hint: {
+        text: 'pages.contactUsQuestions.provingIdentity.section2.paragraph1' | translate
+      },
+    id: "additionalDescription",
+    name: "additionalDescription",
+    value: additionalDescription,
+    errorMessage: {
+        text: errors['additionalDescription'].text
+    } if (errors['additionalDescription'])
+}) }}
+
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
+{% include 'contact-us/questions/_reply_by_email.njk' %}
+
+{{ govukButton({
+    "text": button_text|default("Send message", true),
+    "type": "Submit",
+    "preventDoubleClick": true
+}) }}
+
+</form>

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -62,4 +62,8 @@
         {% include 'contact-us/questions/_suggestion-feedback-questions.njk' %}
     {% endif %}
 
+    {% if theme == 'proving_identity' %}
+        {% include 'contact-us/questions/_proving-identity-problem-questions.njk' %}
+    {% endif %}
+
 {% endblock %}

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -94,5 +94,15 @@ describe("contact us controller", () => {
         "/contact-us-questions?theme=suggestions_feedback&referer=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
+    it("should redirect /contact-us-questions page when 'A problem proving your identity' radio option is chosen", async () => {
+      req.body.theme = ZENDESK_THEMES.PROVING_IDENTITY;
+      req.body.referer = REFERER;
+
+      contactUsFormPost(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith(
+        "/contact-us-questions?theme=proving_identity&referer=https%3A%2F%2Fgov.uk%2Fsign-in"
+      );
+    });
   });
 });

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -44,7 +44,7 @@ describe("contact us controller", () => {
   });
 
   describe("contactUsFormPost", () => {
-    it("should redirect /contact-us-further-information page when 'A problem signing in to your account' radio option is chosen", async () => {
+    it("should redirect /contact-us-further-information page when 'A problem signing in to your GOV.UK account' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.SIGNING_IN;
       req.body.referer = REFERER;
 
@@ -54,7 +54,7 @@ describe("contact us controller", () => {
         "/contact-us-further-information?theme=signing_in&referer=https%3A%2F%2Fgov.uk%2Fsign-in"
       );
     });
-    it("should redirect /contact-us-further-information page when 'A problem creating an account' radio option is chosen", async () => {
+    it("should redirect /contact-us-further-information page when 'A problem creating a GOV.UK account' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
       req.body.referer = REFERER;
 

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -76,6 +76,22 @@ describe("contact us questions controller", () => {
         referer: REFERER,
       });
     });
+
+    it("should render contact-us-questions if a 'A problem proving your identity' radio option was chosen", () => {
+      req.query.theme = ZENDESK_THEMES.PROVING_IDENTITY;
+      req.headers.referer = "/contact-us";
+      req.query.referer = REFERER;
+      contactUsQuestionsGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        theme: "proving_identity",
+        subtheme: undefined,
+        backurl: "/contact-us",
+        pageTitleHeading: "pages.contactUsQuestions.provingIdentity.title",
+        referer: REFERER,
+      });
+    });
+
     it("should redirect to contact-us when no theme is present in request", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1117,8 +1117,8 @@
       },
       "section3": {
         "header": "What are you contacting us about?",
-        "radio1": "A problem creating an account",
-        "radio2": "A problem signing in to your account",
+        "radio1": "A problem creating a GOV.UK account",
+        "radio2": "A problem signing in to your GOV.UK account",
         "radio3": "A problem proving your identity",
         "radio4": "Another problem using your GOV.UK account",
         "radio5": "GOV.UK email subscriptions",
@@ -1130,8 +1130,8 @@
     },
     "contactUsFurtherInformation": {
       "signingIn": {
-        "title": "A problem signing in to your account",
-        "header": "A problem signing in to your account",
+        "title": "A problem signing in to your GOV.UK account",
+        "header": "A problem signing in to your GOV.UK account",
         "section1": {
           "header": "Tell us what happened",
           "radio1": "You did not receive a security code",
@@ -1145,8 +1145,8 @@
         }
       },
       "accountCreation": {
-        "title": "A problem creating an account",
-        "header": "A problem creating an account",
+        "title": "A problem creating a GOV.UK account",
+        "header": "A problem creating a GOV.UK account",
         "section1": {
           "header": "Tell us what happened",
           "radio1": "You did not receive a security code",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1334,7 +1334,7 @@
       "title": "Your message has been submitted",
       "header": "Your message has been submitted",
       "paragraph1": "Thank you for your message.",
-      "paragraph2": "We’ll try to get back to you in 2 working days.",
+      "paragraph2": "We'll respond to you in 2 working days.",
       "paragraph3": {
         "linkHref": "https://www.gov.uk",
         "linkText": "Return to the GOV.UK homepage"

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1119,9 +1119,10 @@
         "header": "What are you contacting us about?",
         "radio1": "A problem creating an account",
         "radio2": "A problem signing in to your account",
-        "radio3": "Another problem using your GOV.UK account",
-        "radio4": "GOV.UK email subscriptions",
-        "radio5": "A suggestion or feedback about using your GOV.UK account",
+        "radio3": "A problem proving your identity",
+        "radio4": "Another problem using your GOV.UK account",
+        "radio5": "GOV.UK email subscriptions",
+        "radio6": "A suggestion or feedback about using your GOV.UK account",
         "errorMessage": "Select a reason for contacting us"
       },
       "submitButtonText": "Submit",
@@ -1221,6 +1222,19 @@
         },
         "section3": {
           "header": "If possible, tell us the URL of the page the error happened on?"
+        }
+      },
+      "provingIdentity": {
+        "title": "A problem proving your identity",
+        "header": "A problem proving your identity",
+        "section1": {
+          "header": "What were you trying to do?",
+          "errorMessage": "Enter what you were trying to do"
+        },
+        "section2": {
+          "header": "What happened?",
+          "paragraph1": "For example, did you see any warning or error messages?",
+          "errorMessage": "Enter what happened"
         }
       },
       "securityCodeSentMethod": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1113,7 +1113,7 @@
         "paragraph1": "Use this form to:",
         "bulletPoint1": "tell us about a problem you’re having with your GOV.UK account",
         "bulletPoint2": "suggest improvements or give feedback about your experience using your GOV.UK account",
-        "paragraph2": "Our office hours are 9:30am to 5:30pm, Monday to Friday."
+        "paragraph2": "Our office hours are 9:30am to 5:30pm, Monday to Friday. We'll respond to you by email in 2 working days."
       },
       "section3": {
         "header": "What are you contacting us about?",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1117,8 +1117,8 @@
       },
       "section3": {
         "header": "What are you contacting us about?",
-        "radio1": "A problem creating an account",
-        "radio2": "A problem signing in to your account",
+        "radio1": "A problem creating a GOV.UK account",
+        "radio2": "A problem signing in to your GOV.UK account",
         "radio3": "A problem proving your identity",
         "radio4": "Another problem using your GOV.UK account",
         "radio5": "GOV.UK email subscriptions",
@@ -1130,8 +1130,8 @@
     },
     "contactUsFurtherInformation": {
       "signingIn": {
-        "title": "A problem signing in to your account",
-        "header": "A problem signing in to your account",
+        "title": "A problem signing in to your GOV.UK account",
+        "header": "A problem signing in to your GOV.UK account",
         "section1": {
           "header": "Tell us what happened",
           "radio1": "You did not receive a security code",
@@ -1145,8 +1145,8 @@
         }
       },
       "accountCreation": {
-        "title": "A problem creating an account",
-        "header": "A problem creating an account",
+        "title": "A problem creating a GOV.UK account",
+        "header": "A problem creating a GOV.UK account",
         "section1": {
           "header": "Tell us what happened",
           "radio1": "You did not receive a security code",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1334,7 +1334,7 @@
       "title": "Your message has been submitted",
       "header": "Your message has been submitted",
       "paragraph1": "Thank you for your message.",
-      "paragraph2": "We’ll try to get back to you in 2 working days.",
+      "paragraph2": "We'll respond to you in 2 working days.",
       "paragraph3": {
         "linkHref": "https://www.gov.uk",
         "linkText": "Return to the GOV.UK homepage"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1119,9 +1119,10 @@
         "header": "What are you contacting us about?",
         "radio1": "A problem creating an account",
         "radio2": "A problem signing in to your account",
-        "radio3": "Another problem using your GOV.UK account",
-        "radio4": "GOV.UK email subscriptions",
-        "radio5": "A suggestion or feedback about using your GOV.UK account",
+        "radio3": "A problem proving your identity",
+        "radio4": "Another problem using your GOV.UK account",
+        "radio5": "GOV.UK email subscriptions",
+        "radio6": "A suggestion or feedback about using your GOV.UK account",
         "errorMessage": "Select a reason for contacting us"
       },
       "submitButtonText": "Submit",
@@ -1221,6 +1222,19 @@
         },
         "section3": {
           "header": "If possible, tell us the URL of the page the error happened on?"
+        }
+      },
+      "provingIdentity": {
+        "title": "A problem proving your identity",
+        "header": "A problem proving your identity",
+        "section1": {
+          "header": "What were you trying to do?",
+          "errorMessage": "Enter what you were trying to do"
+        },
+        "section2": {
+          "header": "What happened?",
+          "paragraph1": "For example, did you see any warning or error messages?",
+          "errorMessage": "Enter what happened"
         }
       },
       "securityCodeSentMethod": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1113,7 +1113,7 @@
         "paragraph1": "Use this form to:",
         "bulletPoint1": "tell us about a problem you’re having with your GOV.UK account",
         "bulletPoint2": "suggest improvements or give feedback about your experience using your GOV.UK account",
-        "paragraph2": "Our office hours are 9:30am to 5:30pm, Monday to Friday."
+        "paragraph2": "Our office hours are 9:30am to 5:30pm, Monday to Friday. We'll respond to you by email in 2 working days."
       },
       "section3": {
         "header": "What are you contacting us about?",


### PR DESCRIPTION
## What?

- Add new radio button on the first page of the support form names 'A problem proving your identity'
- Create a new page which the user is redirected too when they select that radio button.
- This page will contain 2 new mandatory text boxes, along with the generic `Can we reply to you by email?` question
- Update opening text on support form
- Update submit success text

## Why?

- So users have a clear path if they experience any issues when trying to prove their identity

## To review 

- Compare with content doc - https://docs.google.com/document/d/1DWfN09H17vyk-7H7tzKmDQ7NhSQxtpBtZDqdy8Vy5Tg/edit?pli=1#