### PR TITLE
AUT-550 & AUT-464 - Resolve accessibility issues

### DIFF
--- a/src/components/common/show-password/macro.njk
+++ b/src/components/common/show-password/macro.njk
@@ -20,3 +20,26 @@
         }}
     </div>
 {% endmacro %}
+
+{% macro govukInputWithShowPasswordWithLabelAsPageHeading(label, id, errors, hint) %}
+    <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password" data-hide-full-text="Hide password" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">
+        {{ govukInput({
+            label: {
+                text: label,
+                classes: "govuk-label--l",
+                isPageHeading: true
+            },
+            hint: {
+                text: hint
+            },
+            classes: "govuk-!-width-two-thirds govuk-password-input",
+            id: id,
+            name: id,
+            type: "password",
+            spellcheck: false,
+            errorMessage: {
+                text: errors[id].text
+            } if (errors[id])})
+        }}
+    </div>
+{% endmacro %}

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -8,16 +8,16 @@
 
 {% include "common/errors/errorSummary.njk" %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterAuthenticatorAppCode.header' | translate }}</h1>
-
 <form id="form-tracking" action="/enter-authenticator-app-code" method="post" novalidate>
 
   <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
   {{ govukInput({
-    label: {
-      text: 'pages.enterAuthenticatorAppCode.code.label' | translate
-    },
+      label: {
+        text: 'pages.enterAuthenticatorAppCode.header' | translate,
+        classes: "govuk-label--l",
+        isPageHeading: true
+      },
     classes: "govuk-input--width-10",
     id: "code",
     name: "code",

--- a/src/components/enter-email/index-create-account.njk
+++ b/src/components/enter-email/index-create-account.njk
@@ -11,18 +11,16 @@
 
 {% include "common/errors/errorSummary.njk" %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterEmailCreateAccount.header' | translate}}</h1>
-
-<p class="govuk-body">{{'pages.enterEmailCreateAccount.text' | translate}}</p>
-
 <form action="/enter-email-create" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
 {{ govukInput({
-    label: {
-        text: 'pages.enterEmailCreateAccount.email.label' | translate
-    },
+      label: {
+        text: 'pages.enterEmailCreateAccount.header' | translate,
+        classes: "govuk-label--l",
+        isPageHeading: true
+      },
     id: "email",
     name: "email",
     value: email,

--- a/src/components/enter-email/index-existing-account.njk
+++ b/src/components/enter-email/index-existing-account.njk
@@ -11,18 +11,16 @@
 
 {% include "common/errors/errorSummary.njk" %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterEmailExistingAccount.header' | translate}}</h1>
-
-<p class="govuk-body">{{'pages.enterEmailExistingAccount.text' | translate}}</p>
-
 <form action="/enter-email" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
 {{ govukInput({
-    label: {
-        text: 'pages.enterEmailExistingAccount.email.label' | translate
-    },
+     label: {
+            text: 'pages.enterEmailExistingAccount.header' | translate,
+            classes: "govuk-label--l",
+            isPageHeading: true
+        },
     id: "email",
     name: "email",
     value: email,

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "common/show-password/macro.njk" import govukInputWithShowPassword %}
+{% from "common/show-password/macro.njk" import govukInputWithShowPasswordWithLabelAsPageHeading %}
 {% set showBack = true %}
 {% set hrefBack = 'enter-email' %}
 {% set pageTitleName = 'pages.enterPassword.title' | translate %}

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -12,12 +12,10 @@
 
 {% include "common/errors/errorSummary.njk" %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPassword.header' | translate}}</h1>
-
 <form id="form-tracking" action="/enter-password" method="post" novalidate>
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
-{{ govukInputWithShowPassword('pages.enterPassword.password.label' | translate, "password", errors) }}
+{{ govukInputWithShowPasswordWithLabelAsPageHeading('pages.enterPassword.header' | translate, "password", errors) }}
 
 <p class="govuk-body">
     <a href="/reset-password-request" class="govuk-link" rel="noreferrer noopener">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -139,9 +139,8 @@
       }
     },
     "enterEmailExistingAccount": {
-      "title": "Sign in to your GOV.UK account",
-      "header": "Sign in to your GOV.UK account",
-      "text": "Enter your email address to sign in.",
+      "title": "Enter your email address to sign in to your GOV.UK account",
+      "header": "Enter your email address to sign in to your GOV.UK account",
       "email": {
         "label": "Email address",
         "validationError": {
@@ -1579,10 +1578,9 @@
       "changeMfaChoiceLinkText": "Get a code another way"
     },
     "enterAuthenticatorAppCode": {
-      "title": "Enter the security code shown in your authenticator app",
-      "header": "Enter the security code shown in your authenticator app",
+      "title": "Enter the 6 digit security code shown in your authenticator app",
+      "header": "Enter the 6 digit security code shown in your authenticator app",
       "code": {
-        "label": "Security code",
         "validationError": {
           "required": "Enter the security code",
           "invalidFormat": "Enter the security code using only 6 digits",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -128,9 +128,7 @@
     "enterEmailCreateAccount": {
       "title": "Enter your email address",
       "header": "Enter your email address",
-      "text": "Enter your email address to create an account.",
       "email": {
-        "label": "Email address",
         "validationError": {
           "required": "Enter your email address",
           "length": "Email address must be 256 characters or fewer",


### PR DESCRIPTION
## What?

- Resolve accessibility and usability issues in journey
- Note the security code text is slightly different from the ticket. This is intentional following the text that already existed. 

## Why?

 - Use the H1 heading as the label for the input field as per the GOV.UK design system method for question pages. This will present users of screen reading assistive technologies with less content to navigate through and have audibly feedback before reaching the input field.

**AUT-550** 
![Screenshot 2022-08-05 at 13 33 26](https://user-images.githubusercontent.com/35073557/183083116-c922bb80-71ed-4baf-b112-4f83f7f63a02.png)
![Screenshot 2022-08-05 at 13 33 37](https://user-images.githubusercontent.com/35073557/183083124-b3023990-ee37-46bd-a1ec-403e3a714f38.png)
![Screenshot 2022-08-05 at 13 34 00](https://user-images.githubusercontent.com/35073557/183083133-a5c564cc-e058-4709-9fb3-6066c05a9923.png)

**AUT-464** 
![Screenshot 2022-08-05 at 14 00 02](https://user-images.githubusercontent.com/35073557/183083168-8ef17298-f766-481b-b1cf-ebdc0e613bd7.png)

