### PR TITLE
AUT-497: Restore Sign In cookies policy and update content

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -47,6 +47,7 @@ export const PATH_NAMES = {
   GET_SECURITY_CODES: "/get-security-codes",
   ENTER_AUTHENTICATOR_APP_CODE: "/enter-authenticator-app-code",
   CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP: "/setup-authenticator-app",
+  COOKIES_POLICY: "/cookies",
 };
 
 export const HTTP_STATUS_CODES = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -72,6 +72,7 @@ import { docCheckingAppCallbackRouter } from "./components/doc-checking-app-call
 import { selectMFAOptionsRouter } from "./components/select-mfa-options/select-mfa-options-routes";
 import { setupAuthenticatorAppRouter } from "./components/setup-authenticator-app/setup-authenticator-app-routes";
 import { enterAuthenticatorAppCodeRouter } from "./components/enter-authenticator-app-code/enter-authenticator-app-code-routes";
+import { cookiesRouter } from "./components/common/cookies/cookies-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -110,6 +111,7 @@ function registerRoutes(app: express.Application, appEnvIsProduction: boolean) {
   app.use(proveIdentityRouter);
   app.use(proveIdentityWelcomeRouter);
   app.use(proveIdentityCallbackRouter);
+  app.use(cookiesRouter);
   if (!appEnvIsProduction) {
     app.use(docCheckingAppRouter);
     app.use(docCheckingAppCallbackRouter);

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -60,7 +60,11 @@ function initEnterPhoneNumber() {
       cookies.initAnalytics();
     }
 
-    cookies.cookieBannerInit();
+    if (cookies.isOnCookiesPage()) {
+      cookies.cookiesPageInit();
+    } else {
+      cookies.cookieBannerInit();
+    }
   }
 
   initFeedbackRadioButtons();

--- a/src/assets/javascript/application.js
+++ b/src/assets/javascript/application.js
@@ -61,8 +61,8 @@ function initEnterPhoneNumber() {
     }
 
     if (cookies.isOnCookiesPage()) {
-      cookies.cookiesPageInit();
-    } else {
+      cookies.cookiesPageInit();	
+    } else {	
       cookies.cookieBannerInit();
     }
   }

--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -62,36 +62,6 @@ var cookies = function (trackingId, analyticsCookieDomain) {
     }
   }
 
-  function saveCookieSettings(event) {
-    event.preventDefault();
-
-    var hasConsented =
-      document.querySelector(
-        '#radio-cookie-preferences input[type="radio"]:checked'
-      ).value === "true";
-
-    setCookie(COOKIES_PREFERENCES_SET, {
-      analytics: hasConsented,
-    });
-    showElement(document.querySelector("#save-success-banner"));
-
-    if (hasConsented) {
-      initAnalytics();
-    }
-
-    var isGaCookie = !!(getCookie("_ga") && getCookie("_gid"));
-
-    if (isGaCookie && !hasConsented) {
-      var gtagCookie = "_gat_gtag_" + trackingId.replace(/-/g, "_");
-
-      setCookie("_ga", "", { days: -1 });
-      setCookie("_gid", "", { days: -1 });
-      setCookie(gtagCookie, "", { days: -1 });
-    }
-
-    window.scrollTo(0, 0);
-  }
-
   function cookiesPageInit() {
     document.querySelector("#cookie-preferences-form").hidden = false;
   }

