### PR TITLE
AUT-473: Do not open all footer links in a new tab

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -77,22 +77,18 @@
         items: [
           {
             href: "/accessibility-statement",
-            attributes: {target: "_blank"},
             text: 'general.footer.accessibilityStatement.linkText' | translate
           },
           {
             href: "https://www.gov.uk/help/cookies",
-              attributes: {target: "_blank"},
             text: 'general.footer.cookies.linkText' | translate
           },
           {
             href: "/terms-and-conditions",
-              attributes: {target: "_blank"},
             text: 'general.footer.terms.linkText' | translate
           },
           {
               href: "/privacy-notice",
-              attributes: {target: "_blank"},
               text: 'general.footer.privacy.linkText' | translate
           },
           {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -68,7 +68,7 @@
       },
       "support": {
         "pageTitle": "Support",
-        "linkText": "Support"
+        "linkText": "Support (opens in new tab)"
       }
     }
   },


### PR DESCRIPTION


## What?

Do not open all footer links in a new tab.

Will now open in the same tab:

- Accessibility statement
- Cookies
- Terms and conditions
- Privacy notice

Will keep opening in a new tab

- Support

## Why?

If a link opens in a new tab users of screen reading assistive technologies need to be provided with this information prior to activating the link.  Either we update the link text to say that a new tab will open, or stop opening links in a new tab.

Four links will now open in the same tab as they lead to simple, more or less static pages, so using the back button will not cause any issues.  The 'Support' link leads to a more complex page with more steps so it's best to keep this opening in a new tab, in this case the link text has been updated.

