### PR TITLE
AUT-603: Feedback form amendments for auth apps on sign-in journey

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -211,15 +211,24 @@ export function getQuestionsFromFormType(
       moreDetailDescription: req.t(
         "pages.contactUsQuestions.invalidSecurityCode.section2.header"
       ),
+      radioButtons: req.t(
+        "pages.contactUsQuestions.invalidSecurityCode.section1.header"
+      ),
     },
     noPhoneNumberAccess: {
       optionalDescription: req.t(
+        "pages.contactUsQuestions.noPhoneNumberAccess.section1.header"
+      ),
+      radioButtons: req.t(
         "pages.contactUsQuestions.noPhoneNumberAccess.section1.header"
       ),
     },
     noSecurityCode: {
       moreDetailDescription: req.t(
         "pages.contactUsQuestions.noSecurityCode.section2.header"
+      ),
+      radioButtons: req.t(
+        "pages.contactUsQuestions.noSecurityCode.section1.header"
       ),
     },
     noUKMobile: {

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -7,16 +7,22 @@ import { supportMFAOptions } from "../../config";
 export function validateContactUsQuestionsRequest(): ValidationChainFunc {
   return [
     body("securityCodeSentMethod")
-      .if(body("theme").equals("account_creation"))
+      .if((value: string, { req }: any) => {
+        return req.body.theme == "account_creation" || supportMFAOptions();
+      })
       .if(check("radio_buttons").notEmpty())
       .notEmpty()
       .withMessage((value, { req }) => {
         const section = supportMFAOptions()
           ? req.body.formType + ".section1"
           : "securityCodeSentMethod";
-        return req.t("pages.contactUsQuestions." + section + ".errorMessage", {
-          value,
-        });
+        const suffix = req.body.theme == "signing_in" ? "SignIn" : "";
+        return req.t(
+          "pages.contactUsQuestions." + section + ".errorMessage" + suffix,
+          {
+            value,
+          }
+        );
       }),
     body("issueDescription")
       .optional()

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -76,7 +76,7 @@ export function contactUsService(
           securityCodeMethod = "Authenticator app";
           break;
       }
-      htmlBody.push(`<span>[How was the security code sent?]</span>`);
+      htmlBody.push(`<span>[${questions.radioButtons}]</span>`);
       htmlBody.push(`<p>${securityCodeMethod}</p>`);
     }
 

--- a/src/components/contact-us/further-information/_signing-in-further-information.njk
+++ b/src/components/contact-us/further-information/_signing-in-further-information.njk
@@ -28,12 +28,12 @@
                 text: 'pages.contactUsFurtherInformation.signingIn.section1.radio2' | translate
             },
             {
-                value: "no_phone_number_access",
-                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio3' | translate
-            },
-            {
                 value: "forgotten_password",
                 text: 'pages.contactUsFurtherInformation.signingIn.section1.radio4' | translate
+            },
+            {
+                value: "no_phone_number_access",
+                text: 'pages.contactUsFurtherInformation.signingIn.section1.radio3' | translate
             },
             {
                 value: "account_not_found",

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -12,59 +12,8 @@
 <input type="hidden" name="referer" value="{{referer}}"/>
 <input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
-{% if theme == 'account_creation' %}
-
-    {% if supportMFAOptions %}
-        {% set items = [
-            {
-                value: "email",
-                checked: securityCodeSentMethod === 'email',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
-            },
-            {
-                value: "text_message",
-                checked: securityCodeSentMethod === 'text_message',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
-            },
-            {
-                value: "authenticator_app",
-                checked: securityCodeSentMethod === 'authenticator_app',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translate
-            }
-        ]
-        %}
-    {% else %}
-        {% set items = [
-            {
-                value: "email",
-                checked: securityCodeSentMethod === 'email',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
-            },
-            {
-                value: "text_message",
-                checked: securityCodeSentMethod === 'text_message',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
-            }
-        ]
-        %}
-    {% endif %}
-
-    {{ govukRadios({
-        idPrefix: "securityCodeSentMethod",
-        name: "securityCodeSentMethod",
-        fieldset: {
-            legend: {
-                text: 'pages.contactUsQuestions.invalidSecurityCode.section1.header' | translate,
-                isPageHeading: false,
-                classes: "govuk-fieldset__legend--m"
-            }
-        },
-        items: items,
-        errorMessage: {
-          text: errors['securityCodeSentMethod'].text
-        } if (errors['securityCodeSentMethod'])
-    }) }}
-{% endif %}
+{% set radioHeader = 'pages.contactUsQuestions.invalidSecurityCode.section1.header' | translate %}
+{% include "contact-us/questions/_security_send_method.njk" %}
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.noPhoneNumberAccess.header' | translate }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+<form action="/contact-us-questions?radio_buttons=true" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
@@ -10,14 +10,18 @@
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="noPhoneNumberAccess"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
+<input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
+
+{% set radioHeader = 'pages.contactUsQuestions.noPhoneNumberAccess.section1.header' | translate %}
+{% include "contact-us/questions/_security_send_method.njk" %}
 
 {{ govukTextarea({
     label: {
-      text: 'pages.contactUsQuestions.noPhoneNumberAccess.section1.header' | translate,
+      text: 'pages.contactUsQuestions.noPhoneNumberAccess.section2.header' | translate,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.noPhoneNumberAccess.section1.paragraph1' | translate
+        text: 'pages.contactUsQuestions.noPhoneNumberAccess.section2.paragraph1' | translate
       },
     id: "optionalDescription",
     name: "optionalDescription",

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -12,40 +12,30 @@
 <input type="hidden" name="referer" value="{{referer}}"/>
 <input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
-{% if theme == 'account_creation' %}
+{% if theme == 'account_creation' or supportMFAOptions %}
+
+    {% set items = [] %}
+
+    {% if theme == 'account_creation' %}
+        {% set items = (items.push({
+            value: "email",
+            checked: securityCodeSentMethod === 'email',
+            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
+        }), items) %}
+    {% endif %}
+
+    {% set items = (items.push({
+        value: "text_message",
+        checked: securityCodeSentMethod === 'text_message',
+        text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
+    }), items) %}
 
     {% if supportMFAOptions %}
-        {% set items = [
-            {
-                value: "email",
-                checked: securityCodeSentMethod === 'email',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
-            },
-            {
-                value: "text_message",
-                checked: securityCodeSentMethod === 'text_message',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
-            },
-            {
+        {% set items = (items.push({
                 value: "authenticator_app",
                 checked: securityCodeSentMethod === 'authenticator_app',
                 text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translate
-            }
-        ]
-        %}
-    {% else %}
-        {% set items = [
-            {
-                value: "email",
-                checked: securityCodeSentMethod === 'email',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
-            },
-            {
-                value: "text_message",
-                checked: securityCodeSentMethod === 'text_message',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
-            }
-        ]
+            }), items)
         %}
     {% endif %}
 

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -12,50 +12,8 @@
 <input type="hidden" name="referer" value="{{referer}}"/>
 <input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
-{% if theme == 'account_creation' or supportMFAOptions %}
-
-    {% set items = [] %}
-
-    {% if theme == 'account_creation' %}
-        {% set items = (items.push({
-            value: "email",
-            checked: securityCodeSentMethod === 'email',
-            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
-        }), items) %}
-    {% endif %}
-
-    {% set items = (items.push({
-        value: "text_message",
-        checked: securityCodeSentMethod === 'text_message',
-        text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
-    }), items) %}
-
-    {% if supportMFAOptions %}
-        {% set items = (items.push({
-                value: "authenticator_app",
-                checked: securityCodeSentMethod === 'authenticator_app',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translate
-            }), items)
-        %}
-    {% endif %}
-
-    {{ govukRadios({
-        idPrefix: "securityCodeSentMethod",
-        name: "securityCodeSentMethod",
-        fieldset: {
-            legend: {
-                text: 'pages.contactUsQuestions.noSecurityCode.section1.header' | translate,
-                isPageHeading: false,
-                classes: "govuk-fieldset__legend--m"
-            }
-        },
-        items: items,
-        errorMessage: {
-          text: errors['securityCodeSentMethod'].text
-        } if (errors['securityCodeSentMethod'])
-    }) }}
-{% endif %}
-
+{% set radioHeader = 'pages.contactUsQuestions.noSecurityCode.section1.header' | translate %}
+{% include "contact-us/questions/_security_send_method.njk" %}
 
 {{ govukTextarea({
     label: {

--- a/src/components/contact-us/questions/_security_send_method.njk
+++ b/src/components/contact-us/questions/_security_send_method.njk
@@ -1,0 +1,43 @@
+{% if theme == 'account_creation' or supportMFAOptions %}
+
+    {% set items = [] %}
+
+    {% if theme == 'account_creation' %}
+        {% set items = (items.push({
+            value: "email",
+            checked: securityCodeSentMethod === 'email',
+            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
+        }), items) %}
+    {% endif %}
+
+    {% set items = (items.push({
+        value: "text_message",
+        checked: securityCodeSentMethod === 'text_message',
+        text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
+    }), items) %}
+
+    {% if supportMFAOptions %}
+        {% set items = (items.push({
+            value: "authenticator_app",
+            checked: securityCodeSentMethod === 'authenticator_app',
+            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translate
+        }), items)
+        %}
+    {% endif %}
+
+    {{ govukRadios({
+        idPrefix: "securityCodeSentMethod",
+        name: "securityCodeSentMethod",
+        fieldset: {
+            legend: {
+                text: 'pages.contactUsQuestions.noSecurityCode.section1.header' | translate,
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: items,
+        errorMessage: {
+            text: errors['securityCodeSentMethod'].text
+        } if (errors['securityCodeSentMethod'])
+    }) }}
+{% endif %}

--- a/src/components/contact-us/questions/_security_send_method.njk
+++ b/src/components/contact-us/questions/_security_send_method.njk
@@ -30,7 +30,7 @@
         name: "securityCodeSentMethod",
         fieldset: {
             legend: {
-                text: 'pages.contactUsQuestions.noSecurityCode.section1.header' | translate,
+                text: radioHeader,
                 isPageHeading: false,
                 classes: "govuk-fieldset__legend--m"
             }

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -22,6 +22,7 @@ export interface Questions {
   additionalDescription?: string;
   optionalDescription?: string;
   moreDetailDescription?: string;
+  radioButtons?: string;
 }
 
 export interface ThemeQuestions {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1405,6 +1405,7 @@
           "header": "How did you expect to get the security code?",
           "errorMessage": "Select whether you expected to get the code by email, text message or authenticator app",
           "errorMessageSignIn": "Select whether you expected to get the code by text message or authenticator app"
+
         },
         "section2": {
           "header": "Anything else you want to tell us",
@@ -1416,7 +1417,8 @@
         "header": "The security code does not work",
         "section1": {
           "header": "How did you get the security code?",
-          "errorMessage": "Select whether you got the code by email, text message or authenticator app"
+          "errorMessage": "Select whether you got the code by email, text message or authenticator app",
+          "errorMessageSignIn": "Select whether you got the code by text message or authenticator app"
         },
         "section2": {
           "header": "Anything else you want to tell us",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1274,9 +1274,9 @@
         "header": "A problem signing in to your GOV.UK account",
         "section1": {
           "header": "Tell us what happened",
-          "radio1": "You did not receive a security code",
+          "radio1": "You did not get a security code",
           "radio2": "The security code did not work",
-          "radio3": "You do not have access to the phone number you used when you created your account, so you could not receive a security code",
+          "radio3": "You've changed your phone number or lost your phone",
           "radio4": "You’ve forgotten your password",
           "radio5": "You’ve been told your account ‘cannot be found’",
           "radio6": "There was a technical problem (for example, the service was unavailable)",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1422,7 +1422,7 @@
         },
         "section2": {
           "header": "Anything else you want to tell us",
-          "hintText": "You can add more detail, such as what happened when you entered the security code or what you were trying to do, or give us feedback"
+          "hintText": "You can add more detail, such as what you were trying to do, or give us feedback"
         }
       },
       "noUKMobile": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1403,7 +1403,8 @@
         "header": "You did not get a security code",
         "section1": {
           "header": "How did you expect to get the security code?",
-          "errorMessage": "Select whether you expected to get the code by email, text message or authenticator app"
+          "errorMessage": "Select whether you expected to get the code by email, text message or authenticator app",
+          "errorMessageSignIn": "Select whether you expected to get the code by text message or authenticator app"
         },
         "section2": {
           "header": "Anything else you want to tell us",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1445,9 +1445,13 @@
         }
       },
       "noPhoneNumberAccess": {
-        "title": "You do not have access to the phone number you used when you created your account",
-        "header": "You do not have access to the phone number you used when you created your account",
+        "title": "You've changed your phone number or lost your phone",
+        "header": "You've changed your phone number or lost your phone",
         "section1": {
+          "header": "How do you get security codes to sign in?",
+          "errorMessageSignIn": "Select whether you get security codes by text message or authenticator app"
+        },
+        "section2": {
           "header": "Anything else you want to tell us",
           "paragraph1": "For example, if you want to add more detail or give us feedback"
         }


### PR DESCRIPTION
## What

- Change "did not receive" to "did not get" a security code
- Change "do not have access to phone number" to "changed phone number
- Add radios for to be displayed if auth apps are enabled
- Amend validation to validatte under correct circumstances
- Show the radio buttons on the noPhoneNumberAcces feedback questions if auth apps are enabled.
- Replace hard-coded question passed to Zendesk with actual question asked to user.
- Re-order radios on problem signing in form
- Change hint on `invalidSecurityCode` form

## Why

We are going live with authenticator apps and need the feedback form to reflect this
