### PR TITLE
Support 2fa drop out with new screen

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -164,6 +164,10 @@ const authStateMachine = createMachine(
               cond: "requiresMFAAuthAppCode",
             },
             {
+              target: [PATH_NAMES.GET_SECURITY_CODES],
+              cond: "supportMFAOptionsAndIsAccountPartCreated", //TODO this is just to test drop offs
+            },
+            {
               target: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
               cond: "isAccountPartCreated",
             },
@@ -289,6 +293,10 @@ const authStateMachine = createMachine(
       [PATH_NAMES.ENTER_PASSWORD]: {
         on: {
           [USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED]: [
+            {
+              target: [PATH_NAMES.GET_SECURITY_CODES],
+              cond: "supportMFAOptionsAndIsAccountPartCreated", //TODO this is just to test drop offs
+            },
             {
               target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
               cond: "requiresMFAAuthAppCode",
@@ -423,6 +431,10 @@ const authStateMachine = createMachine(
         on: {
           [USER_JOURNEY_EVENTS.PASSWORD_CREATED]: [
             {
+              target: [PATH_NAMES.GET_SECURITY_CODES],
+              cond: "supportMFAOptionsAndIsAccountPartCreated", //TODO this is just to test drop offs
+            },
+            {
               target: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
               cond: "isAccountPartCreated",
             },
@@ -520,6 +532,11 @@ const authStateMachine = createMachine(
       requiresMFAAuthAppCode: (context) =>
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
         context.isMfaMethodVerified === true,
+      supportMFAOptionsAndIsAccountPartCreated: (
+        context //TODO this should be removed before go live
+      ) =>
+        context.supportMFAOptions === true &&
+        context.isMfaMethodVerified === false,
     },
   }
 );

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -18,6 +18,7 @@ import { enterPasswordService } from "../enter-password/enter-password-service";
 import { MfaServiceInterface } from "../common/mfa/types";
 import { mfaService } from "../common/mfa/mfa-service";
 import { MFA_METHOD_TYPE } from "../../app.constants";
+import { supportMFAOptions } from "../../config";
 
 const resetPasswordTemplate = "reset-password/index.njk";
 
@@ -117,6 +118,8 @@ export function resetPasswordPost(
           requiresTwoFactorAuth: true,
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
+          supportMFAOptions: supportMFAOptions(),
+          mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
         },
         res.locals.sessionId

--- a/src/components/reset-password/tests/reset-password-controller.test.ts
+++ b/src/components/reset-password/tests/reset-password-controller.test.ts
@@ -38,6 +38,7 @@ describe("reset password controller (in 6 digit code flow)", () => {
 
   afterEach(() => {
     sinon.restore();
+    delete process.env.SUPPORT_MFA_OPTIONS;
   });
 
   describe("resetPasswordRequestGet", () => {
@@ -140,6 +141,46 @@ describe("reset password controller (in 6 digit code flow)", () => {
       expect(res.redirect).to.have.calledWith(
         PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER
       );
+    });
+
+    it("should redirect to /get-security-codes when password updated and mfa method not verified", async () => {
+      process.env.SUPPORT_MFA_OPTIONS = "1";
+      const fakeResetService: ResetPasswordServiceInterface = {
+        updatePassword: sinon.fake.returns({ success: true }),
+      };
+      const fakeLoginService: EnterPasswordServiceInterface = {
+        loginUser: sinon.fake.returns({
+          success: true,
+          data: {
+            redactedPhoneNumber: "******1234",
+            consentRequired: false,
+            latestTermsAndConditionsAccepted: true,
+            mfaMethodVerified: false,
+            mfaRequired: true,
+          },
+        }),
+      };
+      fakeLoginService.loginUser;
+      const fakeMfAService: MfaServiceInterface = {
+        sendMfaCode: sinon.fake.returns({ success: true }),
+      };
+
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+      req.body.password = "Password1";
+
+      await resetPasswordPost(
+        fakeResetService,
+        fakeLoginService,
+        fakeMfAService
+      )(req as Request, res as Response);
+
+      expect(fakeResetService.updatePassword).to.have.been.calledOnce;
+      expect(fakeLoginService.loginUser).to.have.been.calledOnce;
+      expect(fakeMfAService.sendMfaCode).to.not.have.been.called;
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.GET_SECURITY_CODES);
     });
   });
 

--- a/src/components/select-mfa-options/index.njk
+++ b/src/components/select-mfa-options/index.njk
@@ -4,7 +4,11 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
-{% set pageTitleName = 'pages.getSecurityCodes.title' | translate %}
+{% if isAccountPartCreated %}
+  {% set pageTitleName = 'pages.getSecurityCodes.titleAccountPartCreated' | translate %}
+{% else %}
+  {% set pageTitleName = 'pages.getSecurityCodes.title' | translate %}
+{% endif %}
 
 {% block content %}
 
@@ -15,13 +19,18 @@
   <p class="govuk-body">{{'pages.getSecurityCodes.authAppDetails.paragraph2' | translate}}</p>
 {% endset %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.getSecurityCodes.header' | translate}}</h1>
-
-<p class="govuk-body">{{'pages.getSecurityCodes.summary' | translate}}</p>
+  {% if isAccountPartCreated %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.getSecurityCodes.headerAccountPartCreated' | translate}}</h1>
+    <p class="govuk-body">{{'pages.getSecurityCodes.summaryAccountPartCreated' | translate}}</p>
+  {% else %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.getSecurityCodes.header' | translate}}</h1>
+    <p class="govuk-body">{{'pages.getSecurityCodes.summary' | translate}}</p>
+  {% endif %}
 
 <form action="/get-security-codes" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+<input type="hidden" name="isAccountPartCreated" value="{{isAccountPartCreated}}"/>
 
 {{ govukRadios({
   idPrefix: "mfa-options",

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -3,8 +3,10 @@ import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { generateMfaSecret } from "../../utils/mfa";
 
-export function getSecurityCodesGet(_req: Request, res: Response): void {
-  res.render("select-mfa-options/index.njk");
+export function getSecurityCodesGet(req: Request, res: Response): void {
+  res.render("select-mfa-options/index.njk", {
+    isAccountPartCreated: req.session.user.isAccountPartCreated,
+  });
 }
 
 export function getSecurityCodesPost(req: Request, res: Response): void {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1443,6 +1443,9 @@
       "title": "Choose how to get security codes",
       "header": "Choose how to get security codes",
       "summary": "To finish creating your account, you need to choose a way to prove it's you when you sign in.",
+      "titleAccountPartCreated": "Finish creating your account",
+      "headerAccountPartCreated": "Finish creating your account",
+      "summaryAccountPartCreated": "Choose a way to get security codes when you sign in. This helps keep your account secure.",
       "secondFactorRadios": {
         "textMessageText": "Text message",
         "authAppText": "Authenticator app for smartphone, tablet or computer",


### PR DESCRIPTION
When a user drops off in the sign up process there needs to be a change to support multiple 2fa options when the user comes back. The following has been added.

- A temp change to the state machine to enable the testing of this in parallel of what is currently live
- Get security codes screen update content to support drop out user
- Added functionality to reset password to support the new mfa methods as-well as drop offs.
