### PR TITLE
DCP-157: Ensure TLS >=1.2 and disallow CBC ciphers

### DIFF
--- a/ci/terraform/alb.tf
+++ b/ci/terraform/alb.tf
@@ -36,7 +36,7 @@ resource "aws_alb_listener" "frontend_alb_listener_https" {
   port              = 443
   protocol          = "HTTPS"
 
-  ssl_policy      = "ELBSecurityPolicy-2016-08"
+  ssl_policy      = "ELBSecurityPolicy-FS-1-2-Res-2020-10"
   certificate_arn = aws_acm_certificate.frontend_alb_certificate.arn
 
   default_action {


### PR DESCRIPTION
## What?

Ensure TLS >=1.2 and disallow CBC ciphers

## Why?

Currently we allow TLS 1.0 and 1.1. We should not allow that.

We also allow CBC-mode ciphers.  We should not allow that, preferring
GCM (or ChaCha20, but I don't think ELBs support that).

Amazon load balancer security policies are documented here:
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies

This configuration is (roughly) equivalent to mozilla's "intermediate"
recommendation here:
https://wiki.mozilla.org/Security/Server_Side_TLS

It should support Firefox 27, Android 4.4.2, Chrome 31, Edge 12, IE 11
(on Win7), Java 8u31, OpenSSL 1.0.1, Opera 20 and Safari 9.
## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