--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -2,7 +2,6 @@
 
 var cookies = function (trackingId, analyticsCookieDomain) {
   var COOKIES_PREFERENCES_SET = "cookies_preferences_set";
-
   var cookiesAccepted = document.querySelector("#cookies-accepted");
   var cookiesRejected = document.querySelector("#cookies-rejected");
   var hideCookieBanner = document.querySelectorAll(".cookie-hide-button");
@@ -94,22 +93,7 @@ var cookies = function (trackingId, analyticsCookieDomain) {
   }
 
   function cookiesPageInit() {
-    var analyticsConsent = hasConsentForAnalytics();
-
-    if (analyticsConsent) {
-      setCookie(COOKIES_PREFERENCES_SET, { analytics: analyticsConsent });
-      document.querySelector("#policy-cookies-accepted").checked =
-        analyticsConsent;
-    } else {
-      document.querySelector("#policy-cookies-rejected").checked = true;
-    }
-
-    document.querySelector("#save-cookie-settings").addEventListener(
-      "click",
-      function (event) {
-        saveCookieSettings(event);
-      }.bind(this)
-    );
+    document.querySelector("#cookie-preferences-form").hidden = false;
   }
 
   function hasConsentForAnalytics() {
@@ -120,6 +104,7 @@ var cookies = function (trackingId, analyticsCookieDomain) {
   function initAnalytics() {
     loadGtmScript();
     initGtm();
+    initLinkerHandlers();
   }
 
   function loadGtmScript() {
@@ -137,21 +122,105 @@ var cookies = function (trackingId, analyticsCookieDomain) {
     window.dataLayer = [
       {
         "gtm.allowlist": ["google"],
-        "gtm.blocklist": [
-          "nonGoogleScripts",
-          "nonGoogleIframes",
-          "nonGooglePixels",
-          "customScripts",
-          "customPixels",
-        ],
+        "gtm.blocklist": ["adm", "awct", "sp", "gclidw", "gcs", "opt"],
+      },
+      {
+        department: {
+          programmeteam: "di",
+          productteam: "sso",
+        },
       },
     ];
+
+    var sessionJourney = getJourneyMapping(window.location.pathname);
 
     function gtag(obj) {
       dataLayer.push(obj);
     }
 
+    if (sessionJourney) {
+      gtag(sessionJourney);
+    }
+
     gtag({ "gtm.start": new Date().getTime(), event: "gtm.js" });
+  }
+
+  function initLinkerHandlers() {
+    var submitButton = document.querySelector('button[type="submit"]');
+    var pageForm = document.getElementById("form-tracking");
+
+    if (submitButton && pageForm) {
+      submitButton.addEventListener("click", function () {
+        if (window.ga && window.gaplugins) {
+          var tracker = ga.getAll()[0];
+          var linker = new window.gaplugins.Linker(tracker);
+          var destinationLink = linker.decorate(pageForm.action);
+          pageForm.action = destinationLink;
+        }
+      });
+    }
+
+    var trackLink = document.getElementById("track-link");
+
+    if (trackLink) {
+      trackLink.addEventListener("click", function (e) {
+        e.preventDefault();
+
+        if (window.ga && window.gaplugins) {
+          var tracker = ga.getAll()[0];
+          var linker = new window.gaplugins.Linker(tracker);
+          var destinationLink = linker.decorate(trackLink.href);
+          window.location.href = destinationLink;
+        } else {
+          window.location.href = trackLink.href;
+        }
+      });
+    }
+  }
+
+  function generateSessionJourney(journey, status) {
+    return {
+      sessionjourney: {
+        journey: journey,
+        status: status,
+      },
+    };
+  }
+
+  function getJourneyMapping(url) {
+    const JOURNEY_DATA_LAYER_PATHS = {
+      "/enter-email-create": generateSessionJourney("sign up", "start"),
+      "/account-not-found": generateSessionJourney("sign up", "start"),
+      "/check-your-email": generateSessionJourney("sign up", "middle"),
+      "/create-password": generateSessionJourney("sign up", "middle"),
+      "/enter-phone-number": generateSessionJourney("sign up", "middle"),
+      "/check-your-phone": generateSessionJourney("sign up", "middle"),
+      "/account-created": generateSessionJourney("sign up", "end"),
+      "/enter-email": generateSessionJourney("sign in", "start"),
+      "/enter-password-account-exists": generateSessionJourney(
+        "sign in",
+        "start"
+      ),
+      "/enter-password": generateSessionJourney("sign in", "middle"),
+      "/enter-code": generateSessionJourney("sign in", "middle"),
+      "/resend-code": generateSessionJourney("sign in", "middle"),
+      "/updated-terms-and-conditions": generateSessionJourney(
+        "sign in",
+        "middle"
+      ),
+      "/share-info": generateSessionJourney("sign in", "middle"),
+      "/reset-password-check-email": generateSessionJourney(
+        "password reset",
+        "start"
+      ),
+      "/reset-password": generateSessionJourney("password reset", "middle"),
+      "/reset-password-confirmed": generateSessionJourney(
+        "password reset",
+        "end"
+      ),
+    };
+
+    return JOURNEY_DATA_LAYER_PATHS[url];
   }
 
   function getCookie(name) {
@@ -179,7 +248,13 @@ var cookies = function (trackingId, analyticsCookieDomain) {
       var date = new Date();
       date.setTime(date.getTime() + options.days * 24 * 60 * 60 * 1000);
       cookieString =
-        cookieString + "; expires=" + date.toGMTString() + "; path=/;";
+        cookieString +
+        "; expires=" +
+        date.toGMTString() +
+        "; path=/;" +
+        " domain=" +
+        analyticsCookieDomain +
+        ";";
     }
 
     if (document.location.protocol === "https:") {

--- a/src/components/common/cookie-consent/cookie-consent-service.ts
+++ b/src/components/common/cookie-consent/cookie-consent-service.ts
@@ -14,7 +14,6 @@ export function cookieConsentService(): CookieConsentServiceInterface {
           ? COOKIE_CONSENT.ACCEPT
           : COOKIE_CONSENT.REJECT;
     }
-
     const cookieValue: any = {
       cookie_consent: consentValue,
     };

--- a/src/components/common/cookies/cookies-controller.ts
+++ b/src/components/common/cookies/cookies-controller.ts
@@ -1,0 +1,6 @@
+import { Request, Response } from "express";
+
+export function cookiesGet(req: Request, res: Response): void {
+  res.locals.backUrl = req.get("Referrer");
+  res.render("common/cookies/index.njk");
+}

--- a/src/components/common/cookies/cookies-controller.ts
+++ b/src/components/common/cookies/cookies-controller.ts
@@ -1,6 +1,48 @@
 import { Request, Response } from "express";
+import { cookieConsentService } from "../cookie-consent/cookie-consent-service";
+import { sanitize } from "../../../utils/strings";
+import {
+  COOKIES_PREFERENCES_SET,
+  COOKIE_CONSENT,
+} from "../../../app.constants";
+import { CookieConsentModel } from "../cookie-consent/types";
+
+const cookieService = cookieConsentService();
 
 export function cookiesGet(req: Request, res: Response): void {
-  res.locals.backUrl = req.get("Referrer");
+  const consentValue = cookieService.getCookieConsent(
+    sanitize(req.cookies.cookies_preferences_set)
+  );
+
+  req.session.user.cookies_referer = req.headers.referer;
+  res.locals.backUrl = req.session.user.cookies_referer;
+  res.locals.analyticsConsent =
+    consentValue.cookie_consent === COOKIE_CONSENT.ACCEPT;
+  res.locals.updated = false;
   res.render("common/cookies/index.njk");
+}
+
+export function cookiesPost(req: Request, res: Response): void {
+  const consentValue = req.body.cookie_preferences;
+  const consentCookieValue = cookieService.createConsentCookieValue(
+    consentValue === "true" ? COOKIE_CONSENT.ACCEPT : COOKIE_CONSENT.REJECT
+  );
+
+  createConsentCookie(res, consentCookieValue);
+
+  res.locals.backUrl = req.session.user.cookies_referer;
+  res.locals.analyticsConsent = consentValue === "true";
+  res.locals.updated = true;
+  res.render("common/cookies/index.njk");
+}
+
+function createConsentCookie(
+  res: Response,
+  consentCookieValue: CookieConsentModel
+) {
+  res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
+    expires: consentCookieValue.expiry,
+    secure: true,
+    domain: res.locals.analyticsCookieDomain,
+  });
 }

--- a/src/components/common/cookies/cookies-routes.ts
+++ b/src/components/common/cookies/cookies-routes.ts
@@ -1,0 +1,10 @@
+import { PATH_NAMES } from "../../../app.constants";
+
+import * as express from "express";
+import { cookiesGet } from "./cookies-controller";
+
+const router = express.Router();
+
+router.get(PATH_NAMES.COOKIES_POLICY, cookiesGet);
+
+export { router as cookiesRouter };

--- a/src/components/common/cookies/cookies-routes.ts
+++ b/src/components/common/cookies/cookies-routes.ts
@@ -1,10 +1,12 @@
 import { PATH_NAMES } from "../../../app.constants";
 
 import * as express from "express";
-import { cookiesGet } from "./cookies-controller";
+import { cookiesGet, cookiesPost } from "./cookies-controller";
 
 const router = express.Router();
 
 router.get(PATH_NAMES.COOKIES_POLICY, cookiesGet);
+
+router.post(PATH_NAMES.COOKIES_POLICY, cookiesPost);
 
 export { router as cookiesRouter };

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -16,6 +16,16 @@
 <a class="govuk-notification-banner__link" id="go-back-link" href={{ backUrl }}>{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
 {% endset %}
 
+{% if updated %}
+{{ 
+  govukNotificationBanner({
+  html: html,
+  type: 'success',
+  attributes: {
+    "id": "save-success-banner"
+  }
+}) }}
+{% else %}
 {{ govukNotificationBanner({
   html: html,
   type: 'success',
@@ -24,6 +34,7 @@
     "hidden": true
   }
 }) }}
+{% endif %}
 
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
   {{ 'pages.cookiePolicy.header' | translate }}
@@ -191,9 +202,11 @@
   ]
 }) }}
 
