### PR TITLE
[DO NOT MERGE] AUT-535: Add option to go back from SMS MFA code entry screen

### DIFF
--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -3,27 +3,32 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.checkYourPhone.title' | translate %}
 
 {% block content %}
 
-{% include "common/errors/errorSummary.njk" %}
+  {% include "common/errors/errorSummary.njk" %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourPhone.header' | translate }}</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourPhone.header' | translate }}</h1>
 
-<p class="govuk-body">{{'pages.checkYourPhone.info.paragraph1' | translate | replace("[mobile]", phoneNumber )}}</p>
-<p class="govuk-body">{{'pages.checkYourPhone.info.paragraph2' | translate }}</p>
+  {% set redactedPhoneNumberText = 'pages.checkYourPhone.info.paragraph1' | translate | replace("[mobile]", phoneNumber) %}
+  {{ govukInsetText({
+    text: redactedPhoneNumberText
+  }) }}
 
-<form action="/check-your-phone" method="post" novalidate>
+  <p class="govuk-body">{{'pages.checkYourPhone.info.paragraph2' | translate }}</p>
 
-  <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-  <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
+  <form action="/check-your-phone" method="post" novalidate="novalidate">
 
-  {{ govukInput({
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
+
+    {{ govukInput({
   label: {
   text: 'pages.checkYourPhone.code.label' | translate
   },
-  classes: "govuk-!-width-two-thirds govuk-!-font-weight-bold",
+  classes: "govuk-input--width-10 govuk-!-font-weight-bold",
   id: "code",
   name: "code",
   type: "number",
@@ -35,18 +40,30 @@
   } if (errors['code'])})
   }}
 
-    <p class="govuk-body"> <a href="/enter-phone-number" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.resend.link' | translate }}</a> {{ 'pages.checkYourPhone.resend.paragraph1' | translate}}</p>
-    <ul class="govuk-list govuk-list--bullet">
-     <li>{{ 'pages.checkYourPhone.resend.listItem1' | translate}}</li>
-     <li>{{ 'pages.checkYourPhone.resend.listItem2' | translate}}</li>
-    </ul>
+    {% set detailsHTML %}
+    <p class="govuk-body">
+      {{'pages.checkYourPhone.details.text1' | translate}}
+      <a href="{{'pages.checkYourPhone.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.sendCodeLinkText'| translate}}</a>
+      {{'pages.checkYourPhone.details.text 2' | translate}}
+      <a href="{{'pages.checkYourPhone.details.changePhoneNumberLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.changePhoneNumberLinkText'| translate}}</a>.
+    </p>
 
-  {{ govukButton({
+    <p class="govuk-body">
+      <a href="{{'pages.checkYourPhone.details.changeMfaChoiceLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.changeMfaChoiceLinkText'| translate}}</a>.
+    </p>
+    {% endset %}
+
+    {{ govukDetails({
+  summaryText: 'pages.checkYourPhone.details.summaryText' | translate,
+  html: detailsHTML
+  }) }}
+
+    {{ govukButton({
   "text": button_text|default('general.continue.label' | translate, true),
   "type": "Submit",
   "preventDoubleClick": true
   }) }}
 
-</form>
+  </form>
 
 {% endblock %}

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -279,6 +279,7 @@ const authStateMachine = createMachine(
             PATH_NAMES.SECURITY_CODE_INVALID,
             PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED,
             PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
+            PATH_NAMES.GET_SECURITY_CODES,
           ],
         },
       },

--- a/src/components/enter-phone-number/index.njk
+++ b/src/components/enter-phone-number/index.njk
@@ -5,34 +5,26 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-    {% if isAccountPartCreated %}
-        {% set pageTitleName = 'pages.enterPhoneNumber.returningUser.title' | translate %}
-    {% else %}
-        {% set pageTitleName = 'pages.enterPhoneNumber.title' | translate %}
-    {% endif %}
+{% set pageTitleName = 'pages.enterPhoneNumber.title' | translate %}
 
 {% block content %}
-{% include "common/errors/errorSummary.njk" %}
+  {% include "common/errors/errorSummary.njk" %}
 
-
-   {% if isAccountPartCreated %}
-      <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.returningUser.header' |
-        translate}}</h1>
-       <p class="govuk-body">{{'pages.enterPhoneNumber.returningUser.info.paragraph1' | translate}}</p>
-       <p class="govuk-body">{{'pages.enterPhoneNumber.returningUser.info.paragraph2' | translate}}</p>
-   {% else %}
-       <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.header' |
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.header' |
          translate}}</h1>
-        <p class="govuk-body">{{'pages.enterPhoneNumber.info.paragraph1' | translate}}</p>
-   {% endif %}
 
-<form action="/enter-phone-number" method="post" novalidate>
+  {% if supportInternationalNumbers | length %}
+    <p class="govuk-body">{{'pages.enterPhoneNumber.info.paragraph1' | translate}}</p>
+  {% endif %}
+  <p class="govuk-body">{{'pages.enterPhoneNumber.info.paragraph2' | translate}}</p>
 
-  <input type="hidden" name="_csrf" value="{{csrfToken}}" />
-  <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}" />
-  <input type="hidden" name="isAccountPartCreated" value="{{isAccountPartCreated}}" />
+  <form action="/enter-phone-number" method="post" novalidate="novalidate">
 
