### PR TITLE
AUT-465: Do not delete an invalid phone number when validation fails.

### DIFF
--- a/src/components/enter-phone-number/index.njk
+++ b/src/components/enter-phone-number/index.njk
@@ -28,6 +28,7 @@
   name: "phoneNumber",
   type: "tel",
   autocomplete: "tel",
+  value: phoneNumber,
   errorMessage: {
   text: errors['phoneNumber'].text
   } if (errors['phoneNumber'])})
@@ -41,6 +42,7 @@
         name: "internationalPhoneNumber",
         type: "tel",
         autocomplete: "tel",
+        value: internationalPhoneNumber,
         classes: "govuk-!-width-two-thirds",
         label: {
           text: 'pages.enterPhoneNumber.internationalPhoneNumber.label' | translate


### PR DESCRIPTION
## What?

Do not delete an invalid phone number when validation fails.

## Why?

Resolves accessibility issue, deleting the value makes it more difficult for users.
