### PR TITLE
BAU: Fix question text passed to Zendesk on noPhoneNumberAccess form

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -217,7 +217,7 @@ export function getQuestionsFromFormType(
     },
     noPhoneNumberAccess: {
       optionalDescription: req.t(
-        "pages.contactUsQuestions.noPhoneNumberAccess.section1.header"
+        "pages.contactUsQuestions.noPhoneNumberAccess.section2.header"
       ),
       radioButtons: req.t(
         "pages.contactUsQuestions.noPhoneNumberAccess.section1.header"


### PR DESCRIPTION
## What?

- The `optionalDescription` is now `section2` on the form, update the question map appropriately to map the correct header.

## Why?

As a result of a recent change we were incorrectly mapping the question text to the Zendesk ticket.

## Related PRs

#702 