### PR TITLE
AUT-535: Add back buttons to auth app and sms code setup screens

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -15,7 +15,7 @@ const TEMPLATE_NAME = "check-your-phone/index.njk";
 export function checkYourPhoneGet(req: Request, res: Response): void {
   res.render(TEMPLATE_NAME, {
     phoneNumber: req.session.user.phoneNumber,
-    supportMfaOptions: supportMFAOptions() ? true : null,
+    supportMFAOptions: supportMFAOptions() ? true : null,
   });
 }
 

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -24,6 +24,7 @@
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
+    <input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
     {{ govukInput({
   label: {
@@ -50,7 +51,7 @@
     </p>
     {% endset %}
 
-    {% if supportMfaOptions %}
+    {% if supportMFAOptions %}
       {% set detailsHTML %}
 
       {{detailsHTML | safe}}

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -256,6 +256,7 @@ const authStateMachine = createMachine(
             PATH_NAMES.SECURITY_CODE_WAIT,
             PATH_NAMES.SECURITY_CODE_INVALID,
             PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED,
+            PATH_NAMES.GET_SECURITY_CODES,
           ],
         },
       },

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -16,11 +16,12 @@ import { SendNotificationServiceInterface } from "../common/send-notification/ty
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { prependInternationalPrefix } from "../../utils/phone-number";
-import { supportInternationalNumbers } from "../../config";
+import { supportInternationalNumbers, supportMFAOptions } from "../../config";
 
 export function enterPhoneNumberGet(req: Request, res: Response): void {
   res.render("enter-phone-number/index.njk", {
     supportInternationalNumbers: supportInternationalNumbers() ? true : null,
+    supportMFAOptions: supportMFAOptions() ? true : null,
     isAccountPartCreated: req.session.user.isAccountPartCreated,
   });
 }

--- a/src/components/enter-phone-number/index.njk
+++ b/src/components/enter-phone-number/index.njk
@@ -5,34 +5,39 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-    {% if isAccountPartCreated %}
-        {% set pageTitleName = 'pages.enterPhoneNumber.returningUser.title' | translate %}
-    {% else %}
-        {% set pageTitleName = 'pages.enterPhoneNumber.title' | translate %}
-    {% endif %}
+{% if isAccountPartCreated %}
+  {% set pageTitleName = 'pages.enterPhoneNumber.returningUser.title' | translate %}
+{% else %}
+  {% set pageTitleName = 'pages.enterPhoneNumber.title' | translate %}
+{% endif %}
+
+{% if supportMFAOptions %}
+  {% set showBack = true %}
+  {% set hrefBack = 'get-security-codes' %}
+{% endif %}
 
 {% block content %}
-{% include "common/errors/errorSummary.njk" %}
+  {% include "common/errors/errorSummary.njk" %}
 
-
-   {% if isAccountPartCreated %}
-      <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.returningUser.header' |
+  {% if isAccountPartCreated %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.returningUser.header' |
         translate}}</h1>
-       <p class="govuk-body">{{'pages.enterPhoneNumber.returningUser.info.paragraph1' | translate}}</p>
-       <p class="govuk-body">{{'pages.enterPhoneNumber.returningUser.info.paragraph2' | translate}}</p>
-   {% else %}
-       <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.header' |
+    <p class="govuk-body">{{'pages.enterPhoneNumber.returningUser.info.paragraph1' | translate}}</p>
+    <p class="govuk-body">{{'pages.enterPhoneNumber.returningUser.info.paragraph2' | translate}}</p>
+  {% else %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.header' |
          translate}}</h1>
-        <p class="govuk-body">{{'pages.enterPhoneNumber.info.paragraph1' | translate}}</p>
-   {% endif %}
+    <p class="govuk-body">{{'pages.enterPhoneNumber.info.paragraph1' | translate}}</p>
+  {% endif %}
 
-<form action="/enter-phone-number" method="post" novalidate>
+  <form action="/enter-phone-number" method="post" novalidate="novalidate">
 
-  <input type="hidden" name="_csrf" value="{{csrfToken}}" />
-  <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}" />
-  <input type="hidden" name="isAccountPartCreated" value="{{isAccountPartCreated}}" />
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}"/>
+    <input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
+    <input type="hidden" name="isAccountPartCreated" value="{{isAccountPartCreated}}"/>
 
-  {{ govukInput({
+    {{ govukInput({
   label: {
   text: 'pages.enterPhoneNumber.ukPhoneNumber.label' | translate
   },
@@ -47,7 +52,7 @@
   } if (errors['phoneNumber'])})
   }}
 
-  {% if supportInternationalNumbers %}
+    {% if supportInternationalNumbers %}
 
       {% set internationalNumberHtml %}
       {{ govukInput({
@@ -84,15 +89,14 @@
         ]
       }) }}
 
-  {% endif %}
+    {% endif %}
 
-  {{ govukButton({
+    {{ govukButton({
   "text": button_text|default('general.continue.label' | translate, true),
   "type": "Submit",
   "preventDoubleClick": true
   }) }}
 
-</form>
-
+  </form>
 
 {% endblock %}

--- a/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
@@ -42,6 +42,7 @@ describe("enter phone number controller", () => {
       expect(res.render).to.have.calledWith("enter-phone-number/index.njk", {
         supportInternationalNumbers: true,
         isAccountPartCreated: undefined,
+        supportMFAOptions: null,
       });
     });
 
@@ -54,6 +55,7 @@ describe("enter phone number controller", () => {
       expect(res.render).to.have.calledWith("enter-phone-number/index.njk", {
         supportInternationalNumbers: true,
         isAccountPartCreated: true,
+        supportMFAOptions: null,
       });
     });
   });

--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -5,6 +5,8 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitleName = 'pages.setupAuthenticatorApp.title' | translate %}
+{% set showBack = true %}
+{% set hrefBack = 'get-security-codes' %}
 
 {% block content %}
 


### PR DESCRIPTION
## What?

- Enable back button on auth app setup screen
- Enable back button on input phone number screen (ahead of SMS MFA setup)
- Make both 'point at' MFA method choice page
- Make phone back button conditional on MFA options being supported

## Why?

- To give a further mechanism for users to navigate account creation journey

## Related PRs

- Extension of https://github.com/alphagov/di-authentication-frontend/pull/690 - which allowed much the same, except via text hyperlinks within the main content
