### PR TITLE
BAU: Sanitize cookie referrer

### DIFF
--- a/src/components/common/cookies/cookies-controller.ts
+++ b/src/components/common/cookies/cookies-controller.ts
@@ -14,7 +14,7 @@ export function cookiesGet(req: Request, res: Response): void {
     sanitize(req.cookies.cookies_preferences_set)
   );
 
-  res.locals.backUrl = req.headers.referer;
+  res.locals.backUrl = sanitize(req.headers.referer);
   res.locals.analyticsConsent =
     consentValue.cookie_consent === COOKIE_CONSENT.ACCEPT;
   res.locals.updated = false;


### PR DESCRIPTION
## What?

Sanitize cookie referrer.

Add extra sanitization to the referrer to the cookie page.

## Why?

Additional security just in case Nunjucks fails to do the sanitization.
