### PR TITLE
AUT-534: Redisplay auth app qr code and secret after validation error

### DIFF
--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -26,12 +26,12 @@
 <p class="govuk-body">{{'pages.setupAuthenticatorApp.step2' | translate }}</p>
 
 <p class="govuk-body">
-  <img src="{{qrCode}}" alt="QR Code Image">
+  <img id="qr-code" src="{{qrCode}}" alt="QR Code Image">
 </p>
 
 <p class="govuk-body">
     {{ 'pages.setupAuthenticatorApp.secretKeyLabelText' | translate }}
-    <span class="govuk-body govuk-!-font-weight-bold">{{secretKey}}</span>
+    <span id="secret-key" class="govuk-body govuk-!-font-weight-bold">{{secretKey}}</span>
 </p>
 <p class="govuk-body">{{'pages.setupAuthenticatorApp.step3' | translate }}</p>
 <p class="govuk-body">{{'pages.setupAuthenticatorApp.step4' | translate }}</p>
@@ -39,6 +39,7 @@
 <form id="form-tracking" method="post" novalidate>
   
   <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+  <input type="hidden" name="_secretKey" value="{{secretKey}}"/>
 
   {{ govukInput({
   label: {
@@ -47,7 +48,7 @@
   hint: {
       text: 'pages.setupAuthenticatorApp.code.hintText' | translate
   },
-  classes: "govuk-!-width-two-thirds govuk-!-font-weight-bold",
+  classes: "govuk-input--width-10 govuk-!-font-weight-bold",
   id: "code",
   name: "code",
   type: "number",

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -29,10 +29,10 @@ export async function setupAuthenticatorAppGet(
     req.t("general.authenticatorAppIssuer")
   );
 
-  const qrCodeUrl = await QRCode.toDataURL(qrCodeText);
+  req.session.user.authAppQrCodeUrl = await QRCode.toDataURL(qrCodeText);
 
   res.render(TEMPLATE, {
-    qrCode: qrCodeUrl,
+    qrCode: req.session.user.authAppQrCodeUrl,
     secretKey: req.session.user.authAppSecret,
   });
 }
@@ -78,7 +78,10 @@ export function setupAuthenticatorAppPost(
           "code",
           req.t("pages.setupAuthenticatorApp.code.validationError.invalidCode")
         );
-        return renderBadRequest(res, req, TEMPLATE, error);
+        return renderBadRequest(res, req, TEMPLATE, error, {
+          qrCode: req.session.user.authAppQrCodeUrl,
+          secretKey: req.session.user.authAppSecret,
+        });
       }
 
       throw new BadRequestError(

--- a/src/components/setup-authenticator-app/setup-authenticator-app-validation.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-validation.ts
@@ -1,6 +1,7 @@
 import { body } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
+import { Request } from "express";
 
 export function validateSetupAuthAppRequest(): ValidationChainFunc {
   return [
@@ -14,7 +15,7 @@ export function validateSetupAuthAppRequest(): ValidationChainFunc {
           }
         );
       })
-      .isLength({ max: 6 })
+      .isLength({ min: 6, max: 6 })
       .withMessage((value, { req }) => {
         return req.t(
           "pages.setupAuthenticatorApp.code.validationError.length",
@@ -23,7 +24,18 @@ export function validateSetupAuthAppRequest(): ValidationChainFunc {
           }
         );
       }),
-
-    validateBodyMiddleware("setup-authenticator-app/index.njk"),
+    validateBodyMiddleware(
+      "setup-authenticator-app/index.njk",
+      postValidationLocals
+    ),
   ];
 }
+
+const postValidationLocals = function locals(
+  req: Request
+): Record<string, unknown> {
+  return {
+    qrCode: req.session.user.authAppQrCodeUrl,
+    secretKey: req.session.user.authAppSecret,
+  };
+};

--- a/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
+++ b/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
@@ -89,6 +89,7 @@ describe("Integration::setup-authenticator-app", () => {
         expect($("#code-error").text()).to.contains(
           "Enter the security code shown in your authenticator app"
         );
+        expect($("#secret-key").text()).to.not.be.empty;
       })
       .expect(400, done);
   });
@@ -107,6 +108,7 @@ describe("Integration::setup-authenticator-app", () => {
         expect($("#code-error").text()).to.contains(
           "Enter the security code using only 6 digits"
         );
+        expect($("#secret-key").text()).to.not.be.empty;
       })
       .expect(400, done);
   });

--- a/src/middleware/form-validation-middleware.ts
+++ b/src/middleware/form-validation-middleware.ts
@@ -15,14 +15,21 @@ export const validationErrorFormatter = ({
   };
 };
 
-export function validateBodyMiddleware(template: string) {
+export function validateBodyMiddleware(
+  template: string,
+  postValidationLocals?: (req: Request) => Record<string, unknown>
+) {
   return (req: Request, res: Response, next: NextFunction): any => {
     const errors = validationResult(req)
       .formatWith(validationErrorFormatter)
       .mapped();
 
+    const locals =
+      typeof postValidationLocals !== "undefined"
+        ? postValidationLocals(req)
+        : undefined;
     if (!isObjectEmpty(errors)) {
-      return renderBadRequest(res, req, template, errors);
+      return renderBadRequest(res, req, template, errors, locals);
     }
     next();
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,7 @@ export interface UserSession {
   docCheckingAppUser?: boolean;
   identityProcessCheckStart?: number;
   authAppSecret?: string;
-  cookies_referer?: string;
+  authAppQrCodeUrl?: string;
 }
 
 export interface UserSessionClient {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -22,7 +22,8 @@ export function renderBadRequest(
   res: Response,
   req: Request,
   template: string,
-  errors: { [k: string]: Error }
+  errors: { [k: string]: Error },
+  postValidationLocals?: Record<string, unknown>
 ): void {
   res.status(HTTP_STATUS_CODES.BAD_REQUEST);
 
@@ -30,10 +31,14 @@ export function renderBadRequest(
   const uniqueErrorList = [
     ...new Map(errorValues.map((error) => [error.text, error])).values(),
   ];
-  return res.render(template, {
+  const errorParams = {
     errors,
     errorList: uniqueErrorList,
     ...req.body,
     language: req.i18n.language,
-  });
+  };
+  const params = postValidationLocals
+    ? { ...errorParams, ...postValidationLocals }
+    : errorParams;
+  return res.render(template, params);
 }


### PR DESCRIPTION
## What?

Redisplay auth app QR code and secret after validation error.

Add an additional optional parameter to 'validateBodyMiddleware' and 'renderBadRequest' to allow for locals to be passed back to the page after a validation error.

## Why?

When the user entered an invalid or incorrect code the page was being redisplayed without the QR code and secret.