### PR TITLE
AUT-601 - Change content on create screen for auth apps

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -31,12 +31,17 @@
   <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>{{ 'pages.signInOrCreate.bullet1' | translate }}</li>
+    {% if supportMFAOptions %}
+    <li>{{ 'pages.signInOrCreate.bullet2AuthApps' | translate }}</li>
+    {% else %}
     <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
+    {% endif %}
   </ul>
 
 <form action="/sign-in-or-create" method="post" novalidate>
 
   <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+  <input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
   {{ govukButton({
     text: 'pages.signInOrCreate.createButtonText' | translate,

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -1,10 +1,12 @@
 import { Request, Response } from "express";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { supportMFAOptions } from "../../config";
 
 export function signInOrCreateGet(req: Request, res: Response): void {
   res.render("sign-in-or-create/index.njk", {
     serviceType: req.session.client.serviceType,
+    supportMFAOptions: supportMFAOptions() ? true : null,
   });
 }
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -114,6 +114,7 @@
       "paragraph": "You’ll need:",
       "bullet1": "an email address",
       "bullet2": "a UK mobile phone number",
+      "bullet2AuthApps": "a way to get security codes - this can be a UK mobile phone number or an authenticator app",
       "paragraph2": "If you already have a GOV.UK account you can",
       "signInText": "sign in",
       "moreAbout": {


### PR DESCRIPTION


## What?

- State that a user can receive a security code via an auth app when auth apps are enabled.

## Why?

- So it is clear to a user that they can use an auth app to generate an OTP
