### PR TITLE
AUT-576: Use cookie to track history when setting analytics cookies

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -2,6 +2,7 @@
 
 var cookies = function (trackingId, analyticsCookieDomain) {
   var COOKIES_PREFERENCES_SET = "cookies_preferences_set";
+  var COOKIES_HISTORY_LENGTH = "chl";
   var cookiesAccepted = document.querySelector("#cookies-accepted");
   var cookiesRejected = document.querySelector("#cookies-rejected");
   var hideCookieBanner = document.querySelectorAll(".cookie-hide-button");
@@ -64,6 +65,21 @@ var cookies = function (trackingId, analyticsCookieDomain) {
 
   function cookiesPageInit() {
     document.querySelector("#cookie-preferences-form").hidden = false;
+    var chl = getCookie(COOKIES_HISTORY_LENGTH);
+    if (! chl || chl === "0" ) {
+      setCookie(
+        COOKIES_HISTORY_LENGTH,
+        window.history.length
+        );
+    }
+    document.querySelector("#go-back-link").onclick = function() {
+      var chl = getCookie(COOKIES_HISTORY_LENGTH);
+      if (chl && !isNaN(chl)) {
+        var backCount = (window.history.length - chl) + 1;
+        window.history.go(-(Math.abs(backCount)));
+        setCookie(COOKIES_HISTORY_LENGTH, 0);
+      }
+    };
   }
 
   function hasConsentForAnalytics() {

--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -13,7 +13,7 @@
   {{ 'pages.cookiePolicy.successBanner.header' | translate }}
 </h3>
 <p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translate }}</p>
-<a class="govuk-notification-banner__link" id="go-back-link" href={{ backUrl }}>{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
+<a class="govuk-notification-banner__link" id="go-back-link" href="#">{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
 {% endset %}
 
 {% if updated %}
@@ -336,7 +336,6 @@
 
 <form method="post" id="cookie-preferences-form" novalidate hidden="true">
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-<input type="hidden" name="originalReferer" value="{{backUrl}}"/>
 {{ govukRadios({
   idPrefix: "cookie-preferences",
   name: "cookie_preferences",


### PR DESCRIPTION



## What?

Use cookie to track history when setting analytics cookies.

Uses a new cookie 'chl' to store the referring place in the browser history when landing on the cookies page.  This can then be used to calculate how far to go back in history to get to the referring page when the user clicks on the 'Go back to the page you were looking at' link after changing analytics cookie preferences.

## Why?

Removes reliance on the 'referrer' header which is not guaranteed to be correct across domains with a referrer policy.
Javascript is guaranteed to be available in this scenario as the user cannot switch on analytics cookies with javascript being on.

## Related PRs

#670
