### PR TITLE
AUT-463: Use <h2> instead of <h3> for create password agree terms

### DIFF
--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -32,7 +32,7 @@
   text: 'pages.createPassword.securePasswordDetails.text' | translate
 }) }}
 
-<h3 class="govuk-heading-s">{{'pages.createPassword.termsOfUse.heading' | translate}}</h3>
+<h2 class="govuk-heading-s">{{'pages.createPassword.termsOfUse.heading' | translate}}</h2>
 
 <p class="govuk-body">{{'pages.createPassword.termsOfUse.paragraph1' | translate}}</p>
 <p class="govuk-body">{{'pages.createPassword.termsOfUse.paragraph2' | translate | replace("#PRIVACY_NOTICE_LINK", '<a class="govuk-link" href="/privacy-notice" rel="noreferrer noopener" target="_blank">privacy notice</a>') | safe }}</p>


### PR DESCRIPTION


## What?

Use <h2> instead of <h3> for create password agree terms.

## Why?

Fixes accessbility issue where the preceeding element is level 1.
Removes an unexpected jump from L1 to L3.

"The text ‘Agree to our terms of use’ has been marked up as a level 3 heading. As the prior heading is a level 1, this creates an illogical hierarchal structure for users of screen reading assistive technologies. This can cause confusion as the user would expect a level 3 to follow a level 2 and may think that content has been missed."

