### PR TITLE
BAU: Add SUPPORT_MFA_OPTIONS switch to analyse on merge checks

### DIFF
--- a/.github/workflows/analyse-on-merge.yml
+++ b/.github/workflows/analyse-on-merge.yml
@@ -1,4 +1,4 @@
-name: Pre-merge checks
+name: analyse on merge checks
 on:
   push:
     branches:
@@ -50,4 +50,5 @@ jobs:
       API_KEY: test-key
       REDIS_HOST: localhost
       REDIS_PORT: 6389
+      SUPPORT_MFA_OPTIONS: 1
       ZENDESK_API_URL: https://zendesk.com


### PR DESCRIPTION

## What?

Add SUPPORT_MFA_OPTIONS switch to analyse on merge checks.

## Why?

Unit tests are failing because they test the scenario in which this is switched on.

## Related PRs

#615 