+<form method="post" id="cookie-preferences-form" novalidate hidden="true">
+<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 {{ govukRadios({
   idPrefix: "cookie-preferences",
-  name: "cookie-preferences",
+  name: "cookie_preferences",
   attributes: {
     "id": "radio-cookie-preferences"
   },
@@ -208,23 +221,27 @@
     {
       value: "true",
       text: 'pages.cookiePolicy.settings.yesRadioButton' | translate,
-      id: "policy-cookies-accepted"
+      id: "policy-cookies-accepted",
+      checked: analyticsConsent === true
     },
     {
       value: "false",
       text: 'pages.cookiePolicy.settings.noRadioButton' | translate,
-      id: "policy-cookies-rejected"
+      id: "policy-cookies-rejected",
+      checked: analyticsConsent === false
     }
   ]
 }) }}
 
 {{ govukButton({
   "text": 'pages.cookiePolicy.settings.saveButton' | translate,
-  "type": "Button",
+  "type": "submit",
   "preventDoubleClick": true,
   attributes: {
     "id": "save-cookie-settings"
   }
 }) }}
+
+</form>
 
 {% endblock %}

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -1,0 +1,230 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% set pageTitleName = 'pages.cookiePolicy.title' | translate %}
+
+{% block content %}
+
+{% set html %}
+<h3 class="govuk-notification-banner__heading">
+  {{ 'pages.cookiePolicy.successBanner.header' | translate }}
+</h3>
+<p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translate }}</p>
+<a class="govuk-notification-banner__link" id="go-back-link" href={{ backUrl }}>{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
+{% endset %}
+
+{{ govukNotificationBanner({
+  html: html,
+  type: 'success',
+  attributes: {
+    "id": "save-success-banner",
+    "hidden": true
+  }
+}) }}
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+  {{ 'pages.cookiePolicy.header' | translate }}
+</h1>
+
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph1' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph2' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph3' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph4' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph5' | translate}}
+  <a href="{{'pages.cookiePolicy.info.linkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">
+    {{'pages.cookiePolicy.info.linkText' | translate}}
+  </a>
+  {{'pages.cookiePolicy.info.paragraph6' | translate}}
+</p>
+
+<h2 class="govuk-heading-s">{{'pages.cookiePolicy.essential.header' | translate}}</h2>
+
+<p class="govuk-body">{{'pages.cookiePolicy.essential.info.paragraph1' | translate}}</p>
+
+{{ govukTable({
+  firstCellIsHeader: false,
+  head: [
+    {
+    text: 'pages.cookiePolicy.essential.info.table.headers.col1' | translate,
+    classes: 'govuk-body-s'
+    },
+    {
+    text: 'pages.cookiePolicy.essential.info.table.headers.col2' | translate,
+    classes: 'govuk-body-s'
+    },
+    {
+    text: 'pages.cookiePolicy.essential.info.table.headers.col3' | translate,
+    classes: 'govuk-body-s'
+    }
+  ],
+  rows: [
+    [
+      {
+      text: "lang",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row1.col2' | translate,
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row1.col3' | translate,
+      classes: 'govuk-body-s'
+      }
+    ],
+    [
+      {
+      text: "aps",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row2.col2' | translate,
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row2.col3' | translate,
+      classes: 'govuk-body-s'
+      }
+    ],
+    [
+      {
+      text: "aps.sig",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row3.col2' | translate,
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row3.col3' | translate,
+      classes: 'govuk-body-s'
+      }
+    ],
+    [
+      {
+      text: "_csrf",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row4.col2' | translate,
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row4.col3' | translate,
+      classes: 'govuk-body-s'
+      }
+    ],
+    [
+      {
+      text: "cookies_preferences_set",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row5.col2' | translate,
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row5.col3' | translate,
+      classes: 'govuk-body-s'
+      }
+    ]
+  ]
+}) }}
+
+<h2 class="govuk-heading-s">{{'pages.cookiePolicy.analytics.header' | translate}}</h2>
+<p class="govuk-body">{{'pages.cookiePolicy.analytics.info.paragraph1' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.analytics.info.paragraph2' | translate}}</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>{{'pages.cookiePolicy.analytics.info.bulletPoint1' | translate}}</li>
+  <li>{{'pages.cookiePolicy.analytics.info.bulletPoint2' | translate}}</li>
+  <li>{{'pages.cookiePolicy.analytics.info.bulletPoint3' | translate}}</li>
+</ul>
+
+{{ govukTable({
+  firstCellIsHeader: false,
+  head: [
+    {
+      text: 'pages.cookiePolicy.analytics.table.headers.col1' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.headers.col2' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.headers.col3' | translate,
+      classes: 'govuk-body-s'
+    }
+  ],
+  rows: [
+    [
+    {
+      text: "_ga",
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.rows.row1.col2' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.rows.row1.col3' | translate,
+      classes: 'govuk-body-s'
+    }
+    ],
+    [
+    {
+      text: "_gid",
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.rows.row2.col2' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.rows.row2.col3' | translate,
+      classes: 'govuk-body-s'
+    }
+    ]
+  ]
+}) }}
+
+{{ govukRadios({
+  idPrefix: "cookie-preferences",
+  name: "cookie-preferences",
+  attributes: {
+    "id": "radio-cookie-preferences"
+  },
+  fieldset: {
+    legend: {
+      text: 'pages.cookiePolicy.settings.header' | translate,
+      isPageHeading: false,
+      classes: "govuk-fieldset__legend--m"
+    }
+  },
+  items: [
+    {
+      value: "true",
+      text: 'pages.cookiePolicy.settings.yesRadioButton' | translate,
+      id: "policy-cookies-accepted"
+    },
+    {
+      value: "false",
+      text: 'pages.cookiePolicy.settings.noRadioButton' | translate,
+      id: "policy-cookies-rejected"
+    }
+  ]
+}) }}
+
+{{ govukButton({
+  "text": 'pages.cookiePolicy.settings.saveButton' | translate,
+  "type": "Button",
+  "preventDoubleClick": true,
+  attributes: {
+    "id": "save-cookie-settings"
+  }
+}) }}
+
+{% endblock %}

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -98,7 +98,7 @@
       classes: 'govuk-body-s'
       },
       {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row4.col2' | translate,
+      text: 'pages.cookiePolicy.essential.info.table.rows.row3.col2' | translate,
       classes: 'govuk-body-s'
       }
     ],
@@ -108,7 +108,7 @@
       classes: 'govuk-body-s'
       },
       {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row3.col2' | translate,
+      text: 'pages.cookiePolicy.essential.info.table.rows.row4.col2' | translate,
       classes: 'govuk-body-s'
       }
     ],

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -40,20 +40,24 @@
   {{ 'pages.cookiePolicy.header' | translate }}
 </h1>
 
