### PR TITLE
AUT-598: Authenticator app feedback form

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -123,6 +123,7 @@ export const ZENDESK_THEMES = {
   FORGOTTEN_PASSWORD: "forgotten_password",
   NO_PHONE_NUMBER_ACCESS: "no_phone_number_access",
   PROVING_IDENTITY: "proving_identity",
+  AUTHENTICATOR_APP_PROBLEM: "authenticator_app_problem",
 };
 
 export enum NOTIFICATION_TYPE {

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -81,7 +81,7 @@ export function furtherInformationGet(req: Request, res: Response): void {
   return res.render("contact-us/further-information/index.njk", {
     theme: req.query.theme,
     referer: req.query.referer,
-    supportMFAOptions: supportMFAOptions(),
+    supportMFAOptions: supportMFAOptions() ? true : null,
   });
 }
 
@@ -115,7 +115,7 @@ export function contactUsQuestionsGet(req: Request, res: Response): void {
     backurl: req.headers.referer,
     referer: req.query.referer,
     pageTitleHeading: pageTitle,
-    supportMFAOptions: supportMFAOptions(),
+    supportMFAOptions: supportMFAOptions() ? true : null,
   });
 }
 

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -3,6 +3,7 @@ import { PATH_NAMES, SUPPORT_TYPE, ZENDESK_THEMES } from "../../app.constants";
 import { contactUsService } from "./contact-us-service";
 import { ContactUsServiceInterface, Questions, ThemeQuestions } from "./types";
 import { ExpressRouteFunc } from "../../types";
+import { supportMFAOptions } from "../../config";
 
 const themeToPageTitle = {
   [ZENDESK_THEMES.ACCOUNT_NOT_FOUND]:
@@ -80,6 +81,7 @@ export function furtherInformationGet(req: Request, res: Response): void {
   return res.render("contact-us/further-information/index.njk", {
     theme: req.query.theme,
     referer: req.query.referer,
+    supportMFAOptions: supportMFAOptions(),
   });
 }
 
@@ -113,6 +115,7 @@ export function contactUsQuestionsGet(req: Request, res: Response): void {
     backurl: req.headers.referer,
     referer: req.query.referer,
     pageTitleHeading: pageTitle,
+    supportMFAOptions: supportMFAOptions(),
   });
 }
 

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -27,6 +27,8 @@ const themeToPageTitle = {
     "pages.contactUsQuestions.suggestionOrFeedback.title",
   [ZENDESK_THEMES.PROVING_IDENTITY]:
     "pages.contactUsQuestions.provingIdentity.title",
+  [ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM]:
+    "pages.contactUsQuestions.authenticatorApp.title",
 };
 
 const somethingElseSubThemeToPageTitle = {
@@ -181,6 +183,14 @@ export function getQuestionsFromFormType(
         "pages.contactUsQuestions.anotherProblem.section2.header"
       ),
     },
