### PR TITLE
AUT-497: Update link in cookie banner

### DIFF
--- a/src/components/common/layout/banner.njk
+++ b/src/components/common/layout/banner.njk
@@ -36,7 +36,7 @@
         },
         {
           text: "View cookies",
-          href: "https://www.gov.uk/help/cookies"
+          href: "/cookies"
         }
       ]
     },


### PR DESCRIPTION
## What?

Update link in cookie banner.

## Why?

To point to the new sign in cookie policy page.

## Related PRs

#670 