-<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph1' | translate}}</p>
-<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph2' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph1' | translate}}
+  <a href="{{'pages.cookiePolicy.info.govUkCookiesLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.cookiePolicy.info.govUkCookiesLinkText' | translate}}</a>{{'pages.cookiePolicy.info.paragraph2' | translate}}
+</p>
 <p class="govuk-body">{{'pages.cookiePolicy.info.paragraph3' | translate}}</p>
 <p class="govuk-body">{{'pages.cookiePolicy.info.paragraph4' | translate}}</p>
-<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph5' | translate}}
-  <a href="{{'pages.cookiePolicy.info.linkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">
-    {{'pages.cookiePolicy.info.linkText' | translate}}
-  </a>
-  {{'pages.cookiePolicy.info.paragraph6' | translate}}
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph5' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.info.paragraph6' | translate}}
+  <a href="{{'pages.cookiePolicy.info.linkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.cookiePolicy.info.linkText' | translate}}</a>{{'pages.cookiePolicy.info.paragraph7' | translate}}
 </p>
 
 <h2 class="govuk-heading-s">{{'pages.cookiePolicy.essential.header' | translate}}</h2>
 
 <p class="govuk-body">{{'pages.cookiePolicy.essential.info.paragraph1' | translate}}</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>{{'pages.cookiePolicy.essential.info.bulletPoint1' | translate}}</li>
