### PR TITLE
Remove isPhoneNumberVerified flag

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -58,7 +58,6 @@ const authStateMachine = createMachine(
       isConsentRequired: false,
       requiresUplift: false,
       requiresTwoFactorAuth: false,
-      isPhoneNumberVerified: true,
       isAuthenticated: false,
       isIdentityRequired: false,
       prompt: OIDC_PROMPT.NONE,
@@ -166,7 +165,7 @@ const authStateMachine = createMachine(
             },
             {
               target: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
-              cond: "isPhoneNumberVerified",
+              cond: "isAccountPartCreated",
             },
             { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
             {
@@ -296,7 +295,7 @@ const authStateMachine = createMachine(
             },
             {
               target: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
-              cond: "isPhoneNumberVerified",
+              cond: "isAccountPartCreated",
             },
             { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
             {
@@ -425,7 +424,7 @@ const authStateMachine = createMachine(
           [USER_JOURNEY_EVENTS.PASSWORD_CREATED]: [
             {
               target: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
-              cond: "isPhoneNumberVerified",
+              cond: "isAccountPartCreated",
             },
             { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
             {
@@ -508,8 +507,7 @@ const authStateMachine = createMachine(
         context.requiresUplift === true && context.isAuthenticated === true,
       requiresTwoFactorAuth: (context) =>
         context.requiresTwoFactorAuth === true,
-      isPhoneNumberVerified: (context) =>
-        context.isPhoneNumberVerified === false,
+      isAccountPartCreated: (context) => context.isMfaMethodVerified === false,
       isIdentityRequired: (context) => context.isIdentityRequired === true,
       isAuthenticated: (context) => context.isAuthenticated === true,
       requiresLogin: (context) =>
@@ -520,7 +518,6 @@ const authStateMachine = createMachine(
         context.isAuthenticated === false,
       supportMFAOptions: (context) => context.supportMFAOptions === true,
       requiresMFAAuthAppCode: (context) =>
-        context.supportMFAOptions === true &&
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
         context.isMfaMethodVerified === true,
     },

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -52,7 +52,7 @@ describe("enter password controller", () => {
             mfaRequired: true,
             consentRequired: false,
             latestTermsAndConditionsAccepted: true,
-            phoneNumberVerified: true,
+            mfaMethodVerified: true,
           },
           success: true,
         }),
@@ -89,7 +89,7 @@ describe("enter password controller", () => {
           data: {
             redactedPhoneNumber: "******3456",
             mfaRequired: false,
-            phoneNumberVerified: true,
+            mfaMethodVerified: true,
           },
         }),
       };
@@ -117,7 +117,7 @@ describe("enter password controller", () => {
           success: true,
           data: {
             redactedPhoneNumber: "******3456",
-            phoneNumberVerified: false,
+            mfaMethodVerified: false,
           },
         }),
       };
@@ -147,7 +147,7 @@ describe("enter password controller", () => {
           data: {
             redactedPhoneNumber: "******3456",
             latestTermsAndConditionsAccepted: false,
-            phoneNumberVerified: true,
+            mfaMethodVerified: true,
           },
           success: true,
         }),

--- a/src/components/enter-password/types.ts
+++ b/src/components/enter-password/types.ts
@@ -3,7 +3,6 @@ import { ApiResponseResult, DefaultApiResponse } from "../../types";
 export interface UserLoginResponse extends DefaultApiResponse {
   redactedPhoneNumber?: string;
   mfaRequired?: boolean;
-  phoneNumberVerified?: boolean;
   latestTermsAndConditionsAccepted?: boolean;
   consentRequired?: boolean;
   mfaMethodType?: string;

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -17,6 +17,7 @@ import { EnterPasswordServiceInterface } from "../enter-password/types";
 import { enterPasswordService } from "../enter-password/enter-password-service";
 import { MfaServiceInterface } from "../common/mfa/types";
 import { mfaService } from "../common/mfa/mfa-service";
+import { MFA_METHOD_TYPE } from "../../app.constants";
 
 const resetPasswordTemplate = "reset-password/index.njk";
 
@@ -80,9 +81,12 @@ export function resetPasswordPost(
     req.session.user.isLatestTermsAndConditionsAccepted =
       loginResponse.data.latestTermsAndConditionsAccepted;
     req.session.user.isAccountPartCreated =
-      !loginResponse.data.phoneNumberVerified;
+      !loginResponse.data.mfaMethodVerified;
 
-    if (loginResponse.data.phoneNumberVerified) {
+    if (
+      loginResponse.data.mfaMethodVerified &&
+      loginResponse.data.mfaMethodType === MFA_METHOD_TYPE.SMS
+    ) {
       const mfaResponse = await mfaCodeService.sendMfaCode(
         sessionId,
         clientSessionId,
@@ -113,7 +117,7 @@ export function resetPasswordPost(
           requiresTwoFactorAuth: true,
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
-          isPhoneNumberVerified: loginResponse.data.phoneNumberVerified,
+          isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
         },
         res.locals.sessionId
       )

--- a/src/components/reset-password/tests/reset-password-controller.test.ts
+++ b/src/components/reset-password/tests/reset-password-controller.test.ts
@@ -10,7 +10,7 @@ import {
   resetPasswordRequestGet,
 } from "../reset-password-controller";
 import { ResetPasswordServiceInterface } from "../types";
-import { PATH_NAMES } from "../../../app.constants";
+import { MFA_METHOD_TYPE, PATH_NAMES } from "../../../app.constants";
 import {
   mockRequest,
   mockResponse,
@@ -72,7 +72,8 @@ describe("reset password controller (in 6 digit code flow)", () => {
             redactedPhoneNumber: "******1234",
             consentRequired: false,
             latestTermsAndConditionsAccepted: true,
-            phoneNumberVerified: true,
+            mfaMethodVerified: true,
+            mfaMethodType: MFA_METHOD_TYPE.SMS,
             mfaRequired: true,
           },
         }),
@@ -111,7 +112,7 @@ describe("reset password controller (in 6 digit code flow)", () => {
             redactedPhoneNumber: "******1234",
             consentRequired: false,
             latestTermsAndConditionsAccepted: true,
-            phoneNumberVerified: false,
+            mfaMethodVerified: false,
             mfaRequired: true,
           },
         }),
@@ -153,8 +154,9 @@ describe("reset password controller (in 6 digit code flow)", () => {
           redactedPhoneNumber: "******1234",
           consentRequired: false,
           latestTermsAndConditionsAccepted: true,
-          phoneNumberVerified: true,
+          mfaMethodVerified: true,
           mfaRequired: false,
+          mfaMethodType: MFA_METHOD_TYPE.SMS,
         },
       }),
     };


### PR DESCRIPTION
## What?

Remove isPhoneNumberVerified flag everywhere

## Why?

This value is super seeded by isMfaMethodVerified and allows the code base to simplified to support auth apps as a feature toggle easier.
