### PR TITLE
AUT-418: Environment specific text for authenticator app

### DIFF
--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -25,7 +25,8 @@ export async function setupAuthenticatorAppGet(
 ): Promise<void> {
   const qrCodeText = generateQRCodeValue(
     req.session.user.authAppSecret,
-    req.session.user.email
+    req.session.user.email,
+    req.t("general.authenticatorAppIssuer")
   );
 
   const qrCodeUrl = await QRCode.toDataURL(qrCodeText);

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -12,6 +12,7 @@
       "tag": "beta",
       "content": "This is a new service – your <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">feedback (opens in new tab)</a> will help us to improve it."
     },
+    "authenticatorAppIssuer": "GOV.UK SignIn",
     "yes": "Yes",
     "no": "No",
     "footer": {},

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -12,6 +12,7 @@
       "tag": "beta",
       "content": "This is a new service – your <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">feedback (opens in new tab)</a> will help us to improve it."
     },
+    "authenticatorAppIssuer": "GOV.UK SignIn",
     "yes": "Yes",
     "no": "No",
     "footer": {},

--- a/src/utils/mfa.ts
+++ b/src/utils/mfa.ts
@@ -7,6 +7,8 @@ import {
 } from "@otplib/core";
 import * as base32EncDec from "@otplib/plugin-base32-enc-dec";
 import crypto from "crypto";
+import { APP_ENV_NAME } from "../app.constants";
+import { getAppEnv } from "../config";
 
 function createRandomBytes(size: number, encoding: KeyEncodings): string {
   return crypto.randomBytes(size).toString(encoding);
@@ -22,14 +24,22 @@ export function generateMfaSecret(): string {
   return authenticatorGenerateSecret(32, options);
 }
 
-export function generateQRCodeValue(secret: string, email: string): string {
+export function generateQRCodeValue(
+  secret: string,
+  email: string,
+  issuerName: string
+): string {
+  const issuer =
+    getAppEnv() === APP_ENV_NAME.PROD
+      ? issuerName
+      : `${issuerName} - ${getAppEnv()}`;
   return keyuri({
     accountName: email,
     secret: secret,
     algorithm: HashAlgorithms.SHA1,
     digits: 6,
     step: 30,
-    issuer: "GOV.UK SignIn",
+    issuer: issuer,
     type: Strategy.TOTP,
   });
 }


### PR DESCRIPTION
## What?

Environment specific text for authenticator app

For production just display 'GOV.UK SignIn', for all test environments add an environment name too.

## Why?

Allows people who test in multiple environments to have several entries in the same app.
