### PR TITLE
AUT-582: Add an external route to the http 500 error page (for the doc-app-callback api)

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -48,6 +48,7 @@ export const PATH_NAMES = {
   ENTER_AUTHENTICATOR_APP_CODE: "/enter-authenticator-app-code",
   CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP: "/setup-authenticator-app",
   COOKIES_POLICY: "/cookies",
+  ERROR_PAGE: "/error",
 };
 
 export const HTTP_STATUS_CODES = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -73,6 +73,7 @@ import { selectMFAOptionsRouter } from "./components/select-mfa-options/select-m
 import { setupAuthenticatorAppRouter } from "./components/setup-authenticator-app/setup-authenticator-app-routes";
 import { enterAuthenticatorAppCodeRouter } from "./components/enter-authenticator-app-code/enter-authenticator-app-code-routes";
 import { cookiesRouter } from "./components/common/cookies/cookies-routes";
+import { errorPageRouter } from "./components/common/errors/error-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -114,6 +115,7 @@ function registerRoutes(app: express.Application) {
   app.use(cookiesRouter);
   app.use(docCheckingAppRouter);
   app.use(docCheckingAppCallbackRouter);
+  app.use(errorPageRouter);
 }
 
 async function createApp(): Promise<express.Application> {

--- a/src/components/common/errors/error-controller.ts
+++ b/src/components/common/errors/error-controller.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from "express";
+import { HTTP_STATUS_CODES } from "../../../app.constants";
+
+export function errorPageGet(req: Request, res: Response): void {
+  res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+  res.render("common/errors/500.njk");
+}

--- a/src/components/common/errors/error-routes.ts
+++ b/src/components/common/errors/error-routes.ts
@@ -1,0 +1,10 @@
+import { PATH_NAMES } from "../../../app.constants";
+import * as express from "express";
+import { validateSessionMiddleware } from "../../../middleware/session-middleware";
+import { errorPageGet } from "./error-controller";
+
+const router = express.Router();
+
+router.get(PATH_NAMES.ERROR_PAGE, validateSessionMiddleware, errorPageGet);
+
+export { router as errorPageRouter };

--- a/src/components/common/errors/tests/error-controller.test.ts
+++ b/src/components/common/errors/tests/error-controller.test.ts
@@ -1,0 +1,40 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import { errorPageGet } from "../error-controller";
+
+import { PATH_NAMES } from "../../../../app.constants";
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
+
+describe("error page controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = mockRequest({
+      path: PATH_NAMES.ERROR_PAGE,
+      session: { client: {}, user: {} },
+      log: { info: sinon.fake() },
+    });
+    res = mockResponse();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("errorPageGet", () => {
+    it("should render the error page", () => {
+      errorPageGet(req as Request, res as Response);
+
+      expect(res.render).to.have.been.calledWith("common/errors/500.njk");
+    });
+  });
+});


### PR DESCRIPTION
## What?

Add an external route to the http 500 error page (for the doc-app-callback api).

## Why?

So that the doc-app-callback lambda can redirect to this error page in the event of an internal server error.

At the moment the 500 error page is only displayed in response to an internal error, such as when an error is returned by api call, and there is no way to route to this page externally.

The doc-app-callback lambda returns a 500 directly in case of error, which is displayed in the browser in a rather unfriendly way.  When this route is deployed the api will be able to route to the more user friendly error page when something goes wrong, where links to contact support etc are available.
