### PR TITLE
BAU - Update tag application name for frontend

### DIFF
--- a/ci/terraform/site.tf
+++ b/ci/terraform/site.tf
@@ -33,6 +33,6 @@ data "aws_partition" "current" {}
 locals {
   default_tags = {
     environment = var.environment
-    application = "account-management"
+    application = "auth-frontend"
   }
 }


### PR DESCRIPTION
## What?

- Update tag application name for frontend

## Why?

- It was tagged as account-management previously. This should be the authentication frontend. 