+  <li>{{'pages.cookiePolicy.essential.info.bulletPoint2' | translate}}</li>
+  <li>{{'pages.cookiePolicy.essential.info.bulletPoint3' | translate}}</li>
+</ul>
 
 {{ govukTable({
   firstCellIsHeader: false,
@@ -65,52 +69,16 @@
     {
     text: 'pages.cookiePolicy.essential.info.table.headers.col2' | translate,
     classes: 'govuk-body-s'
-    },
-    {
-    text: 'pages.cookiePolicy.essential.info.table.headers.col3' | translate,
-    classes: 'govuk-body-s'
     }
   ],
   rows: [
-    [
-      {
-      text: "lang",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row1.col2' | translate,
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row1.col3' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
     [
       {
       text: "aps",
       classes: 'govuk-body-s'
       },
       {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row2.col2' | translate,
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row2.col3' | translate,
-      classes: 'govuk-body-s'
-      }
-    ],
-    [
-      {
-      text: "aps.sig",
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row3.col2' | translate,
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row3.col3' | translate,
+      text: 'pages.cookiePolicy.essential.info.table.rows.row1.col2' | translate,
       classes: 'govuk-body-s'
       }
     ],
@@ -120,27 +88,118 @@
       classes: 'govuk-body-s'
       },
       {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row4.col2' | translate,
-      classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row4.col3' | translate,
+      text: 'pages.cookiePolicy.essential.info.table.rows.row2.col2' | translate,
       classes: 'govuk-body-s'
       }
     ],
     [
       {
-      text: "cookies_preferences_set",
+      text: "gs",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row4.col2' | translate,
+      classes: 'govuk-body-s'
+      }
+    ],
+    [
+      {
+      text: "di-persistent-session-id",
+      classes: 'govuk-body-s'
+      },
+      {
+      text: 'pages.cookiePolicy.essential.info.table.rows.row3.col2' | translate,
+      classes: 'govuk-body-s'
+      }
+    ],
+    [
+      {
+      text: "am",
       classes: 'govuk-body-s'
       },
       {
       text: 'pages.cookiePolicy.essential.info.table.rows.row5.col2' | translate,
       classes: 'govuk-body-s'
-      },
-      {
-      text: 'pages.cookiePolicy.essential.info.table.rows.row5.col3' | translate,
-      classes: 'govuk-body-s'
       }
+    ]
+  ]
+}) }}
+
+<h2 class="govuk-heading-s">{{'pages.cookiePolicy.cookiesMessage.header' | translate}}</h2>
+<p class="govuk-body">{{'pages.cookiePolicy.cookiesMessage.paragraph1' | translate}}</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>{{'pages.cookiePolicy.cookiesMessage.bulletPoint1' | translate}}</li>
+  <li>{{'pages.cookiePolicy.cookiesMessage.bulletPoint2' | translate}}</li>
+</ul>
+
+{{ govukTable({
+  firstCellIsHeader: false,
+  head: [
+    {
+      text: 'pages.cookiePolicy.cookiesMessage.table.headers.col1' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.cookiesMessage.table.headers.col2' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.cookiesMessage.table.headers.col3' | translate,
+      classes: 'govuk-body-s'
+    }
+  ],
+  rows: [
+    [
+    {
+      text: "cookies_preferences_set",
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.cookiesMessage.table.rows.row1.col2' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.cookiesMessage.table.rows.row1.col3' | translate,
+      classes: 'govuk-body-s'
+    }
+    ]
+  ]
+}) }}
+
+<h2 class="govuk-heading-s">{{'pages.cookiePolicy.settingsCookies.header' | translate}}</h2>
+<p class="govuk-body">{{'pages.cookiePolicy.settingsCookies.paragraph1' | translate}}</p>
+<p class="govuk-body">{{'pages.cookiePolicy.settingsCookies.paragraph2' | translate}}</p>
+
+{{ govukTable({
+  firstCellIsHeader: false,
+  head: [
+    {
+      text: 'pages.cookiePolicy.settingsCookies.table.headers.col1' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.settingsCookies.table.headers.col2' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.settingsCookies.table.headers.col3' | translate,
+      classes: 'govuk-body-s'
+    }
+  ],
+  rows: [
+    [
+    {
+      text: "lng",
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.settingsCookies.table.rows.row1.col2' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.settingsCookies.table.rows.row1.col3' | translate,
+      classes: 'govuk-body-s'
+    }
     ]
   ]
 }) }}
