### PR TITLE
AUT-571 - Update terms of use content on create password screen

### DIFF
--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -35,7 +35,10 @@
 <h2 class="govuk-heading-s">{{'pages.createPassword.termsOfUse.heading' | translate}}</h2>
 
 <p class="govuk-body">{{'pages.createPassword.termsOfUse.paragraph1' | translate}}</p>
-<p class="govuk-body">{{'pages.createPassword.termsOfUse.paragraph2' | translate | replace("#PRIVACY_NOTICE_LINK", '<a class="govuk-link" href="/privacy-notice" rel="noreferrer noopener" target="_blank">privacy notice</a>') | safe }}</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li><a href="{{'pages.createPassword.termsOfUse.bullet1LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.createPassword.termsOfUse.bullet1LinkText'| translate}}</a>{{'pages.createPassword.termsOfUse.bullet1Text'| translate}}</li>
+    <li><a href="{{'pages.createPassword.termsOfUse.bullet2LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'pages.createPassword.termsOfUse.bullet2LinkText'| translate}}</a></li>
+  </ul>
 
 {{ govukButton({
     "text": button_text|default("Continue", true),

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -290,8 +290,12 @@
       },
       "termsOfUse": {
         "heading": "Agree to our terms of use",
-        "paragraph1": "We will collect and save your information securely. We will not share your personal information without your consent.",
-        "paragraph2": "By continuing, you confirm that you agree to our <a href=\"/privacy-notice\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">privacy notice</a> and our <a href=\"/terms-and-conditions\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">terms and conditions</a>."
+        "paragraph1": "By continuing, you confirm that you agree to our:",
+        "bullet1LinkText": "privacy notice (opens in a new tab)",
+        "bullet1Text": ", which explains how we use your personal information",
+        "bullet1LinkHref": "/privacy-notice",
+        "bullet2LinkText": "terms and conditions (opens in a new tab)",
+        "bullet2LinkHref": "/terms-and-conditions"
       }
     },
     "enterPhoneNumber": {


### PR DESCRIPTION
## What?

- Make it clear which links opens in a new tab by adding '(opens in a new tab)' to the link
- Update the text to remove any potential contradiction between this screen and our privacy policy.

## Why?

- Improve accessibility for screen readers 
-  To remove any potential contradiction between this screen and our privacy policy.
<img width="799" alt="Screenshot 2022-08-02 at 14 07 18" src="https://user-images.githubusercontent.com/35073557/182382211-d395e168-0516-4e66-a791-ab9928a67bc1.png">

