### PR TITLE
AUT 440: Add 'Enter the security code shown in your authenticator app' screen for sign in journey

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -45,6 +45,7 @@ export const PATH_NAMES = {
   HEALTHCHECK: "/healthcheck",
   PROVE_IDENTITY_WELCOME: "/prove-identity-welcome",
   GET_SECURITY_CODES: "/get-security-codes",
+  ENTER_AUTHENTICATOR_APP_CODE: "/enter-authenticator-app-code",
   CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP: "/setup-authenticator-app",
 };
 
@@ -138,6 +139,11 @@ export const COOKIE_CONSENT = {
 export enum SUPPORT_TYPE {
   GOV_SERVICE = "GOV_SERVICE",
   PUBLIC = "PUBLIC",
+}
+
+export enum MFA_METHOD_TYPE {
+  SMS = "SMS",
+  AUTH_APP = "AUTH_APP",
 }
 
 export const ENVIRONMENT_NAME = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -71,6 +71,7 @@ import { docCheckingAppRouter } from "./components/doc-checking-app/doc-checking
 import { docCheckingAppCallbackRouter } from "./components/doc-checking-app-callback/doc-checking-app-callback-routes";
 import { selectMFAOptionsRouter } from "./components/select-mfa-options/select-mfa-options-routes";
 import { setupAuthenticatorAppRouter } from "./components/setup-authenticator-app/setup-authenticator-app-routes";
+import { enterAuthenticatorAppCodeRouter } from "./components/enter-authenticator-app-code/enter-authenticator-app-code-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -88,6 +89,8 @@ function registerRoutes(app: express.Application, appEnvIsProduction: boolean) {
   app.use(createPasswordRouter);
   if (supportMFAOptions()) {
     app.use(selectMFAOptionsRouter);
+    app.use(enterAuthenticatorAppCodeRouter);
+    app.use(setupAuthenticatorAppRouter);
   }
   app.use(enterPhoneNumberRouter);
   app.use(registerAccountCreatedRouter);
@@ -111,7 +114,6 @@ function registerRoutes(app: express.Application, appEnvIsProduction: boolean) {
     app.use(docCheckingAppRouter);
     app.use(docCheckingAppCallbackRouter);
   }
-  app.use(setupAuthenticatorAppRouter);
 }
 
 async function createApp(): Promise<express.Application> {

--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -13,6 +13,8 @@ export enum SecurityCodeErrorType {
   EmailMaxCodesSent = "emailMaxCodesSent",
   EmailBlocked = "emailBlocked",
   EmailMaxRetries = "emailMaxRetries",
+  AuthAppMfaNoCodeValidator = "authAppMfaNoCodeValidator",
+  AuthAppMfaMaxRetries = "authAppMfaMaxRetries",
 }
 
 export const ERROR_CODES = {
@@ -33,6 +35,7 @@ export const ERROR_CODES = {
   INVALID_VERIFY_PHONE_NUMBER_CODE: 1037,
   INVALID_PASSWORD_MAX_ATTEMPTS_REACHED: 1028,
   RESET_PASSWORD_INVALID_CODE: 1021,
+  AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED: 1042,
   AUTH_APP_INVALID_CODE: 1043,
 };
 
@@ -90,6 +93,11 @@ export const ERROR_CODE_MAPPING: { [p: string]: string } = {
     PATH_NAMES["SECURITY_CODE_WAIT"],
     SECURITY_CODE_ERROR,
     SecurityCodeErrorType.EmailBlocked
+  ),
+  [ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED]: pathWithQueryParam(
+    PATH_NAMES["SECURITY_CODE_INVALID"],
+    SECURITY_CODE_ERROR,
+    SecurityCodeErrorType.AuthAppMfaMaxRetries
   ),
 };
 

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -1,0 +1,93 @@
+import { Request, Response } from "express";
+import { ExpressRouteFunc } from "../../types";
+import {
+  ERROR_CODES,
+  getErrorPathByCode,
+  getNextPathAndUpdateJourney,
+} from "../common/constants";
+import { VerifyMfaCodeInterface, VerifyMfaCodeConfig } from "./types";
+import { authenticatorAppCodeService } from "./enter-authenticator-app-code-service";
+import { BadRequestError } from "../../utils/error";
+import {
+  formatValidationError,
+  renderBadRequest,
+} from "../../utils/validation";
+import { MFA_METHOD_TYPE } from "../../app.constants";
+import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+
+const TEMPLATE_NAME = "enter-authenticator-app-code/index.njk";
+
+export function enterAuthenticatorAppCodeGet(
+  _req: Request,
+  res: Response
+): void {
+  res.render(TEMPLATE_NAME);
+}
+
+export const enterAuthenticatorAppCodePost = (
+  service: VerifyMfaCodeInterface = authenticatorAppCodeService()
+): ExpressRouteFunc => {
+  return verifyAuthenticatorAppCodePost(service, {
+    template: TEMPLATE_NAME,
+    validationKey:
+      "pages.enterAuthenticatorAppCode.code.validationError.invalidCode",
+    validationErrorCode: ERROR_CODES.AUTH_APP_INVALID_CODE,
+  });
+};
+
+export function verifyAuthenticatorAppCodePost(
+  service: VerifyMfaCodeInterface,
+  options: VerifyMfaCodeConfig
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const code = req.body["code"];
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+
+    const result = await service.verifyMfaCode(
+      MFA_METHOD_TYPE.AUTH_APP,
+      code,
+      false,
+      sessionId,
+      clientSessionId,
+      req.ip,
+      persistentSessionId
+    );
+
+    if (!result.success) {
+      if (result.data.code === options.validationErrorCode) {
+        const error = formatValidationError(
+          "code",
+          req.t(options.validationKey)
+        );
+        return renderBadRequest(res, req, options.template, error);
+      }
+
+      const path = getErrorPathByCode(result.data.code);
+
+      if (path) {
+        return res.redirect(path);
+      }
+
+      throw new BadRequestError(result.data.message, result.data.code);
+    }
+
+    if (options.callback) {
+      return options.callback(req, res);
+    }
+
+    res.redirect(
+      getNextPathAndUpdateJourney(
+        req,
+        req.path,
+        USER_JOURNEY_EVENTS.AUTH_APP_CODE_VERIFIED,
+        {
+          isIdentityRequired: req.session.user.isIdentityRequired,
+          isConsentRequired: req.session.user.isConsentRequired,
+          isLatestTermsAndConditionsAccepted:
+            req.session.user.isLatestTermsAndConditionsAccepted,
+        },
+        res.locals.sessionId
+      )
+    );
+  };
+}

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-routes.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-routes.ts
@@ -1,0 +1,28 @@
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import { PATH_NAMES } from "../../app.constants";
+import express from "express";
+import {
+  enterAuthenticatorAppCodeGet,
+  enterAuthenticatorAppCodePost,
+} from "./enter-authenticator-app-code-controller";
+import { asyncHandler } from "../../utils/async";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import { validateEnterAuthenticatorAppCodeRequest } from "./enter-authenticator-app-code-validation";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  enterAuthenticatorAppCodeGet
+);
+
+router.post(
+  PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  validateEnterAuthenticatorAppCodeRequest(),
+  asyncHandler(enterAuthenticatorAppCodePost())
+);
+export { router as enterAuthenticatorAppCodeRouter };

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-service.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-service.ts
@@ -1,0 +1,47 @@
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  MFA_METHOD_TYPE,
+} from "../../app.constants";
+import {
+  createApiResponse,
+  getRequestConfig,
+  http,
+  Http,
+} from "../../utils/http";
+import { ApiResponseResult, DefaultApiResponse } from "../../types";
+import { VerifyMfaCodeInterface } from "./types";
+
+export function authenticatorAppCodeService(
+  axios: Http = http
+): VerifyMfaCodeInterface {
+  const verifyMfaCode = async function (
+    methodType: MFA_METHOD_TYPE,
+    code: string,
+    isRegistration: boolean,
+    sessionId: string,
+    clientSessionId: string,
+    sourceIp: string,
+    persistentSessionId: string
+  ): Promise<ApiResponseResult<DefaultApiResponse>> {
+    const response = await axios.client.post<DefaultApiResponse>(
+      API_ENDPOINTS.VERIFY_MFA_CODE,
+      {
+        mfaMethodType: methodType,
+        code: code,
+        isRegistration: isRegistration,
+      },
+      getRequestConfig({
+        sessionId,
+        clientSessionId,
+        sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
+      })
+    );
+    return createApiResponse(response, [HTTP_STATUS_CODES.NO_CONTENT]);
+  };
+
+  return {
+    verifyMfaCode,
+  };
+}

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-validation.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-validation.ts
@@ -1,0 +1,19 @@
+import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
+import { ValidationChainFunc } from "../../types";
+import { validateCode } from "../common/verify-code/verify-code-validation";
+
+export function validateEnterAuthenticatorAppCodeRequest(): ValidationChainFunc {
+  return [
+    validateCode({
+      requiredKey:
+        "pages.enterAuthenticatorAppCode.code.validationError.required",
+      maxLengthKey:
+        "pages.enterAuthenticatorAppCode.code.validationError.invalidFormat",
+      minLengthKey:
+        "pages.enterAuthenticatorAppCode.code.validationError.invalidFormat",
+      numbersOnlyKey:
+        "pages.enterAuthenticatorAppCode.code.validationError.invalidFormat",
+    }),
+    validateBodyMiddleware("enter-authenticator-app-code/index.njk"),
+  ];
+}

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -1,0 +1,39 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set pageTitleName = 'pages.enterAuthenticatorAppCode.title' | translate %}
+
+{% block content %}
+
+{% include "common/errors/errorSummary.njk" %}
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterAuthenticatorAppCode.header' | translate }}</h1>
+
+<form id="form-tracking" action="/enter-authenticator-app-code" method="post" novalidate>
+
+  <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+  {{ govukInput({
+    label: {
+      text: 'pages.enterAuthenticatorAppCode.code.label' | translate
+    },
+    classes: "govuk-input--width-10",
+    id: "code",
+    name: "code",
+    type: "number",
+    autocomplete:"off",
+    errorMessage: {
+      text: errors['code'].text
+    } if (errors['code'])})
+  }}
+
+  {{ govukButton({
+    "text": button_text|default('general.continue.label' | translate, true),
+    "type": "Submit",
+    "preventDoubleClick": true
+  }) }}
+
+</form>
+
+{% endblock %}

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
@@ -1,0 +1,120 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import {
+  enterAuthenticatorAppCodeGet,
+  enterAuthenticatorAppCodePost,
+} from "../enter-authenticator-app-code-controller";
+import { PATH_NAMES } from "../../../app.constants";
+import { ERROR_CODES } from "../../common/constants";
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
+import { VerifyMfaCodeInterface } from "../types";
+
+describe("enter authenticator app code controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = mockRequest({
+      path: PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
+      session: { client: {}, user: {} },
+      log: { info: sinon.fake() },
+      i18n: { language: "en" },
+    });
+    res = mockResponse();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("enterAuthenticatorAppCodeGet", () => {
+    it("should render enter mfa code view", () => {
+      enterAuthenticatorAppCodeGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "enter-authenticator-app-code/index.njk"
+      );
+    });
+  });
+
+  describe("enterAuthenticatorAppCodePost", () => {
+    it("should redirect to /auth-code when valid code entered", async () => {
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
+          success: true,
+        }),
+      };
+
+      req.body.code = "123456";
+      res.locals.sessionId = "123456-djjad";
+
+      await enterAuthenticatorAppCodePost(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(fakeService.verifyMfaCode).to.have.been.calledOnce;
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.AUTH_CODE);
+    });
+
+    it("should return error when invalid code entered", async () => {
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
+          success: false,
+          data: {
+            code: ERROR_CODES.AUTH_APP_INVALID_CODE,
+            message: "",
+          },
+        }),
+      };
+
+      req.t = sinon.fake.returns("translated string");
+      req.body.code = "678988";
+      res.locals.sessionId = "123456-djjad";
+
+      await enterAuthenticatorAppCodePost(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(fakeService.verifyMfaCode).to.have.been.calledOnce;
+      expect(res.render).to.have.been.calledWith(
+        "enter-authenticator-app-code/index.njk"
+      );
+    });
+
+    it("should redirect to security code expired when invalid authenticator app code entered more than max retries", async () => {
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
+          data: {
+            code: ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED,
+            message: "",
+          },
+          success: false,
+        }),
+      };
+
+      req.t = sinon.fake.returns("translated string");
+      req.body.code = "678988";
+      res.locals.sessionId = "123456-djjad";
+
+      await enterAuthenticatorAppCodePost(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(fakeService.verifyMfaCode).to.have.been.calledOnce;
+      expect(res.redirect).to.have.been.calledWith(
+        `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=authAppMfaMaxRetries`
+      );
+    });
+  });
+});

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
@@ -1,0 +1,205 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { expect, sinon } from "../../../../test/utils/test-utils";
+import nock = require("nock");
+import * as cheerio from "cheerio";
+import decache from "decache";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  PATH_NAMES,
+} from "../../../app.constants";
+import { ERROR_CODES, SecurityCodeErrorType } from "../../common/constants";
+
+describe("Integration:: enter authenticator app code", () => {
+  let token: string | string[];
+  let cookies: string;
+  let app: any;
+  let baseApi: string;
+
+  before(async () => {
+    decache("../../../app");
+    decache("../../../middleware/session-middleware");
+    const sessionMiddleware = require("../../../middleware/session-middleware");
+
+    sinon
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+
+        req.session.user = {
+          email: "test@test.com",
+          journey: {
+            nextPath: PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
+          },
+        };
+        next();
+      });
+
+    app = await require("../../../app").createApp();
+    baseApi = process.env.FRONTEND_API_BASE_URL;
+
+    request(app)
+      .get(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE)
+      .end((err, res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("should return enter authenticator app security code", (done) => {
+    request(app).get(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE).expect(200, done);
+  });
+
+  it("should return error when csrf not present", (done) => {
+    request(app)
+      .post(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE)
+      .type("form")
+      .send({
+        code: "123456",
+      })
+      .expect(500, done);
+  });
+
+  it("should return validation error when code not entered", (done) => {
+    request(app)
+      .post(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#code-error").text()).to.contains("Enter the security code");
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when code is less than 6 characters", (done) => {
+    request(app)
+      .post(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "2",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#code-error").text()).to.contains(
+          "Enter the security code using only 6 digits"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when code is greater than 6 characters", (done) => {
+    request(app)
+      .post(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "1234567",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#code-error").text()).to.contains(
+          "Enter the security code using only 6 digits"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should return validation error when code entered contains letters", (done) => {
+    request(app)
+      .post(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "12ert-",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#code-error").text()).to.contains(
+          "Enter the security code using only 6 digits"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should redirect to /auth-code when valid code entered", (done) => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.VERIFY_MFA_CODE)
+      .once()
+      .reply(HTTP_STATUS_CODES.NO_CONTENT, {});
+
+    request(app)
+      .post(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123456",
+      })
+      .expect("Location", PATH_NAMES.AUTH_CODE)
+      .expect(302, done);
+  });
+
+  it("should return validation error when incorrect code entered", (done) => {
+    nock(baseApi).post(API_ENDPOINTS.VERIFY_MFA_CODE).once().reply(400, {
+      code: ERROR_CODES.AUTH_APP_INVALID_CODE,
+      success: false,
+    });
+
+    request(app)
+      .post(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123455",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#code-error").text()).to.contains(
+          " The security code you entered is not correct, try entering it again or wait for your authenticator app to give you a new code"
+        );
+      })
+      .expect(400, done);
+  });
+
+  it("should redirect to security code expired when incorrect code has been entered 5 times", (done) => {
+    nock(baseApi).post(API_ENDPOINTS.VERIFY_MFA_CODE).times(6).reply(400, {
+      code: ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED,
+      success: false,
+    });
+
+    request(app)
+      .post(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123455",
+      })
+      .expect(
+        "Location",
+        `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=${SecurityCodeErrorType.AuthAppMfaMaxRetries}`
+      )
+      .expect(302, done);
+  });
+});

--- a/src/components/enter-authenticator-app-code/types.ts
+++ b/src/components/enter-authenticator-app-code/types.ts
@@ -1,0 +1,22 @@
+import { ApiResponseResult, DefaultApiResponse } from "../../types";
+import { Request, Response } from "express";
+import { MFA_METHOD_TYPE } from "../../app.constants";
+
+export interface VerifyMfaCodeInterface {
+  verifyMfaCode: (
+    methodType: MFA_METHOD_TYPE,
+    code: string,
+    isRegistration: boolean,
+    sessionId: string,
+    clientSessionId: string,
+    sourceIp: string,
+    persistentSessionId: string
+  ) => Promise<ApiResponseResult<DefaultApiResponse>>;
+}
+
+export interface VerifyMfaCodeConfig {
+  template: string;
+  validationKey: string;
+  validationErrorCode: number;
+  callback?: (req: Request, res: Response) => void;
+}

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -15,6 +15,7 @@ import {
 } from "../common/constants";
 import { BadRequestError } from "../../utils/error";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { supportMFAOptions } from "../../config";
 
 const ENTER_PASSWORD_TEMPLATE = "enter-password/index.njk";
 const ENTER_PASSWORD_VALIDATION_KEY =
@@ -116,7 +117,6 @@ export function enterPasswordPost(
         throw new BadRequestError(result.data.message, result.data.code);
       }
     }