@@ -148,11 +207,6 @@
 <h2 class="govuk-heading-s">{{'pages.cookiePolicy.analytics.header' | translate}}</h2>
 <p class="govuk-body">{{'pages.cookiePolicy.analytics.info.paragraph1' | translate}}</p>
 <p class="govuk-body">{{'pages.cookiePolicy.analytics.info.paragraph2' | translate}}</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>{{'pages.cookiePolicy.analytics.info.bulletPoint1' | translate}}</li>
-  <li>{{'pages.cookiePolicy.analytics.info.bulletPoint2' | translate}}</li>
-  <li>{{'pages.cookiePolicy.analytics.info.bulletPoint3' | translate}}</li>
-</ul>
 
 {{ govukTable({
   firstCellIsHeader: false,
@@ -198,6 +252,20 @@
       text: 'pages.cookiePolicy.analytics.table.rows.row2.col3' | translate,
       classes: 'govuk-body-s'
     }
+    ],
+    [
+    {
+      text: "_gat_UA-[number]",
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.rows.row3.col2' | translate,
+      classes: 'govuk-body-s'
+    },
+    {
+      text: 'pages.cookiePolicy.analytics.table.rows.row3.col3' | translate,
+      classes: 'govuk-body-s'
+    }
     ]
   ]
 }) }}
