### PR TITLE
AUT-535: Make MFA choice reversible until method validated

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -8,12 +8,14 @@ import { ERROR_CODES, getNextPathAndUpdateJourney } from "../common/constants";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { supportMFAOptions } from "../../config";
 
 const TEMPLATE_NAME = "check-your-phone/index.njk";
 
 export function checkYourPhoneGet(req: Request, res: Response): void {
   res.render(TEMPLATE_NAME, {
     phoneNumber: req.session.user.phoneNumber,
+    supportMfaOptions: supportMFAOptions() ? true : null,
   });
 }
 

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -50,6 +50,18 @@
     </p>
     {% endset %}
 
+    {% if supportMfaOptions %}
+      {% set detailsHTML %}
+
+      {{detailsHTML | safe}}
+
+      <p class="govuk-body">
+        <a href="{{'pages.checkYourPhone.details.changeMfaChoiceLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.changeMfaChoiceLinkText'| translate}}</a>.
+      </p>
+
+      {% endset %}
+    {% endif %}
+
     {{ govukDetails({
       summaryText: 'pages.checkYourPhone.details.summaryText' | translate,
       html: detailsHTML

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -242,7 +242,7 @@ const authStateMachine = createMachine(
           ],
         },
         meta: {
-          optionalPaths: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
+          optionalPaths: [PATH_NAMES.GET_SECURITY_CODES],
         },
       },
       [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER]: {
@@ -280,6 +280,7 @@ const authStateMachine = createMachine(
             PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED,
             PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
             PATH_NAMES.RESEND_MFA_CODE,
+            PATH_NAMES.GET_SECURITY_CODES,
           ],
         },
       },

--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -8,40 +8,40 @@
 
 {% block content %}
 
-{% include "common/errors/errorSummary.njk" %}
+  {% include "common/errors/errorSummary.njk" %}
 
-{% set insetTextHtml %}
-    <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph1' | translate}}</p>
-    <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph2' | translate}}</p>
-    <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph3' | translate}}</p>
-{% endset %}
+  {% set insetTextHtml %}
+  <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph1' | translate}}</p>
+  <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph2' | translate}}</p>
+  <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph3' | translate}}</p>
+  {% endset %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.setupAuthenticatorApp.header' | translate }}</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.setupAuthenticatorApp.header' | translate }}</h1>
 
-<p class="govuk-body">{{'pages.setupAuthenticatorApp.step1' | translate }}</p>
-    {{ govukDetails({
+  <p class="govuk-body">{{'pages.setupAuthenticatorApp.step1' | translate }}</p>
+  {{ govukDetails({
         summaryText: 'pages.setupAuthenticatorApp.noAuthAppDetails.summaryText' | translate,
         html: insetTextHtml
     }) }}
-<p class="govuk-body">{{'pages.setupAuthenticatorApp.step2' | translate }}</p>
+  <p class="govuk-body">{{'pages.setupAuthenticatorApp.step2' | translate }}</p>
 
-<p class="govuk-body">
-  <img id="qr-code" src="{{qrCode}}" alt="QR Code Image">
-</p>
+  <p class="govuk-body">
+    <img id="qr-code" src="{{qrCode}}" alt="QR Code Image">
+  </p>
 
-<p class="govuk-body">
+  <p class="govuk-body">
     {{ 'pages.setupAuthenticatorApp.secretKeyLabelText' | translate }}
     <span id="secret-key" class="govuk-body govuk-!-font-weight-bold">{{secretKey}}</span>
-</p>
-<p class="govuk-body">{{'pages.setupAuthenticatorApp.step3' | translate }}</p>
-<p class="govuk-body">{{'pages.setupAuthenticatorApp.step4' | translate }}</p>
+  </p>
+  <p class="govuk-body">{{'pages.setupAuthenticatorApp.step3' | translate }}</p>
+  <p class="govuk-body">{{'pages.setupAuthenticatorApp.step4' | translate }}</p>
 
-<form id="form-tracking" method="post" novalidate>
-  
-  <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-  <input type="hidden" name="_secretKey" value="{{secretKey}}"/>
+  <form id="form-tracking" method="post" novalidate="novalidate">
 
-  {{ govukInput({
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="_secretKey" value="{{secretKey}}"/>
+
+    {{ govukInput({
   label: {
   text: 'pages.setupAuthenticatorApp.code.label' | translate
   },
@@ -58,15 +58,16 @@
   } if (errors['code'])})
   }}
 
-{{ govukButton({
+    {{ govukButton({
   "text": button_text|default('general.continue.label' | translate, true),
   "type": "Submit",
   "preventDoubleClick": true
   }) }}
 
-  <p class="govuk-body"> <a href="/enter-phone-number" class="govuk-link" rel="noreferrer">{{'pages.setupAuthenticatorApp.textMessageInsteadLinkText' | translate }}</a></p>
+    <p class="govuk-body">
+      <a href="/get-security-codes" class="govuk-link" rel="noreferrer">{{'pages.setupAuthenticatorApp.changeMfaChoiceLinkText' | translate }}</a>
+    </p>
 
-</form>
+  </form>
 
 {% endblock %}
-

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1547,11 +1547,11 @@
       },
       "step2": "2. Use your authenticator app to scan the QR code or type the secret key into your authenticator app.  Some authenticator apps call the secret key a 'code'.",
       "secretKeyLabelText": "Secret key: ",
-      "step3": "3. The authenticator app will show an access code.",
-      "step4": "4. Enter the access code.",
+      "step3": "3. The authenticator app will show an security code.",
+      "step4": "4. Enter the security code.",
       "code": {
-        "label": "Access code",
-        "hintText": "This is the number show in your authenticator app",
+        "label": "Security code",
+        "hintText": "This is the 6-digit number shown in your authenticator app",
         "validationError":{
          "required": "Enter the security code shown in your authenticator app",
           "invalidCode": "The security code you entered is not correct, try entering it again or wait for for your authenticator app to give you a new code",
@@ -1559,7 +1559,7 @@
         }
       },
       "continueButtonText": "Continue",
-      "textMessageInsteadLinkText": "Get a security code by text message instead"
+      "changeMfaChoiceLinkText": "Get a code another way"
     },
     "enterAuthenticatorAppCode": {
       "title": "Enter the security code shown in your authenticator app",


### PR DESCRIPTION
## What?

- For both phone and auth app journey branches, ensure there is a link back to the MFA method selection page (`/get-security-codes`)
- For auth app, amend content to match Figma - particularly 'access code' => 'security code'
- For SMS MFA, make additional text to go back to the MFA method selection page conditional on supporting MFA env var - as this page will only become live when auth apps are live

## Why?

- To allow user to change their mind about which MFA option to select (SMS or Auth App at the moment) up to the point that they have validated their choice by inputting a correct code.