### PR TITLE
BAU: remove github actions coverage task

### DIFF
--- a/.github/workflows/analyse-on-merge.yml
+++ b/.github/workflows/analyse-on-merge.yml
@@ -35,8 +35,6 @@ jobs:
         run: yarn test:integration
       - name: Run lint
         run: yarn lint
-      - name: Run test coverage
-        run: yarn test:coverage
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -40,8 +40,6 @@ jobs:
         run: yarn test:integration
       - name: Run lint
         run: yarn lint
-      - name: Run test coverage
-        run: yarn test:coverage
       - name: SonarCloud Scan
         if: ${{ github.actor != 'dependabot[bot]' }}
         uses: sonarsource/sonarcloud-github-action@master


### PR DESCRIPTION
## What?

Remove github actions coverage task

## Why?

The unit test and integration test tasks already produce coverage reports so this is duplication.
As these tasks also clear coverage before running the output only represents integration test coverage and not combined coverage.
