### PR TITLE
BAU: Add missing switches to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - API_KEY=${API_KEY}
       - FRONTEND_API_BASE_URL=${FRONTEND_API_BASE_URL}
       - ANALYTICS_COOKIE_DOMAIN=localhost
+      - SUPPORT_INTERNATIONAL_NUMBERS=${SUPPORT_INTERNATIONAL_NUMBERS}
+      - SUPPORT_MFA_OPTIONS=${SUPPORT_MFA_OPTIONS}
     restart: on-failure
     networks:
       - di-net


### PR DESCRIPTION
## What?

Add missing switches to docker-compose.

- SUPPORT_INTERNATIONAL_NUMBERS
- SUPPORT_MFA_OPTIONS

## Why?

Able to test locally with the switches on and off.

