### PR TITLE
AUT-495: Inject basic auth bypass IP addresses

### DIFF
--- a/ci/tasks/deploy-frontend.yml
+++ b/ci/tasks/deploy-frontend.yml
@@ -24,6 +24,7 @@ params:
   BASIC_AUTH_PASSWORD: ((no-basic-auth-password))
   SUPPORT_INTERNATIONAL_NUMBERS: "0"
   INCOMING_TRAFFIC_CIDR_BLOCKS: '["0.0.0.0/0"]'
+  BASIC_AUTH_BYPASS_CIDR_BLOCKS: '[]'
 inputs:
   - name: frontend-src
   - name: frontend-image
@@ -83,6 +84,7 @@ run:
         -var "basic_auth_username=${NORMALISED_BASIC_AUTH_USERNAME}" \
         -var "basic_auth_password=${NORMALISED_BASIC_AUTH_PASSWORD}" \
         -var "incoming_traffic_cidr_blocks=${INCOMING_TRAFFIC_CIDR_BLOCKS}" \
+        -var "basic_auth_bypass_cidr_blocks=${BASIC_AUTH_BYPASS_CIDR_BLOCKS}" \
         -var-file ${DEPLOY_ENVIRONMENT}.tfvars \
 
       terraform output --json > ../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -134,6 +134,10 @@ locals {
         name  = "NGINX_HOST"
         value = local.frontend_fqdn
       },
+      {
+        name  = "IP_ALLOW_LIST"
+        value = length(var.basic_auth_bypass_cidr_blocks) == 0 ? "" : json_encode(var.basic_auth_bypass_cidr_blocks)
+      },
     ]
   }
 }

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -199,3 +199,9 @@ variable "incoming_traffic_cidr_blocks" {
   type        = list(string)
   description = "The list of CIDR blocks allowed to send requests to the ALB"
 }
+
+variable "basic_auth_bypass_cidr_blocks" {
+  default     = []
+  type        = list(string)
+  description = "The list of CIDR blocks allowed to bypass basic auth (if enabled)"
+}


### PR DESCRIPTION
## What?

- Inject a list of IP addresses into the basic auth side car that are allowed to bypass basic auth.

## Why?

We need to disable to basic auth for the automated end to end tests to run, however, we need to keep it on for external IP addresses. The allow list will be injected at deploy time by Concourse.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/302
https://github.com/alphagov/di-infrastructure/pull/303