### PR TITLE
AUT-537: Add basic auth app code validation

### DIFF
--- a/src/components/setup-authenticator-app/setup-authenticator-app-validation.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-validation.ts
@@ -13,6 +13,15 @@ export function validateSetupAuthAppRequest(): ValidationChainFunc {
             value,
           }
         );
+      })
+      .isLength({ max: 6 })
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.setupAuthenticatorApp.code.validationError.length",
+          {
+            value,
+          }
+        );
       }),
     validateBodyMiddleware("setup-authenticator-app/index.njk"),
   ];

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1409,7 +1409,8 @@
         "hintText": "This is the number show in your authenticator app",
         "validationError":{
           "required": "Enter the security code shown in your authenticator app",
-          "invalidCode": "The security code you entered is not correct, try entering it again or wait for for your authenticator app to give you a new code"
+          "invalidCode": "The security code you entered is not correct, try entering it again or wait for for your authenticator app to give you a new code",
+          "length": "The security code you entered must not be longer than 6 digits"
         }
       },
       "continueButtonText": "Continue",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1409,7 +1409,8 @@
         "hintText": "This is the number show in your authenticator app",
         "validationError":{
          "required": "Enter the security code shown in your authenticator app",
-          "invalidCode": "The security code you entered is not correct, try entering it again or wait for for your authenticator app to give you a new code"
+          "invalidCode": "The security code you entered is not correct, try entering it again or wait for for your authenticator app to give you a new code",
+          "length": "The security code you entered must not be longer than 6 digits"
         }
       },
       "continueButtonText": "Continue",


### PR DESCRIPTION
## What?

- Add a minimum limit of 6 characters on auth app code length

## Why?

- Avoids back end being hit by invalid auth codes (algorithm itself can't process most 10+ digit codes anyway)

## Related PRs

[Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.](https://github.com/alphagov/di-authentication-api/pull/2131) - PR which guards against longer (or nonexistent) strings in the back end
