### PR TITLE
AUT-199 - Show different content on enter phone number for user drop offs

### DIFF
--- a/src/components/common/verify-code/verify-code-controller.ts
+++ b/src/components/common/verify-code/verify-code-controller.ts
@@ -52,6 +52,7 @@ export function verifyCodePost(
 
       throw new BadRequestError(result.data.message, result.data.code);
     }
+    req.session.user.isAccountPartCreated = false;
 
     if (options.callback) {
       return options.callback(req, res);

--- a/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
@@ -56,6 +56,8 @@ describe("enter mfa controller", () => {
 
       expect(fakeService.verifyCode).to.have.been.calledOnce;
       expect(res.redirect).to.have.calledWith(PATH_NAMES.AUTH_CODE);
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.AUTH_CODE);
+      expect(req.session.user.isAccountPartCreated).to.be.eq(false);
     });
 
     it("should return error when invalid code entered", async () => {

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -93,6 +93,7 @@ export function enterPasswordPost(
 
     req.session.user.phoneNumber = userLogin.data.redactedPhoneNumber;
     req.session.user.isConsentRequired = userLogin.data.consentRequired;
+    req.session.user.isAccountPartCreated = !userLogin.data.phoneNumberVerified;
     req.session.user.isLatestTermsAndConditionsAccepted =
       userLogin.data.latestTermsAndConditionsAccepted;
 

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -52,6 +52,7 @@ describe("enter password controller", () => {
             mfaRequired: true,
             consentRequired: false,
             latestTermsAndConditionsAccepted: true,
+            phoneNumberVerified: true,
           },
           success: true,
         }),
@@ -78,13 +79,18 @@ describe("enter password controller", () => {
       )(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_MFA);
+      expect(req.session.user.isAccountPartCreated).to.be.eq(false);
     });
 
     it("should redirect to auth code when mfa is not required", async () => {
       const fakeService: EnterPasswordServiceInterface = {
         loginUser: sinon.fake.returns({
           success: true,
-          data: { redactedPhoneNumber: "******3456", mfaRequired: false },
+          data: {
+            redactedPhoneNumber: "******3456",
+            mfaRequired: false,
+            phoneNumberVerified: true,
+          },
         }),
       };
 
@@ -102,6 +108,7 @@ describe("enter password controller", () => {
       );
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.AUTH_CODE);
+      expect(req.session.user.isAccountPartCreated).to.be.eq(false);
     });
 
     it("should redirect to enter phone number when phone number is not verified", async () => {
@@ -131,6 +138,7 @@ describe("enter password controller", () => {
       expect(res.redirect).to.have.calledWith(
         PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER
       );
+      expect(req.session.user.isAccountPartCreated).to.be.eq(true);
     });
 
     it("should redirect to updated terms when terms and conditions not accepted", async () => {
@@ -139,6 +147,7 @@ describe("enter password controller", () => {
           data: {
             redactedPhoneNumber: "******3456",
             latestTermsAndConditionsAccepted: false,
+            phoneNumberVerified: true,
           },
           success: true,
         }),
@@ -160,6 +169,7 @@ describe("enter password controller", () => {
       expect(res.redirect).to.have.calledWith(
         PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS
       );
+      expect(req.session.user.isAccountPartCreated).to.be.eq(false);
     });
 
     it("should throw error when API call throws error", async () => {

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -16,9 +16,15 @@ import { prependInternationalPrefix } from "../../utils/phone-number";
 import { supportInternationalNumbers } from "../../config";
 
 export function enterPhoneNumberGet(req: Request, res: Response): void {
-  res.render("enter-phone-number/index.njk", {
-    supportInternationalNumbers: supportInternationalNumbers() ? true : null,
-  });
+  if (req.session.user.isAccountPartCreated) {
+    res.render("enter-phone-number/returning-user-index.njk", {
+      supportInternationalNumbers: supportInternationalNumbers() ? true : null,
+    });
+  } else {
+    res.render("enter-phone-number/index.njk", {
+      supportInternationalNumbers: supportInternationalNumbers() ? true : null,
+    });
+  }
 }
 
 export function enterPhoneNumberPost(

--- a/src/components/enter-phone-number/returning-user-index.njk
+++ b/src/components/enter-phone-number/returning-user-index.njk
@@ -1,0 +1,83 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set pageTitleName = 'pages.enterPhoneNumber.returningUser.title' | translate %}
+{% block content %}
+
+{% include "common/errors/errorSummary.njk" %}
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.returningUser.header' |
+  translate}}</h1>
+
+<form action="/enter-phone-number" method="post" novalidate>
+
+  <input type="hidden" name="_csrf" value="{{csrfToken}}" />
+   <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}" />
+
+  <p class="govuk-body">{{'pages.enterPhoneNumber.returningUser.info.paragraph1' | translate}}</p>
+  <p class="govuk-body">{{'pages.enterPhoneNumber.returningUser.info.paragraph2' | translate}}</p>
+
+  {{ govukInput({
+  label: {
+  text: 'pages.enterPhoneNumber.ukPhoneNumber.label' | translate
+  },
+  classes: "govuk-!-width-two-thirds",
+  id: "phoneNumber",
+  name: "phoneNumber",
+  type: "tel",
+  autocomplete: "tel",
+  errorMessage: {
+  text: errors['phoneNumber'].text
+  } if (errors['phoneNumber'])})
+  }}
+
+  {% if supportInternationalNumbers %}
+
+      {% set internationalNumberHtml %}
+      {{ govukInput({
+        id: "internationalPhoneNumber",
+        name: "internationalPhoneNumber",
+        type: "tel",
+        autocomplete: "tel",
+        classes: "govuk-!-width-two-thirds",
+        label: {
+          text: 'pages.enterPhoneNumber.internationalPhoneNumber.label' | translate
+        },
+        hint: {
+          text: 'pages.enterPhoneNumber.internationalPhoneNumber.hint' | translate
+        },
+        errorMessage: {
+        text: errors['internationalPhoneNumber'].text
+        } if (errors['internationalPhoneNumber'])
+      }) }}
+      {% endset -%}
+
+      {{ govukCheckboxes({
+        items: [
+          {
+            value: "true",
+            id: "hasInternationalPhoneNumber",
+            name: "hasInternationalPhoneNumber",
+            text: 'pages.enterPhoneNumber.internationalPhoneNumber.checkBoxLabel' | translate,
+            conditional: {
+              html: internationalNumberHtml
+            },
+            checked: hasInternationalPhoneNumber === 'true'
+          }
+        ]
+      }) }}
+
+  {% endif %}
+
+  {{ govukButton({
+  "text": button_text|default('general.continue.label' | translate, true),
+  "type": "Submit",
+  "preventDoubleClick": true
+  }) }}
+
+</form>
+
+{% endblock %}

--- a/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
@@ -41,6 +41,17 @@ describe("enter phone number controller", () => {
 
       expect(res.render).to.have.calledWith("enter-phone-number/index.njk");
     });
+
+    it("should render enter phone number returning user view when user has a partly created account", () => {
+      req.session.user = {
+        isAccountPartCreated: true,
+      };
+      enterPhoneNumberGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "enter-phone-number/returning-user-index.njk"
+      );
+    });
   });
 
   describe("enterPhoneNumberPost", () => {

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -79,6 +79,8 @@ export function resetPasswordPost(
     req.session.user.isConsentRequired = loginResponse.data.consentRequired;
     req.session.user.isLatestTermsAndConditionsAccepted =
       loginResponse.data.latestTermsAndConditionsAccepted;
+    req.session.user.isAccountPartCreated =
+      !loginResponse.data.phoneNumberVerified;
 
     if (loginResponse.data.phoneNumberVerified) {
       const mfaResponse = await mfaCodeService.sendMfaCode(

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -297,6 +297,14 @@
       "info": {
         "paragraph1": "We will send a 6 digit security code to the number you give us."
       },
+      "returningUser": {
+        "title": "Finish creating your account",
+        "header": "Finish creating your account",
+        "info": {
+          "paragraph1": "You need to add a UK mobile phone number to your GOV.UK account.",
+          "paragraph2": "We will send a 6 digit security code to the number you give us."
+        }
+      },
       "ukPhoneNumber": {
         "label": "UK mobile phone number",
         "validationError": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -297,6 +297,14 @@
       "info": {
         "paragraph1": "We will send a 6 digit security code to the number you give us."
       },
+      "returningUser": {
+        "title": "Finish creating your account",
+        "header": "Finish creating your account",
+        "info": {
+          "paragraph1": "You need to add a UK mobile phone number to your GOV.UK account.",
+          "paragraph2": "We will send a 6 digit security code to the number you give us."
+        }
+      },
       "ukPhoneNumber": {
         "label": "UK mobile phone number",
         "validationError": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface UserSession {
   isLatestTermsAndConditionsAccepted?: boolean;
   isIdentityRequired?: boolean;
   isUpliftRequired?: boolean;
+  isAccountPartCreated?: boolean;
   docCheckingAppUser?: boolean;
   identityProcessCheckStart?: number;
 }


### PR DESCRIPTION
## What?

- Show different content on enter phone number for user drop offs
- Add a new attribute to the session which will be set on either enter-password or reset-password if the phone number is not verified. When we then load enter-phone-number we will display a new template with the different content. Once the user verifies this phonenumber by successfully entering an MFA, we will set the new attribute `isAccountPartCreated` to false again.


## Why?

- When a user enters an email address and creates a password, they have a part created account. If they then go to add a phone number and verify that phone number, they will have a created account. If a user has a partially created account and then drops off, when they return they need to set up their phone number. For this situation we want to display different content to the user to make it clear to them.
