### PR TITLE
AUT-495: Use correct function name

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -136,7 +136,7 @@ locals {
       },
       {
         name  = "IP_ALLOW_LIST"
-        value = length(var.basic_auth_bypass_cidr_blocks) == 0 ? "" : json_encode(var.basic_auth_bypass_cidr_blocks)
+        value = length(var.basic_auth_bypass_cidr_blocks) == 0 ? "" : jsonencode(var.basic_auth_bypass_cidr_blocks)
       },
     ]
   }


### PR DESCRIPTION
## What?

- Correct `json_encode()` to `jsonencode()`

## Why?

Pipeline is failing.

## Related PRs

#654 