@@ -209,13 +277,6 @@
   name: "cookie_preferences",
   attributes: {
     "id": "radio-cookie-preferences"
-  },
-  fieldset: {
-    legend: {
-      text: 'pages.cookiePolicy.settings.header' | translate,
-      isPageHeading: false,
-      classes: "govuk-fieldset__legend--m"
-    }
   },
   items: [
     {

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -80,7 +80,7 @@
             text: 'general.footer.accessibilityStatement.linkText' | translate
           },
           {
-            href: "https://www.gov.uk/help/cookies",
+            href: "/cookies",
             text: 'general.footer.cookies.linkText' | translate
           },
           {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -526,61 +526,95 @@
       "goBackToService": "Complete your "
     },
     "cookiePolicy": {
-      "title": "Cookies",
-      "header": "Cookies",
+      "title": "GOV.UK accounts cookies policy",
+      "header": "GOV.UK accounts cookies policy",
       "info": {
-        "paragraph1": "GOV.UK Sign in puts small files (known as ‘cookies’) on to your phone, tablet or computer when you use the service.",
-        "paragraph2": "We use these cookies to make the service work.",
-        "paragraph3": "We may also use analytics cookies to learn about how you use the service. Analytics cookies are optional.",
-        "paragraph4": "Cookies aren’t used to identify you personally.",
-        "paragraph5": "Find out more about",
+        "paragraph1": "This cookies policy only covers GOV.UK accounts. Read the main ",
+        "govUkCookiesLinkHref": "https://www.gov.uk/help/cookies",
+        "govUkCookiesLinkText": "GOV.UK cookies policy",
+        "paragraph2": " to find out about cookies that are used on GOV.UK.",
+        "paragraph3": "Cookies are files saved on to your phone, tablet or computer when you visit a website. We use cookies to make the GOV.UK account work.",
+        "paragraph4": "We may also use analytics cookies to learn about how you use the account and help us improve it. We'll ask for your permission before we do this.",
+        "paragraph5": "Cookies are not used to identify you personally.",
+        "paragraph6": "Find out more about",
         "linkHref": "https://ico.org.uk/your-data-matters/online/cookies/",
         "linkText": "how to manage cookies",
-        "paragraph6": " on the Information Commissioner’s Office (ICO) website."
+        "paragraph7": " on the Information Commissioner’s Office (ICO) website."
       },
       "essential": {
-        "header": "Essential cookies",
+        "header": "Strictly necessary cookies",
         "info": {
-          "paragraph1": "We use essential cookies to make the service work as it should.",
+          "paragraph1": "We use essential cookies to:",
+          "bulletPoint1": "make the account work",
+          "bulletPoint2": "keep your information secure",
+          "bulletPoint3": "detect fraudulent or malicious activity and breaches of our terms and conditions",
           "table": {
             "headers": {
               "col1": "Name",
-              "col2": "Purpose",
-              "col3": "Expires"
+              "col2": "Expires"
             },
             "rows": {
               "row1": {
-                "col2": "Remembers whether you chose to use the service in English or Welsh",
-                "col3": "1 year"
+                "col2": "2 hours"
               },
               "row2": {
-                "col2": "Stores session data",
-                "col3": "24 hours"
+                "col2": "When you close your web browser"
               },
               "row3": {
-                "col2": "Stores session data",
-                "col3": "24 hours"
+                "col2": "2 hours"
               },
               "row4": {
-                "col2": "To keep the service secure (security for pages that include forms)",
-                "col3": "When you close your browser"
+                "col2": "13 months"
               },
               "row5": {
-                "col2": "Saves your cookie consent settings",
-                "col3": "1 year"
+                "col2": "2 hours"
               }
             }
           }
         }
       },
+      "cookiesMessage": {
+        "header": "Cookies message",
+        "paragraph1": "You may see a banner when you use your GOV.UK account inviting you to accept cookies or review your settings. We’ll set cookies to: ",
+        "bulletPoint1": "let your computer know you’ve seen this message so you do not get shown it again",
+        "bulletPoint2": "store your settings",
+        "table": {
+          "headers": {
+            "col1": "Name",
+            "col2": "Purpose",
+            "col3": "Expires"
+          },
+          "rows": {
+            "row1": {
+              "col2": "Saves your cookie consent settings",
+              "col3": "1 year"
+            }
+          }
+        }
+      },
+      "settingsCookies": {
+        "header": "Cookies that remember your settings",
+        "paragraph1": "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using your GOV.UK account.",
+        "paragraph2": "We set a cookie when you use your GOV.UK account to save your language preference. At the moment, this defaults to English.",
+        "table": {
+          "headers": {
+            "col1": "Name",
+            "col2": "Purpose",
+            "col3": "Expires"
+          },
+          "rows": {
+            "row1": {
+              "col2": "Remembers the language you use the account in",
+              "col3": "1 year"
+            }
+          }
+        }
+      },
       "analytics": {
-        "header": "Analytics cookies (optional)",
+        "header": "Cookies that measure how you use your GOV.UK account",
         "info": {
-          "paragraph1": "With your permission, we use Google Analytics to help us understand how you use the service. We do this to help us improve the services for our users.",
-          "paragraph2": "Google Analytics stores anonymised information about:",
-          "bulletPoint1": "how you got to GOV.UK Sign in",
-          "bulletPoint2": "the pages you visit and how long you spend on them",
-          "bulletPoint3": "any errors you see while using GOV.UK Sign in"
+          "paragraph1": "We use Google Analytics cookies to collect anonymised information about how you use your GOV.UK account, for example what pages you visit and what you click on.",
+          "paragraph2": "This helps us understand how we can improve the account."
         },
         "table": {
           "headers": {
@@ -596,14 +630,17 @@
             "row2": {
               "col2": "Helps us count how many people visit GOV.UK account by checking if you’ve visited before",
               "col3": "24 hours"
+            },
+            "row3": {
+              "col2": "Helps us count how many people visit GOV.UK accounts by checking if you’ve visited before",
+              "col3": "When you close your web browser"
             }
           }
         }
       },
       "settings": {
-        "header": "Do you want to accept analytics cookies?",
-        "yesRadioButton": "Yes",
-        "noRadioButton": "No",
+        "yesRadioButton": "Use cookies that measure how I use my GOV.UK account",
+        "noRadioButton": "Do not use cookies that measure how I use my GOV.UK account",
         "saveButton": "Save cookie settings"
       },
       "successBanner": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export interface UserSession {
   docCheckingAppUser?: boolean;
   identityProcessCheckStart?: number;
   authAppSecret?: string;
+  cookies_referer?: string;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What?

Restore Sign In cookies policy and update content.

- Stop linking to the GOV.UK Cookies Policy, link instead to the custom Sign In policy which will apply across DI.
- Restore the cookies policy page and the ability to save analytics cookie preferences within the page.
- Update the page content to cover all cookies.

## Why?

The GOV.UK Cookies Policy did not support transferring analytics behaviour from the GOV.UK Account to Sign In.
