### PR TITLE
Update test running instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The unit tests have been written with Mocha and Supertest.
 If the app is run in a container then the tests are run there too:
 
 ```shell script
-docker exec -it di-auth-frontend-dev /bin/sh
+docker exec -it di-authentication-frontend_di-auth-frontend /bin/sh
 
 # yarn run test:unit
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.8'
 
 services:
   di-auth-frontend:
+    container_name: di-authentication-frontend_di-auth-frontend
     build:
       context: .
       dockerfile: local.Dockerfile


### PR DESCRIPTION
This change does two things: 

- Add `container_name` to docker compose file
- Update README to reflect this container name

## What?

When following the README I found that the [Running the tests](https://github.com/alphagov/di-authentication-frontend/blob/main/README.md#running-the-tests) section did not work. I got some advice on how this might be fixed and have included those changes in this PR.  

## Why?

Fixes issue with instructions in README not working.