### PR TITLE
AUT-610 - Make changes to drop off screen when auth apps are enabled

### DIFF
--- a/src/components/enter-phone-number/index.njk
+++ b/src/components/enter-phone-number/index.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% if isAccountPartCreated %}
+{% if isAccountPartCreated and not supportMFAOptions %}
   {% set pageTitleName = 'pages.enterPhoneNumber.returningUser.title' | translate %}
 {% else %}
   {% set pageTitleName = 'pages.enterPhoneNumber.title' | translate %}
@@ -19,7 +19,7 @@
 {% block content %}
   {% include "common/errors/errorSummary.njk" %}
 
-  {% if isAccountPartCreated %}
+  {% if isAccountPartCreated and not supportMFAOptions %}
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.returningUser.header' |
         translate}}</h1>
     <p class="govuk-body">{{'pages.enterPhoneNumber.returningUser.info.paragraph1' | translate}}</p>
@@ -28,6 +28,9 @@
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.header' |
          translate}}</h1>
     <p class="govuk-body">{{'pages.enterPhoneNumber.info.paragraph1' | translate}}</p>
+    {% if not supportInternationalNumbers %}
+        <p class="govuk-body">{{'pages.enterPhoneNumber.info.paragraph2' | translate}}</p>
+    {% endif %}
   {% endif %}
 
   <form action="/enter-phone-number" method="post" novalidate="novalidate">

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -303,7 +303,8 @@
       "title": "Enter your mobile phone number",
       "header": "Enter your mobile phone number",
       "info": {
-        "paragraph1": "We will send a 6 digit security code to the number you give us."
+        "paragraph1": "We will send a 6 digit security code to the number you give us.",
+        "paragraph2": "You must use a UK mobile phone number."
       },
       "returningUser": {
         "title": "Finish creating your account",


### PR DESCRIPTION


## What?

- Make changes to drop off screen when auth apps are enabled
- Add missing line `You must use a UK mobile phone number` to the enter phone number screen and ensure it is not displayed if international phone numbers are enabled 

## Why?

- The current drop of screen when auth apps are enabled correctly reads 'Finish creating your account' when asking for a phone number. However when auth apps are enabled, the previous screen already reads 'Finish creating your account'. 2 consecutive screens should not have the same H1 so it needs to be changed to improve usability and accessibility.

