### PR TITLE
AUT-460 - Update arial label to be consistent with screen

### DIFF
--- a/src/components/common/layout/banner.njk
+++ b/src/components/common/layout/banner.njk
@@ -3,11 +3,6 @@
 <p class="govuk-body">{{ 'general.cookie.cookieBanner.paragraph2' | translate }}</p>
 {% endset %}
 
-{% set html %}
-  <p class="govuk-body" >We use some essential cookies to make this service work.</p>
-  <p class="govuk-body">We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
-{% endset %}
-
 {% set acceptHtml %}
   <p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="https://www.gov.uk/help/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph2' | translate }}</p>
 {% endset %}
@@ -57,7 +52,7 @@
           type: "button",
           classes:"cookie-hide-button",
           attributes: {
-            "aria-label": "Hide cookie banner button"
+            "aria-label": 'general.cookie.cookieBanner.cookieBannerHideLink' | translate
           }
         }
       ],
@@ -75,7 +70,7 @@
           type: "button",
           classes:"cookie-hide-button",
           attributes: {
-            "aria-label": "Hide cookie banner button"
+            "aria-label": 'general.cookie.cookieBanner.cookieBannerHideLink' | translate
           }
         }
       ],


### PR DESCRIPTION
## What?

- Update arial label to be consistent with screen

## Why?

- The visual label is not the same as the source code which can cause issues with a screen reader. Update the source code so it is consistent and will work with screen readers
