### PR TITLE
AUT-619 - Send clientSessionId in request for account creation for auth apps 

### DIFF
--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -69,7 +69,8 @@ export function setupAuthenticatorAppPost(
       code,
       req.ip,
       sessionId,
-      persistentSessionId
+      persistentSessionId,
+      clientSessionId
     );
 
     if (!verifyAccessCodeRes.success) {

--- a/src/components/setup-authenticator-app/setup-authenticator-app-service.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-service.ts
@@ -16,7 +16,8 @@ export function setupAuthAppService(axios: Http = http): any {
     code: string,
     sourceIp: string,
     sessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    clientSessionId: string
   ): Promise<ApiResponseResult<DefaultApiResponse>> {
     const response = await axios.client.post<DefaultApiResponse>(
       API_ENDPOINTS.VERIFY_MFA_CODE,
@@ -33,6 +34,7 @@ export function setupAuthAppService(axios: Http = http): any {
         sourceIp: sourceIp,
         sessionId: sessionId,
         persistentSessionId: persistentSessionId,
+        clientSessionId: clientSessionId,
       })
     );
 

--- a/src/components/setup-authenticator-app/types.ts
+++ b/src/components/setup-authenticator-app/types.ts
@@ -5,6 +5,7 @@ export interface AuthAppServiceInterface {
     code: string,
     sourceIp: string,
     sessionId: string,
-    persistentSessionId: string
+    persistentSessionId: string,
+    clientSessionId: string
   ) => Promise<ApiResponseResult<DefaultApiResponse>>;
 }


### PR DESCRIPTION
## What?

- Send the clientSessionId in the request to the verify-mfa-code endpoint for account-creation

## Why?

- So we can attach the clientSessionId in the lambda logs
