### PR TITLE
AUT-538: Make "Get a security code by text message instead" link redirect to /enter-phone-number

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -241,6 +241,9 @@ const authStateMachine = createMachine(
             { target: [PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL] },
           ],
         },
+        meta: {
+          optionalPaths: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
+        },
       },
       [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER]: {
         on: {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -12,7 +12,7 @@
       "tag": "beta",
       "content": "This is a new service – your <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">feedback (opens in new tab)</a> will help us to improve it."
     },
-    "authenticatorAppIssuer": "GOV.UK SignIn",
+    "authenticatorAppIssuer": "GOV.UK account",
     "yes": "Yes",
     "no": "No",
     "cookie": {


### PR DESCRIPTION
## What?

Make "Get a security code by text message instead" link redirect to /enter-phone-number.

Update the state machine to allow the redirect.
Update product name text used to show codes in authenticator apps

## Why?

The link was not redirecting correctly.
