### PR TITLE
AUT-495: Inject trusted proxies into basic auth side car

### DIFF
--- a/ci/terraform/core.tf
+++ b/ci/terraform/core.tf
@@ -16,6 +16,6 @@ locals {
   private_subnet_ids                         = data.terraform_remote_state.core.outputs.private_subnet_ids
   private_subnet_cidr_blocks                 = data.terraform_remote_state.core.outputs.private_subnet_cidr_blocks
   public_subnet_ids                          = data.terraform_remote_state.core.outputs.public_subnet_ids
-  public_subnet_cidr_blocks                  = data.terraform_remote_state.core.outputs.private_subnet_cidr_blocks
+  public_subnet_cidr_blocks                  = data.terraform_remote_state.core.outputs.public_subnet_cidr_blocks
   cluster_id                                 = data.terraform_remote_state.core.outputs.cluster_id
 }

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -138,6 +138,10 @@ locals {
         name  = "IP_ALLOW_LIST"
         value = length(var.basic_auth_bypass_cidr_blocks) == 0 ? "" : jsonencode(var.basic_auth_bypass_cidr_blocks)
       },
+      {
+        name  = "TRUSTED_PROXIES"
+        value = jsonencode(local.public_subnet_cidr_blocks)
+      },
     ]
   }
 }


### PR DESCRIPTION
## What?

- Set the `TRUSTED_PROXIES` environment variable on the sidecar to be the list of CIDR blocks for the public subnet (where the ALB lives).

## Why?

The ability to bypass basic auth, based on IP address (i.e. GDS addresses only), is not working due to the NGinx reporting the ALB IP as the client IP. We're now using the RealIP module in NGinx to determine the actual client address and we need to tell it which IPs are our known proxies.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/305