-
     return res.redirect(
       getNextPathAndUpdateJourney(
         req,
@@ -128,6 +128,9 @@ export function enterPasswordPost(
           isPhoneNumberVerified: userLogin.data.phoneNumberVerified,
           requiresTwoFactorAuth: userLogin.data.mfaRequired,
           isConsentRequired: req.session.user.isConsentRequired,
+          supportMFAOptions: supportMFAOptions(),
+          mfaMethodType: userLogin.data.mfaMethodType,
+          isMfaMethodVerified: userLogin.data.mfaMethodVerified,
         },
         sessionId
       )

--- a/src/components/enter-password/types.ts
+++ b/src/components/enter-password/types.ts
@@ -6,6 +6,8 @@ export interface UserLoginResponse extends DefaultApiResponse {
   phoneNumberVerified?: boolean;
   latestTermsAndConditionsAccepted?: boolean;
   consentRequired?: boolean;
+  mfaMethodType?: string;
+  mfaMethodVerified?: boolean;
 }
 
 export interface EnterPasswordServiceInterface {

--- a/src/components/security-code-error/index.njk
+++ b/src/components/security-code-error/index.njk
@@ -8,9 +8,15 @@
 
 <p class="govuk-body">{{'pages.securityCodeInvalid.info.paragraph1' | translate}}</p>
 <p class="govuk-body">
-    {{'pages.securityCodeInvalid.info.paragraph2Start' | translate}}
-    <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeInvalid.info.link' | translate}}</a>
-    {{'pages.securityCodeInvalid.info.paragraph2End' | translate}}
+    {% if isAuthApp == true %}
+        {{'pages.securityCodeInvalid.authAppInfo.paragraph2Start' | translate}}
+        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeInvalid.authAppInfo.link' | translate}}</a>
+        {{'pages.securityCodeInvalid.authAppInfo.paragraph2End' | translate}}
+    {% else %}
+        {{'pages.securityCodeInvalid.info.paragraph2Start' | translate}}
+        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeInvalid.info.link' | translate}}</a>
+        {{'pages.securityCodeInvalid.info.paragraph2End' | translate}}
+    {% endif %}
 </p>
 
 {% endblock %}

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -5,6 +5,7 @@ import { PATH_NAMES } from "../../app.constants";
 export function securityCodeInvalidGet(req: Request, res: Response): void {
   res.render("security-code-error/index.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
+    isAuthApp: isAuthApp(req.query.actionType as SecurityCodeErrorType),
   });
 }
 
@@ -40,5 +41,16 @@ function getNewCodePath(actionType: SecurityCodeErrorType) {
     case SecurityCodeErrorType.EmailBlocked:
     case SecurityCodeErrorType.EmailMaxRetries:
       return PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT;
+    case SecurityCodeErrorType.AuthAppMfaMaxRetries:
+      return PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE;
+  }
+}
+
+function isAuthApp(actionType: SecurityCodeErrorType) {
+  switch (actionType) {
+    case SecurityCodeErrorType.AuthAppMfaMaxRetries:
+      return true;
+    default:
+      return false;
   }
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -397,6 +397,11 @@
         "paragraph2Start": "You can then ",
         "link": "get a new code",
         "paragraph2End": " and try again."
+      },
+      "authAppInfo": {
+        "paragraph2Start": "You can then ",
+        "link": "try again",
+        "paragraph2End": " with a new code."
       }
     },
     "securityRequestsExceededExpired": {
@@ -1420,6 +1425,18 @@
       },
       "continueButtonText": "Continue",
       "textMessageInsteadLinkText": "Get a security code by text message instead"
