### PR TITLE
AUT-574: Remove third bullet point from section

### DIFF
--- a/src/components/common/footer/accessibility-statement.njk
+++ b/src/components/common/footer/accessibility-statement.njk
@@ -41,7 +41,6 @@
 <ul class="govuk-list govuk-list--bullet">
   <li>{{'pages.accessibilityStatement.section2.bulletPoint1' | translate}}</li>
   <li>{{'pages.accessibilityStatement.section2.bulletPoint2' | translate}}</li>
-  <li>{{'pages.accessibilityStatement.section2.bulletPoint3' | translate}}</li>
 </ul>
 <p class="govuk-body">{{'pages.accessibilityStatement.section2.paragraph2' | translate}}</p>
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -722,7 +722,6 @@
         "paragraph1": "The following parts of GOV.UK accounts are not fully accessible:",
         "bulletPoint1": "it’s not possible to stop or change the length of the time-out when you use, sign in to or create an account",
         "bulletPoint2": "one link has poor colour contrast",
-        "bulletPoint3": "one page has heading elements that are not consistent",
         "paragraph2": "We’ll update this page when issues are fixed or with information about when we plan to fix them."
       },
       "section3": {


### PR DESCRIPTION
## What?

To remove third bullet point from the accessibility statement page of the "How accessible GOV.UK accounts are" section

## Why?

The problem referred to in the bullet point has been fixed

## Related PRs

[AUT-463](https://github.com/alphagov/di-authentication-frontend/pull/656)