-  {{ govukInput({
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}"/>
+    <input type="hidden" name="isAccountPartCreated" value="{{isAccountPartCreated}}"/>
+
+    {{ govukInput({
   label: {
   text: 'pages.enterPhoneNumber.ukPhoneNumber.label' | translate
   },
@@ -47,7 +39,7 @@
   } if (errors['phoneNumber'])})
   }}
 
-  {% if supportInternationalNumbers %}
+    {% if supportInternationalNumbers %}
 
       {% set internationalNumberHtml %}
       {{ govukInput({
@@ -84,15 +76,14 @@
         ]
       }) }}
 
-  {% endif %}
+    {% endif %}
 
-  {{ govukButton({
+    {{ govukButton({
   "text": button_text|default('general.continue.label' | translate, true),
   "type": "Submit",
   "preventDoubleClick": true
   }) }}
 
-</form>
-
+  </form>
 
 {% endblock %}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -298,15 +298,8 @@
       "title": "Enter your mobile phone number",
       "header": "Enter your mobile phone number",
       "info": {
-        "paragraph1": "We will send a 6 digit security code to the number you give us."
-      },
-      "returningUser": {
-        "title": "Finish creating your account",
-        "header": "Finish creating your account",
-        "info": {
-          "paragraph1": "You need to add a UK mobile phone number to your GOV.UK account.",
-          "paragraph2": "We will send a 6 digit security code to the number you give us."
-        }
+        "paragraph1": "You need to add a UK mobile phone number to your GOV.UK account.",
+        "paragraph2": "We will send a 6 digit security code to the number you give us."
       },
       "ukPhoneNumber": {
         "label": "UK mobile phone number",
@@ -369,14 +362,8 @@
       "title": "Check your phone",
       "header": "Check your phone",
       "info": {
-        "paragraph1": "We sent a code to [mobile].",
+        "paragraph1": "We have sent a code to [mobile].",
         "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes."
-      },
-      "resend": {
-        "link": "Request a new code",
-        "paragraph1": "if:",
-        "listItem1": "the code is not working or has expired, or you did not receive one",
-        "listItem2": "you want to use a different phone number"
       },
       "code": {
         "label": "Enter the 6 digit security code",
@@ -387,6 +374,17 @@
           "invalidFormat": "Enter the security code using only 6 digits",
           "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
         }
+      },
+      "details": {
+        "summaryText": "Problems with the code?",
+        "text1": "We can ",
+        "sendCodeLinkText": "send the code again",
+        "sendCodeLinkHref": "/enter-phone-number",
+        "text 2": " or you can ",
+        "changePhoneNumberLinkText": "use a different phone number",
+        "changePhoneNumberLinkHref": "/enter-phone-number",
+        "changeMfaChoiceLinkText": "Get a code another way",
+        "changeMfaChoiceLinkHref": "/get-security-codes"
       }
     },
     "securityCodeInvalid": {
@@ -1526,11 +1524,11 @@
       },
       "step2": "2. Use your authenticator app to scan the QR code or type the secret key into your authenticator app.  Some authenticator apps call the secret key a 'code'.",
       "secretKeyLabelText": "Secret key: ",
-      "step3": "3. The authenticator app will show an access code.",
-      "step4": "4. Enter the access code.",
+      "step3": "3. The authenticator app will show a security code.",
+      "step4": "4. Enter the security code.",
       "code": {
-        "label": "Access code",
-        "hintText": "This is the number show in your authenticator app",
+        "label": "Security code",
+        "hintText": "This is the number shown in your authenticator app",
         "validationError":{
          "required": "Enter the security code shown in your authenticator app",
           "invalidCode": "The security code you entered is not correct, try entering it again or wait for for your authenticator app to give you a new code",
@@ -1538,7 +1536,7 @@
         }
       },
       "continueButtonText": "Continue",
-      "textMessageInsteadLinkText": "Get a security code by text message instead"
+      "textMessageInsteadLinkText": "Get a code another way"
     },
     "enterAuthenticatorAppCode": {
       "title": "Enter the security code shown in your authenticator app",


### PR DESCRIPTION
One of the links currently in this PR will need to change - the 'resend code' link on the SMS MFA journey. This has not yet been implemented, but is expected to go live before the auth app journey.

## What?

- Amend state machine to make it possible to return to MFA type selection screen from phone number set-up screen i.e. allowing auth app selection instead
- Add links in details element to allow change of phone number or change of MFA type selection
- Amend content to match Figma
-- Includes changing enter your mobile phone number page not to differentiate between returning and non-returning user
-- Includes changing enter your mobile phone number page to include paragraph on You need to add a UK mobile phone number to your GOV.UK account to not display when international phone numbers are enabled

## Why?

So that a user is able to reverse MFA method selection up to the point that it is set up e.g. because they have a problem receiving security code via SMS or because their auth app cannot successfully scan the QR code.