+    },
+    "enterAuthenticatorAppCode": {
+      "title": "Enter the security code shown in your authenticator app",
+      "header": "Enter the security code shown in your authenticator app",
+      "code": {
+        "label": "Security code",
+        "validationError": {
+          "required": "Enter the security code",
+          "invalidFormat": "Enter the security code using only 6 digits",
+          "invalidCode": "The security code you entered is not correct, try entering it again or wait for your authenticator app to give you a new code"
+        }
+      }
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -397,6 +397,11 @@
         "paragraph2Start": "You can then ",
         "link": "get a new code",
         "paragraph2End": " and try again."
+      },
+      "authAppInfo": {
+        "paragraph2Start": "You can then ",
+        "link": "try again",
+        "paragraph2End": " with a new code."
       }
     },
     "securityRequestsExceededExpired": {
@@ -1420,6 +1425,18 @@
       },
       "continueButtonText": "Continue",
       "textMessageInsteadLinkText": "Get a security code by text message instead"
+    },
+    "enterAuthenticatorAppCode": {
+      "title": "Enter the security code shown in your authenticator app",
+      "header": "Enter the security code shown in your authenticator app",
+      "code": {
+        "label": "Security code",
+        "validationError": {
+          "required": "Enter the security code",
+          "invalidFormat": "Enter the security code using only 6 digits",
+          "invalidCode": "The security code you entered is not correct, try entering it again or wait for your authenticator app to give you a new code"
+        }
+      }
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -340,11 +340,6 @@
     "@otplib/plugin-crypto" "^12.0.1"
     "@otplib/plugin-thirty-two" "^12.0.1"
 
-"@sindresorhus/is@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
-  integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
-
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.3":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -3064,11 +3059,6 @@ otplib@*:
     "@otplib/preset-default" "^12.0.1"
     "@otplib/preset-v11" "^12.0.1"
 
-p-cancelable@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
-  integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
-
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -3348,13 +3338,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-pupa@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.1.1.tgz#f5e8fd4afc2c5d97828faa523549ed8744a20d62"
-  integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
-  dependencies:
-    escape-goat "^2.0.0"
 
 qrcode@^1.5.0:
   version "1.5.0"


### PR DESCRIPTION
## What?

Add 'Enter the security code shown in your authenticator app' screen for sign in journey.

The option will only be displayed if SUPPORT_MFA_OPTIONS is turned on, and if the user has auth app credentials in the database, otherwise it will default to SMS.

## Why?

Allows the user to sign in with an authenticator app if they have set one up, rather than using SMS as a second factor.

