### PR TITLE
AUT-497: Remove cookies update referer from session

### DIFF
--- a/src/components/common/cookies/cookies-controller.ts
+++ b/src/components/common/cookies/cookies-controller.ts
@@ -14,8 +14,7 @@ export function cookiesGet(req: Request, res: Response): void {
     sanitize(req.cookies.cookies_preferences_set)
   );
 
-  req.session.user.cookies_referer = req.headers.referer;
-  res.locals.backUrl = req.session.user.cookies_referer;
+  res.locals.backUrl = req.headers.referer;
   res.locals.analyticsConsent =
     consentValue.cookie_consent === COOKIE_CONSENT.ACCEPT;
   res.locals.updated = false;
@@ -30,7 +29,7 @@ export function cookiesPost(req: Request, res: Response): void {
 
   createConsentCookie(res, consentCookieValue);
 
-  res.locals.backUrl = req.session.user.cookies_referer;
+  res.locals.backUrl = req.body.originalReferer;
   res.locals.analyticsConsent = consentValue === "true";
   res.locals.updated = true;
   res.render("common/cookies/index.njk");

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -272,6 +272,7 @@
 
 <form method="post" id="cookie-preferences-form" novalidate hidden="true">
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+<input type="hidden" name="originalReferer" value="{{backUrl}}"/>
 {{ govukRadios({
   idPrefix: "cookie-preferences",
   name: "cookie_preferences",

--- a/src/components/common/cookies/tests/cookies-controller.test.ts
+++ b/src/components/common/cookies/tests/cookies-controller.test.ts
@@ -44,7 +44,7 @@ describe("cookies controller", () => {
   describe("cookiesPost", () => {
     it("should save analytics preferences as yes and render cookies page", () => {
       req.body.cookie_preferences = "true";
-      req.session.user.cookies_referer = "/page-before-1";
+      req.body.originalReferer = "/page-before-1";
 
       cookiesPost(req as Request, res as Response);
 
@@ -56,7 +56,7 @@ describe("cookies controller", () => {
     });
     it("should save analytics preferences as no and render cookies page", () => {
       req.body.cookie_preferences = "false";
-      req.session.user.cookies_referer = "/page-before-2";
+      req.body.originalReferer = "/page-before-2";
 
       cookiesPost(req as Request, res as Response);
 


### PR DESCRIPTION
## What?

Remove cookies update referer from session.  Add as a hidden form parameter instead to remove reliance on the session.

## Why?

Stops users without a session from seeing an error.

The cookies policy page shows a banner when the cookies preferences are updated with a link to go back to the page the user was looking at.  Given that the user can submit their preferences multiple times this could not be based on the original 'referer' as the referer could then be the cookies page, so this information was stored in the session.

A few users appear to be landing directly on the accessiblity statement or privacy statement, meaning they don't have a session.  If they clicked on the cookies page they then saw an error.  These users may be bots, but it's possible they are arriving directly from a search engine and are real users.

## Related PRs

#670 