+    authenticatorApp: {
+      issueDescription: req.t(
+        "pages.contactUsQuestions.authenticatorApp.section1.header"
+      ),
+      additionalDescription: req.t(
+        "pages.contactUsQuestions.authenticatorApp.section2.header"
+      ),
+    },
     emailSubscription: {
       issueDescription: req.t(
         "pages.contactUsQuestions.emailSubscriptions.section1.header"
@@ -299,6 +309,9 @@ export function getQuestionFromThemes(
     ),
     something_else: req.t(
       "pages.contactUsFurtherInformation.accountCreation.section1.radio5"
+    ),
+    authenticator_app_problem: req.t(
+      "pages.contactUsFurtherInformation.accountCreation.section1.radio6"
     ),
   };
   const themeQuestion = themesToQuestions[theme];

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -2,6 +2,7 @@ import { body, check } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import { ZENDESK_THEMES } from "../../app.constants";
+import { supportMFAOptions } from "../../config";
 
 export function validateContactUsQuestionsRequest(): ValidationChainFunc {
   return [
@@ -10,10 +11,12 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .if(check("radio_buttons").notEmpty())
       .notEmpty()
       .withMessage((value, { req }) => {
-        return req.t(
-          "pages.contactUsQuestions." + req.body.formType + ".section1.errorMessage",
-          { value }
-        );
+        const section = supportMFAOptions()
+          ? req.body.formType + ".section1"
+          : "securityCodeSentMethod";
+        return req.t("pages.contactUsQuestions." + section + ".errorMessage", {
+          value,
+        });
       }),
     body("issueDescription")
       .optional()

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -11,7 +11,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .notEmpty()
       .withMessage((value, { req }) => {
         return req.t(
-          "pages.contactUsQuestions.securityCodeSentMethod.errorMessage",
+          "pages.contactUsQuestions." + req.body.formType + ".section1.errorMessage",
           { value }
         );
       }),

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -107,6 +107,9 @@ export function getErrorMessageForIssueDescription(
   ) {
     return "pages.contactUsQuestions.accountCreationProblem.section1.errorMessage";
   }
+  if (subtheme === ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM) {
+    return "pages.contactUsQuestions.authenticatorApp.section1.errorMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(
@@ -124,5 +127,8 @@ export function getErrorMessageForAdditionalDescription(
   }
   if (subtheme === ZENDESK_THEMES.TECHNICAL_ERROR) {
     return "pages.contactUsQuestions.technicalError.section2.errorMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM) {
+    return "pages.contactUsQuestions.authenticatorApp.section2.errorMessage";
   }
 }

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -64,9 +64,17 @@ export function contactUsService(
     }
 
     if (securityCodeSentMethod) {
-      let securityCodeMethod = "Email";
-      if (securityCodeSentMethod == "text_message") {
-        securityCodeMethod = "Text message";
+      let securityCodeMethod = "";
+      switch (securityCodeSentMethod) {
+        case "email":
+          securityCodeMethod = "Email";
+          break;
+        case "text_message":
+          securityCodeMethod = "Text message";
+          break;
+        case "authenticator_app":
+          securityCodeMethod = "Authenticator app";
+          break;
       }
       htmlBody.push(`<span>[How was the security code sent?]</span>`);
       htmlBody.push(`<p>${securityCodeMethod}</p>`);

--- a/src/components/contact-us/further-information/_account-creation-further-information.njk
+++ b/src/components/contact-us/further-information/_account-creation-further-information.njk
@@ -8,17 +8,36 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-    {{ govukRadios({
-        idPrefix: "account-creation",
-        name: "subtheme",
-        fieldset: {
-            legend: {
-                text: 'pages.contactUsFurtherInformation.accountCreation.section1.header' | translate,
-                isPageHeading: false,
-                classes: "govuk-fieldset__legend--m"
-            }
-        },
-        items: [
+    {% if supportMFAOptions %}
+        {% set items = [
+                {
+                    value: "no_uk_mobile_number",
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio3' | translate
+                },
+                {
+                    value: "no_security_code",
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio1' | translate
+                },
+                {
+                    value: "invalid_security_code",
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio2' | translate
+                },
+                {
+                    value: "authenticator_app_problem",
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio6' | translate
+                },
+                {
+                    value: "technical_error",
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio4' | translate
+                },
+                {
+                    value: "something_else",
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio5' | translate
+                }
+            ]
+        %}
+    {% else %}
+        {% set items = [
             {
                 value: "no_uk_mobile_number",
                 text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio3' | translate
@@ -32,10 +51,6 @@
                 text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio2' | translate
             },
             {
-                value: "authenticator_app_problem",
-                text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio6' | translate
-            },
-            {
                 value: "technical_error",
                 text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio4' | translate
             },
@@ -43,7 +58,21 @@
                 value: "something_else",
                 text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio5' | translate
             }
-        ],
+        ]
+        %}
+    {% endif %}
+
+    {{ govukRadios({
+        idPrefix: "account-creation",
+        name: "subtheme",
+        fieldset: {
+            legend: {
+                text: 'pages.contactUsFurtherInformation.accountCreation.section1.header' | translate,
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: items,
       errorMessage: {
       text: errors['subtheme'].text
       } if (errors['subtheme'])

--- a/src/components/contact-us/further-information/_account-creation-further-information.njk
+++ b/src/components/contact-us/further-information/_account-creation-further-information.njk
@@ -32,6 +32,10 @@
                 text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio2' | translate
             },
             {
+                value: "authenticator_app_problem",
+                text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio6' | translate
+            },
+            {
                 value: "technical_error",
                 text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio4' | translate
             },

--- a/src/components/contact-us/further-information/_account-creation-further-information.njk
+++ b/src/components/contact-us/further-information/_account-creation-further-information.njk
@@ -7,6 +7,7 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
+<input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
     {% if supportMFAOptions %}
         {% set items = [

--- a/src/components/contact-us/questions/_authenticator-app-problem.njk
+++ b/src/components/contact-us/questions/_authenticator-app-problem.njk
@@ -1,0 +1,56 @@
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+  {{ 'pages.contactUsQuestions.authenticatorApp.header' | translate }}
+</h1>
+
+<form action="/contact-us-questions" method="post" novalidate>
+
+<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+<input type="hidden" name="theme" value="{{theme}}"/>
+<input type="hidden" name="subtheme" value="{{subtheme}}"/>
+<input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="formType" value="authenticatorApp"/>
+<input type="hidden" name="referer" value="{{referer}}"/>
+
+{{ govukTextarea({
+    label: {
+      text: 'pages.contactUsQuestions.authenticatorApp.section1.header' | translate,
+      classes: "govuk-label--s"
+    },
+    id: "issueDescription",
+    name: "issueDescription",
+    value: issueDescription,
+    errorMessage: {
+        text: errors['issueDescription'].text
+    } if (errors['issueDescription'])
+}) }}
+
+{{ govukTextarea({
+    label: {
+      text: 'pages.contactUsQuestions.authenticatorApp.section2.header' | translate,
+      classes: "govuk-label--s"
+    },
+    hint: {
+        text: 'pages.contactUsQuestions.authenticatorApp.section2.paragraph1' | translate
+      },
+    id: "additionalDescription",
+    name: "additionalDescription",
+    value: additionalDescription,
+    errorMessage: {
+        text: errors['additionalDescription'].text
+    } if (errors['additionalDescription'])
+}) }}
+
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
+{% include 'contact-us/questions/_reply_by_email.njk' %}
+
+{{ govukButton({
+    "text": button_text|default("Send message", true),
+    "type": "Submit",
+    "preventDoubleClick": true
+}) }}
+
+</form>

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -10,6 +10,7 @@
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="invalidSecurityCode"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
+<input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
 {% if theme == 'account_creation' %}
 

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -12,17 +12,9 @@
 <input type="hidden" name="referer" value="{{referer}}"/>
 
 {% if theme == 'account_creation' %}
-    {{ govukRadios({
-        idPrefix: "securityCodeSentMethod",
-        name: "securityCodeSentMethod",
-        fieldset: {
-            legend: {
-                text: 'pages.contactUsQuestions.invalidSecurityCode.section1.header' | translate,
-                isPageHeading: false,
-                classes: "govuk-fieldset__legend--m"
-            }
-        },
-        items: [
+
+    {% if supportMFAOptions %}
+        {% set items = [
             {
                 value: "email",
                 checked: securityCodeSentMethod === 'email',
@@ -38,10 +30,38 @@
                 checked: securityCodeSentMethod === 'authenticator_app',
                 text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translate
             }
-        ],
-          errorMessage: {
+        ]
+        %}
+    {% else %}
+        {% set items = [
+            {
+                value: "email",
+                checked: securityCodeSentMethod === 'email',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
+            },
+            {
+                value: "text_message",
+                checked: securityCodeSentMethod === 'text_message',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
+            }
+        ]
+        %}
+    {% endif %}
+
+    {{ govukRadios({
+        idPrefix: "securityCodeSentMethod",
+        name: "securityCodeSentMethod",
+        fieldset: {
+            legend: {
+                text: 'pages.contactUsQuestions.invalidSecurityCode.section1.header' | translate,
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: items,
+        errorMessage: {
           text: errors['securityCodeSentMethod'].text
-          } if (errors['securityCodeSentMethod'])
+        } if (errors['securityCodeSentMethod'])
     }) }}
 {% endif %}
 

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -32,6 +32,11 @@
                 value: "text_message",
                 checked: securityCodeSentMethod === 'text_message',
                 text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
+            },
+            {
+                value: "authenticator_app",
+                checked: securityCodeSentMethod === 'authenticator_app',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translate
             }
         ],
           errorMessage: {

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -17,7 +17,7 @@
         name: "securityCodeSentMethod",
         fieldset: {
             legend: {
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.header' | translate,
+                text: 'pages.contactUsQuestions.invalidSecurityCode.section1.header' | translate,
                 isPageHeading: false,
                 classes: "govuk-fieldset__legend--m"
             }

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -10,6 +10,7 @@
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="noSecurityCode"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
+<input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
 {% if theme == 'account_creation' %}
 

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -12,17 +12,9 @@
 <input type="hidden" name="referer" value="{{referer}}"/>
 
 {% if theme == 'account_creation' %}
-    {{ govukRadios({
-        idPrefix: "securityCodeSentMethod",
-        name: "securityCodeSentMethod",
-        fieldset: {
-            legend: {
-                text: 'pages.contactUsQuestions.noSecurityCode.section1.header' | translate,
-                isPageHeading: false,
-                classes: "govuk-fieldset__legend--m"
-            }
-        },
-        items: [
+
+    {% if supportMFAOptions %}
+        {% set items = [
             {
                 value: "email",
                 checked: securityCodeSentMethod === 'email',
@@ -38,10 +30,38 @@
                 checked: securityCodeSentMethod === 'authenticator_app',
                 text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translate
             }
-        ],
-          errorMessage: {
+        ]
+        %}
+    {% else %}
+        {% set items = [
+            {
+                value: "email",
+                checked: securityCodeSentMethod === 'email',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
+            },
+            {
+                value: "text_message",
+                checked: securityCodeSentMethod === 'text_message',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
+            }
+        ]
+        %}
+    {% endif %}
+
+    {{ govukRadios({
+        idPrefix: "securityCodeSentMethod",
+        name: "securityCodeSentMethod",
+        fieldset: {
+            legend: {
+                text: 'pages.contactUsQuestions.noSecurityCode.section1.header' | translate,
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: items,
+        errorMessage: {
           text: errors['securityCodeSentMethod'].text
-          } if (errors['securityCodeSentMethod'])
+        } if (errors['securityCodeSentMethod'])
     }) }}
 {% endif %}
 

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -32,6 +32,11 @@
                 value: "text_message",
                 checked: securityCodeSentMethod === 'text_message',
                 text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
+            },
+            {
+                value: "authenticator_app",
+                checked: securityCodeSentMethod === 'authenticator_app',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translate
             }
         ],
           errorMessage: {

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -17,7 +17,7 @@
         name: "securityCodeSentMethod",
         fieldset: {
             legend: {
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.header' | translate,
+                text: 'pages.contactUsQuestions.noSecurityCode.section1.header' | translate,
                 isPageHeading: false,
                 classes: "govuk-fieldset__legend--m"
             }

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -42,6 +42,10 @@
         {% include 'contact-us/questions/_no-phone-number-access-questions.njk' %}
     {% endif %}
 
+    {% if subtheme == 'authenticator_app_problem' %}
+        {% include 'contact-us/questions/_authenticator-app-problem.njk' %}
+    {% endif %}
+
     {% if (theme == 'account_creation') and (subtheme == 'something_else') %}
         {% include 'contact-us/questions/_account-creation-problem-questions.njk' %}
     {% endif %}

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -187,12 +187,13 @@ describe("Integration:: contact us - public user", () => {
         theme: "account_creation",
         subtheme: "no_security_code",
         moreDetailDescription: "issue",
+        formType: "noSecurityCode",
         contact: "false",
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#securityCodeSentMethod-error").text()).to.contains(
-          "Select whether the code was sent by email or text message"
+          "Select whether you expected to get the code by email, text message or authenticator app"
         );
       })
       .expect(400, done);

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -218,4 +218,26 @@ describe("Integration:: contact us - public user", () => {
       .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
       .expect(302, done);
   });
+
+  it("should redirect to success page when authenticator app problem form submitted", (done) => {
+    nock(zendeskApiUrl).post("/tickets.json").once().reply(200);
+
+    request(app)
+      .post("/contact-us-questions")
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        theme: "account_creation",
+        subtheme: "authenticator_app_problem",
+        issueDescription: "issue",
+        additionalDescription: "additional information",
+        contact: "true",
+        email: "test@test.com",
+        formType: "authenticatorApp",
+        referer: "https://gov.uk/sign-in",
+      })
+      .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
+      .expect(302, done);
+  });
 });

--- a/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
@@ -37,6 +37,7 @@ describe("contact us further information controller", () => {
         {
           theme: "signing_in",
           referer: REFERER,
+          supportMFAOptions: true,
         }
       );
     });
@@ -51,6 +52,7 @@ describe("contact us further information controller", () => {
         {
           theme: "account_creation",
           referer: REFERER,
+          supportMFAOptions: true,
         }
       );
     });

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -46,6 +46,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'GOV.UK email subscriptions' radio option was chosen", () => {
@@ -60,6 +61,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.emailSubscriptions.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'A suggestion or feedback' radio option was chosen", () => {
@@ -74,6 +76,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.suggestionOrFeedback.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
 
@@ -89,6 +92,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.provingIdentity.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
 
@@ -113,6 +117,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -128,6 +133,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'You do not have access to the phone number' radio option was chosen", () => {
@@ -143,6 +149,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noPhoneNumberAccess.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'You've forgotten your password' radio option was chosen", () => {
@@ -158,6 +165,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.forgottenPassword.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'Your account cannot be found' radio option was chosen", () => {
@@ -173,6 +181,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.accountNotFound.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -188,6 +197,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -203,6 +213,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
   });
@@ -221,6 +232,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -236,6 +248,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'You do not have a UK number' radio option was chosen", () => {
@@ -251,6 +264,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noUKMobile.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -266,6 +280,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -281,6 +296,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.accountCreation.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'problem with authenticator app' radio option was chosen", () => {
@@ -296,6 +312,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.authenticatorApp.title",
         referer: REFERER,
+        supportMFAOptions: true,
       });
     });
 

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -283,6 +283,22 @@ describe("contact us questions controller", () => {
         referer: REFERER,
       });
     });
+    it("should render contact-us-questions if a 'problem with authenticator app' radio option was chosen", () => {
+      req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
+      req.query.subtheme = ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM;
+      req.headers.referer = "/contact-us-further-information";
+      req.query.referer = REFERER;
+      contactUsQuestionsGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        theme: "account_creation",
+        subtheme: "authenticator_app_problem",
+        backurl: "/contact-us-further-information",
+        pageTitleHeading: "pages.contactUsQuestions.authenticatorApp.title",
+        referer: REFERER,
+      });
+    });
+
     describe("contactUsFormPost", () => {
       it("should redirect /contact-us-submit-success page when ticket posted", async () => {
         const fakeService: ContactUsServiceInterface = {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1395,12 +1395,6 @@
       "invalidSecurityCode": {
         "title": "The security code does not work",
         "header": "The security code does not work",
-        "section1": {
-          "header": "How was the security code sent?",
-          "radio1": "Email",
-          "radio2": "Text message",
-          "errorMessage": "Select whether the code was sent by email or text message"
-        },
         "section2": {
           "header": "Anything else you want to tell us",
           "hintText": "You can add more detail, such as what happened when you entered the security code or what you were trying to do, or give us feedback"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1394,7 +1394,8 @@
       "securityCodeSentMethod": {
         "radio1": "Email",
         "radio2": "Text message",
-        "radio3": "Authenticator app"
+        "radio3": "Authenticator app",
+        "errorMessage": "Select whether the code was sent by email or text message"
       },
       "noSecurityCode": {
         "title": "You did not get a security code",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1378,20 +1378,15 @@
         }
       },
       "securityCodeSentMethod": {
-        "header": "How was the security code sent?",
+        "header": "How did you expect to get the security code?",
         "radio1": "Email",
         "radio2": "Text message",
+        "radio3": "Authenticator App",
         "errorMessage": "Select whether the code was sent by email or text message"
       },
       "noSecurityCode": {
-        "title": "You did not receive a security code",
-        "header": "You did not receive a security code",
-        "section1": {
-          "header": "How was the security code sent?",
-          "radio1": "Email",
-          "radio2": "Text message",
-          "errorMessage": "Select whether the code was sent by email or text message"
-        },
+        "title": "You did not get a security code",
+        "header": "You did not get a security code",
         "section2": {
           "header": "Anything else you want to tell us",
           "hintText": "You can add more detail, such as what you were trying to do, or give us feedback"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1288,7 +1288,7 @@
         "header": "A problem creating a GOV.UK account",
         "section1": {
           "header": "Tell us what happened",
-          "radio1": "You did not receive a security code",
+          "radio1": "You did not get a security code",
           "radio2": "The security code did not work",
           "radio3": "You do not have a UK mobile phone number",
           "radio4": "There was a technical problem (for example, the service was unavailable)",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1392,15 +1392,17 @@
         }
       },
       "securityCodeSentMethod": {
-        "header": "How did you expect to get the security code?",
         "radio1": "Email",
         "radio2": "Text message",
-        "radio3": "Authenticator App",
-        "errorMessage": "Select whether the code was sent by email or text message"
+        "radio3": "Authenticator app"
       },
       "noSecurityCode": {
         "title": "You did not get a security code",
         "header": "You did not get a security code",
+        "section1": {
+          "header": "How did you expect to get the security code?",
+          "errorMessage": "Select whether you expected to get the code by email, text message or authenticator app"
+        },
         "section2": {
           "header": "Anything else you want to tell us",
           "hintText": "You can add more detail, such as what you were trying to do, or give us feedback"
@@ -1409,6 +1411,10 @@
       "invalidSecurityCode": {
         "title": "The security code does not work",
         "header": "The security code does not work",
+        "section1": {
+          "header": "How did you get the security code?",
+          "errorMessage": "Select whether you got the code by email, text message or authenticator app"
+        },
         "section2": {
           "header": "Anything else you want to tell us",
           "hintText": "You can add more detail, such as what happened when you entered the security code or what you were trying to do, or give us feedback"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1293,6 +1293,7 @@
           "radio3": "You do not have a UK mobile phone number",
           "radio4": "There was a technical problem (for example, the service was unavailable)",
           "radio5": "Something else",
+          "radio6": "You had a problem with an authenticator app",
           "errorMessage": "Select the problem you had when creating an account"
         }
       }
@@ -1325,6 +1326,19 @@
         "section2": {
           "header": "What happened?",
           "paragraph1": "For example, was there a technical problem?",
+          "errorMessage": "Enter what happened"
+        }
+      },
+      "authenticatorApp": {
+        "title": "You had a problem with an authenticator app",
+        "header": "You had a problem with an authenticator app",
+        "section1": {
+          "header": "What were you trying to do?",
+          "errorMessage": "Enter what you were trying to do"
+        },
+        "section2": {
+          "header": "What happened?",
+          "paragraph1": "For example, you had a problem with the QR code or finding an authenticator app",
           "errorMessage": "Enter what happened"
         }
       },


### PR DESCRIPTION
## What?

- Change the text on the radio button for "did not receive code" on the feedback form for account creation journey.
- Add a new radio button to the list of code receive methods on no security code and invalid code pages
- Add new subtheme for "problem with authenticator app"
- Hide authenticator app specific changes behind feature flag
- Remove unused entries from `translations.json`
 
## Why?

We are going introduce authenticator apps and the feedback form needs to provide a way of reporting issues with this journey.
