### PR TITLE
AUT-393: Add resend phone OTP code screen to account creation journey

### DIFF
--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -3,27 +3,33 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.checkYourPhone.title' | translate %}
+{% set showBack = true %}
+{% set hrefBack = 'pages.checkYourPhone.details.changePhoneNumberLinkHref' | translate %}
 
 {% block content %}
 
-{% include "common/errors/errorSummary.njk" %}
+  {% include "common/errors/errorSummary.njk" %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourPhone.header' | translate }}</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourPhone.header' | translate }}</h1>
 
-<p class="govuk-body">{{'pages.checkYourPhone.info.paragraph1' | translate | replace("[mobile]", phoneNumber )}}</p>
-<p class="govuk-body">{{'pages.checkYourPhone.info.paragraph2' | translate }}</p>
+  {{ govukInsetText({
+    text: 'pages.checkYourPhone.info.paragraph1' | translate | replace("[mobile]", phoneNumber )
+  }) }}
 
-<form action="/check-your-phone" method="post" novalidate>
+  <p class="govuk-body">{{'pages.checkYourPhone.info.paragraph2' | translate }}</p>
 
-  <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-  <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
+  <form action="/check-your-phone" method="post" novalidate="novalidate">
 
-  {{ govukInput({
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
+
+    {{ govukInput({
   label: {
   text: 'pages.checkYourPhone.code.label' | translate
   },
-  classes: "govuk-!-width-two-thirds govuk-!-font-weight-bold",
+  classes: "govuk-input--width-10 govuk-!-font-weight-bold",
   id: "code",
   name: "code",
   type: "number",
@@ -35,18 +41,26 @@
   } if (errors['code'])})
   }}
 
-    <p class="govuk-body"> <a href="/enter-phone-number" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.resend.link' | translate }}</a> {{ 'pages.checkYourPhone.resend.paragraph1' | translate}}</p>
-    <ul class="govuk-list govuk-list--bullet">
-     <li>{{ 'pages.checkYourPhone.resend.listItem1' | translate}}</li>
-     <li>{{ 'pages.checkYourPhone.resend.listItem2' | translate}}</li>
-    </ul>
+    {% set detailsHTML %}
+    <p class="govuk-body">
+      {{'pages.checkYourPhone.details.text1' | translate}}
+      <a href="{{'pages.checkYourPhone.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.sendCodeLinkText'| translate}}</a>
+      {{'pages.checkYourPhone.details.text 2' | translate}}
+      <a href="{{'pages.checkYourPhone.details.changePhoneNumberLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.changePhoneNumberLinkText'| translate}}</a>.
+    </p>
+    {% endset %}
 
-  {{ govukButton({
+    {{ govukDetails({
+      summaryText: 'pages.checkYourPhone.details.summaryText' | translate,
+      html: detailsHTML
+    }) }}
+
+    {{ govukButton({
   "text": button_text|default('general.continue.label' | translate, true),
   "type": "Submit",
   "preventDoubleClick": true
   }) }}
 
-</form>
+  </form>
 
 {% endblock %}

--- a/src/components/common/mfa/mfa-service.ts
+++ b/src/components/common/mfa/mfa-service.ts
@@ -14,12 +14,14 @@ export function mfaService(axios: Http = http): MfaServiceInterface {
     clientSessionId: string,
     emailAddress: string,
     sourceIp: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    isResendCodeRequest: boolean
   ): Promise<ApiResponseResult<DefaultApiResponse>> {
     const response = await axios.client.post<DefaultApiResponse>(
       API_ENDPOINTS.MFA,
       {
         email: emailAddress,
+        isResendCodeRequest,
       },
       getRequestConfig({
         sessionId: sessionId,

--- a/src/components/common/mfa/types.ts
+++ b/src/components/common/mfa/types.ts
@@ -6,6 +6,7 @@ export interface MfaServiceInterface {
     clientSessionId: string,
     emailAddress: string,
     sourceIp: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    isResendCodeRequest: boolean
   ) => Promise<ApiResponseResult<DefaultApiResponse>>;
 }

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -279,6 +279,7 @@ const authStateMachine = createMachine(
             PATH_NAMES.SECURITY_CODE_INVALID,
             PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED,
             PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
+            PATH_NAMES.RESEND_MFA_CODE,
           ],
         },
       },

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -7,22 +7,22 @@
 
 {% block content %}
 
-{% include "common/errors/errorSummary.njk" %}
+  {% include "common/errors/errorSummary.njk" %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterMfa.header' | translate }}</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterMfa.header' | translate }}</h1>
 
-<p class="govuk-body">{{'pages.enterMfa.info.paragraph1' | translate | replace("[mobile]", phoneNumber )}}</p>
-<p class="govuk-body">{{'pages.enterMfa.info.paragraph2' | translate | replace("[mobile]", phoneNumber )}}</p>
+  <p class="govuk-body">{{'pages.enterMfa.info.paragraph1' | translate }}</p>
+  <p class="govuk-body">{{'pages.enterMfa.info.paragraph2' | translate }}</p>
 
-<form id="form-tracking" action="/enter-code" method="post" novalidate>
-  <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
-  <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+  <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">
+    <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
-  {{ govukInput({
+    {{ govukInput({
   label: {
   text: 'pages.enterMfa.code.label' | translate
   },
-  classes: "govuk-!-width-two-thirds govuk-!-font-weight-bold",
+  classes: "govuk-input--width-10 govuk-!-font-weight-bold",
   id: "code",
   name: "code",
   type: "number",
@@ -32,14 +32,25 @@
   } if (errors['code'])})
   }}
 
-  <p class="govuk-body"> <a href="/resend-code" class="govuk-link" rel="noreferrer">{{'pages.enterMfa.resend.link' | translate }}</a> {{ 'pages.enterMfa.resend.paragraph1' | translate}}</p>
+    {% set detailsHTML %}
+    <p class="govuk-body">
+      {{'pages.enterMfa.details.text1' | translate}}
+      <a href="{{'pages.enterMfa.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterMfa.details.sendCodeLinkText'| translate}}</a>
+      {{'pages.enterMfa.details.text 2' | translate}}
+    </p>
+    {% endset %}
 
-  {{ govukButton({
+    {{ govukDetails({
+      summaryText: 'pages.enterMfa.details.summaryText' | translate,
+      html: detailsHTML
+    }) }}
+
+    {{ govukButton({
   "text": button_text|default('general.continue.label' | translate, true),
   "type": "Submit",
   "preventDoubleClick": true
   }) }}
 
-</form>
+  </form>
 
 {% endblock %}

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -109,7 +109,8 @@ export function enterPasswordPost(
         clientSessionId,
         email,
         req.ip,
-        persistentSessionId
+        persistentSessionId,
+        false
       );
 
       if (!result.success) {

--- a/src/components/resend-mfa-code/index.njk
+++ b/src/components/resend-mfa-code/index.njk
@@ -1,22 +1,34 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
 {% set pageTitleName = 'pages.resendMfaCode.title' | translate %}
 {% set showBack = true %}
 {% set hrefBack = 'enter-code' %}
+
+{% if isResendCodeRequest %}
+    {% set phoneNumberMessage = 'pages.resendMfaCode.phoneNumber.isResendCodeRequest' | translate | replace("[mobile]", phoneNumber) %}
+{% else %}
+    {% set phoneNumberMessage = 'pages.resendMfaCode.phoneNumber.default' | translate | replace("[mobile]", phoneNumber) %}
+{% endif %}
+
 {% block content %}
+    <form action="/resend-code" method="post" novalidate="novalidate">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+        <input type="hidden" name="isResendCodeRequest" value="{{isResendCodeRequest}}"/>
 
-<form action="/resend-code" method="post" novalidate>
-<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resendMfaCode.header' | translate}}</h1>
 
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resendMfaCode.header' | translate }}</h1>
-    <p class="govuk-body">{{'pages.resendMfaCode.phoneNumber' | translate | replace("[mobile]", phoneNumber )}}</p>
-    <p class="govuk-body">{{'pages.resendMfaCode.message' | translate}}</p>
-    {{ govukButton({
+        {{ govukInsetText({
+            text: phoneNumberMessage
+        }) }}
+
+        <p class="govuk-body">{{'pages.resendMfaCode.message' | translate}}</p>
+        {{ govukButton({
         "text": button_text|default('pages.resendMfaCode.continue' | translate, true),
         "type": "Submit",
         "preventDoubleClick": true
     }) }}
 
-</form>
-
+    </form>
 {% endblock %}

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -7,6 +7,7 @@ import { sendMfaGeneric } from "../common/mfa/send-mfa-controller";
 export function resendMfaCodeGet(req: Request, res: Response): void {
   res.render("resend-mfa-code/index.njk", {
     phoneNumber: req.session.user.phoneNumber,
+    isResendCodeRequest: req.query?.isResendCodeRequest,
   });
 }
 

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -5,10 +5,22 @@ import { MfaServiceInterface } from "../common/mfa/types";
 import { sendMfaGeneric } from "../common/mfa/send-mfa-controller";
 
 export function resendMfaCodeGet(req: Request, res: Response): void {
-  res.render("resend-mfa-code/index.njk", {
-    phoneNumber: req.session.user.phoneNumber,
-    isResendCodeRequest: req.query?.isResendCodeRequest,
-  });
+  const isStillLockedOutBy15MinOtpCodeBlockWindow = req.cookies?.re;
+
+  if (isStillLockedOutBy15MinOtpCodeBlockWindow) {
+    const newCodeLink = req.query?.isResendCodeRequest
+      ? "/resend-code?isResendCodeRequest=true"
+      : "/resend-code";
+
+    res.render("security-code-error/index-wait.njk", {
+      newCodeLink,
+    });
+  } else {
+    res.render("resend-mfa-code/index.njk", {
+      phoneNumber: req.session.user.phoneNumber,
+      isResendCodeRequest: req.query?.isResendCodeRequest,
+    });
+  }
 }
 
 export function resendMfaCodePost(

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -108,6 +108,16 @@ describe("Integration:: resend mfa code", () => {
       .expect(302, done);
   });
 
+  it.only("should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active", () => {
+    const testSpecificCookies = cookies + "; re=true";
+    request(app)
+      .get(PATH_NAMES.RESEND_MFA_CODE)
+      .set("Cookie", testSpecificCookies)
+      .expect((res) => {
+        res.text.includes("You cannot get a new security code at the moment");
+      });
+  });
+
   it("should return 500 error screen when API call fails", (done) => {
     nock(baseApi).post(API_ENDPOINTS.MFA).once().reply(500, {
       errorCode: "1234",

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -100,7 +100,8 @@ export function resetPasswordPost(
         clientSessionId,
         email,
         req.ip,
-        persistentSessionId
+        persistentSessionId,
+        false
       );
 
       if (!mfaResponse.success) {

--- a/src/components/security-code-error/index-too-many-requests.njk
+++ b/src/components/security-code-error/index-too-many-requests.njk
@@ -1,16 +1,20 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+
 {% set pageTitleName = 'pages.securityRequestsExceededExpired.title' | translate %}
+
+{% if isResendCodeRequest %}
+    {% set newCodeLink = newCodeLink + "?isResendCodeRequest=true" %}
+{% endif %}
+
 {% block content %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityRequestsExceededExpired.header' | translate }}</h1>
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityRequestsExceededExpired.header' | translate }}</h1>
-
-<p class="govuk-body">{{'pages.securityRequestsExceededExpired.info.paragraph1' | translate}}</p>
+    <p class="govuk-body">{{'pages.securityRequestsExceededExpired.info.paragraph1' | translate}}</p>
     <p class="govuk-body">
         {{'pages.securityRequestsExceededExpired.info.paragraph2Start' | translate}}
         <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityRequestsExceededExpired.info.link' | translate}}</a>
         {{'pages.securityRequestsExceededExpired.info.paragraph2End' | translate}}
     </p>
-
 
 {% endblock %}

--- a/src/components/security-code-error/index-wait.njk
+++ b/src/components/security-code-error/index-wait.njk
@@ -3,13 +3,13 @@
 {% set pageTitleName = 'pages.securityCodeWaitToRequest.title' | translate %}
 {% block content %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeWaitToRequest.header' | translate }}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeWaitToRequest.header' | translate }}</h1>
 
-<p class="govuk-body">{{'pages.securityCodeWaitToRequest.info.paragraph1' | translate}}</p>
+    <p class="govuk-body">{{'pages.securityCodeWaitToRequest.info.paragraph1' | translate}}</p>
     <p class="govuk-body">
-        {{'pages.securityCodeInvalid.info.paragraph2Start' | translate}}
-        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeInvalid.info.link' | translate}}</a>
-        {{'pages.securityCodeInvalid.info.paragraph2End' | translate}}
+        {{'pages.securityCodeWaitToRequest.info.paragraph2Start' | translate}}
+        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeWaitToRequest.info.link' | translate}}</a>
+        {{'pages.securityCodeWaitToRequest.info.paragraph2End' | translate}}
     </p>
 
 {% endblock %}

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -13,7 +13,9 @@ export function securityCodeTriesExceededGet(
   req: Request,
   res: Response
 ): void {
-  res.render("security-code-error/index-too-many-requests.njk", {
+  res.cookie("re", "true", { maxAge: 15 * 60 * 1000, httpOnly: true });
+
+  return res.render("security-code-error/index-too-many-requests.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
     isResendCodeRequest: req.query.isResendCodeRequest,
   });

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -15,6 +15,7 @@ export function securityCodeTriesExceededGet(
 ): void {
   res.render("security-code-error/index-too-many-requests.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
+    isResendCodeRequest: req.query.isResendCodeRequest,
   });
 }
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -369,14 +369,8 @@
       "title": "Check your phone",
       "header": "Check your phone",
       "info": {
-        "paragraph1": "We sent a code to [mobile].",
+        "paragraph1": "We have sent a code to [mobile].",
         "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes."
-      },
-      "resend": {
-        "link": "Request a new code",
-        "paragraph1": "if:",
-        "listItem1": "the code is not working or has expired, or you did not receive one",
-        "listItem2": "you want to use a different phone number"
       },
       "code": {
         "label": "Enter the 6 digit security code",
@@ -387,6 +381,17 @@
           "invalidFormat": "Enter the security code using only 6 digits",
           "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
         }
+      },
+      "details": {
+        "summaryText": "Problems with the code?",
+        "text1": "We can ",
+        "sendCodeLinkText": "send the code again",
+        "sendCodeLinkHref": "/resend-code?isResendCodeRequest=true",
+        "text 2": " or you can ",
+        "changePhoneNumberLinkText": "use a different phone number",
+        "changePhoneNumberLinkHref": "/enter-phone-number",
+        "changeMfaChoiceLinkText": "Get a code another way",
+        "changeMfaChoiceLinkHref": "/get-security-codes"
       }
     },
     "securityCodeInvalid": {
@@ -405,8 +410,8 @@
       }
     },
     "securityRequestsExceededExpired": {
-      "title": "You requested too many security codes",
-      "header": "You requested too many security codes",
+      "title": "You asked to resend the security code too many times",
+      "header": "You asked to resend the security code too many times",
       "info": {
         "paragraph1": "You need to wait 15 minutes.",
         "paragraph2Start": "You can then ",
@@ -428,7 +433,7 @@
       "title": "Check your phone",
       "header": "Check your phone",
       "info": {
-        "paragraph1": "We sent a code to [mobile].",
+        "paragraph1": "We sent a code to the phone number linked to your account.",
         "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes."
       },
       "resend": {
@@ -444,14 +449,24 @@
           "invalidFormat": "Enter the security code using only 6 digits",
           "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
         }
+      },
+      "details": {
+        "summaryText": "Problems with the code?",
+        "text1": "We can ",
+        "sendCodeLinkText": "send the code again",
+        "sendCodeLinkHref": "/resend-code",
+        "text 2": " if the code is not working or you did not receive it."
       }
     },
     "resendMfaCode": {
-      "title": "Request a new security code",
-      "header": "Request a new security code",
-      "continue": "Send a new  code",
+      "title": "Resend the security code",
+      "header": "Resend the security code",
+      "continue": "Resend the code",
       "message": "Text messages can sometimes take a few minutes to arrive.",
-      "phoneNumber": "We'll send a new code to [mobile]."
+      "phoneNumber": {
+        "default": "We will send a code to the phone number linked to your account",
+        "isResendCodeRequest": "We will send a new code to [mobile]."
+      }
     },
     "signedOut": {
       "title": "You have signed out",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -423,10 +423,10 @@
       "title": "You cannot get a new security code at the moment ",
       "header": "You cannot get a new security code at the moment ",
       "info": {
-        "paragraph1": "This is because you requested too many security codes.",
+        "paragraph1": "This is because you asked to resend the security code too many times.",
         "paragraph2Start": "You can ",
         "link": "get a new code",
-        "paragraph2End": " after 15 minutes have passed."
+        "paragraph2End": " after 15 minutes."
       }
     },
     "enterMfa": {
@@ -459,13 +459,13 @@
       }
     },
     "resendMfaCode": {
-      "title": "Resend the security code",
-      "header": "Resend the security code",
-      "continue": "Resend the code",
+      "title": "Get security code",
+      "header": "Get security code",
+      "continue": "Get security code",
       "message": "Text messages can sometimes take a few minutes to arrive.",
       "phoneNumber": {
         "default": "We will send a code to the phone number linked to your account",
-        "isResendCodeRequest": "We will send a new code to [mobile]."
+        "isResendCodeRequest": "We will send a code to: [mobile]."
       }
     },
     "signedOut": {


### PR DESCRIPTION
NOTE: Booked in separately with Kim Clayden for content aspect run through and sign-off (before which this PR will not be merged regardless of tech review progress).

NOTE: Also covers AUT-391 (remind user why they cannot get a new code within 15 minute lockout window) as this is so closely related to AUT-393 that it does not make sense to release either first without the other: https://govukverify.atlassian.net/jira/software/c/projects/AUT/boards/193?modal=detail&selectedIssue=AUT-391

## What?

- Add resend phone OTP code screen to account creation journey
- Amend some content of resend phone OTP code screen in sign in journey to match current Figma
- Differentiate between calls to MFA Lambda when they are `isResendCodeRequest` (resending a code in the account creation journey) vs when it's resending an MFA code for an existing account as these are stored differently in Redis
- Propagate `isResendCodeRequest` from enter code screen to resend code screen and onwards to 'max codes sent' (15 minute cool-off screen via query parameters, which had to be added in quite a few places to preserve the distinction between this and the existing journeys in sign-in user flow
- Add a new `re` cookie to time the OTP code lockout (15 minutes default on the back end at time of writing). During this time, stop the user from accessing resend code screen and remind them why they cannot request a new code yet.

- Changed screens:

Check your phone (account creation journey only):
<img width="981" alt="image" src="https://user-images.githubusercontent.com/106964077/181392648-0f54b0bd-8414-458a-964e-3294cde0cf01.png">

Resend code (account creation journey variant):
<img width="976" alt="image" src="https://user-images.githubusercontent.com/106964077/181496233-2d5f63b9-6e7e-4d10-a12c-af21f8391957.png">

You asked to resend code too many times (same for both account creation and sign in journeys):
<img width="972" alt="image" src="https://user-images.githubusercontent.com/106964077/181390328-5bdd9506-d1c5-4a2f-9790-3d62fc268211.png">

You cannot get a new security code at the moment (same for both account creation and sign in journeys):
<img width="972" alt="image" src="https://user-images.githubusercontent.com/106964077/181496087-1e823538-63a5-4288-b2ac-969674bc05db.png">

Enter code (sign in journey only - close counterpart of Check your phone in account creation):
<img width="975" alt="image" src="https://user-images.githubusercontent.com/106964077/181390490-13e432df-ace9-42c6-adf0-1608d06a4435.png">

Resend code (sign in journey variant):
<img width="971" alt="image" src="https://user-images.githubusercontent.com/106964077/181390544-225b0e40-7659-4ea1-b411-50b40cf149cb.png">


## Why?

- To reflect the fact that the same code can be resent (not only a new code sent when changing phone number as part of account creation).

- To give precise content to the user to explain why they cannot get a code resent within a 15 minute time window of their original lockout

## Related PRs

Relies on recent change to back-end, which allows MFA handler to differentiate between isResendCodeRequest `NotificationType` of `VERIFY_PHONE_NUMBER` and a 'normal' MFA code issuing request (which yields `NotificationType` of `MFA_SMS`)
