### PR TITLE
AUT-615 - Remove supportMFAOptions flag from frontend code base

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -23,7 +23,6 @@ import {
   getRedisPort,
   getSessionExpiry,
   getSessionSecret,
-  supportMFAOptions,
 } from "./config";
 import { logErrorMiddleware } from "./middleware/log-error-middleware";
 import { enterEmailRouter } from "./components/enter-email/enter-email-routes";
@@ -89,11 +88,9 @@ function registerRoutes(app: express.Application) {
   app.use(resetPasswordCheckEmailRouter);
   app.use(checkYourEmailRouter);
   app.use(createPasswordRouter);
-  if (supportMFAOptions()) {
-    app.use(selectMFAOptionsRouter);
-    app.use(enterAuthenticatorAppCodeRouter);
-    app.use(setupAuthenticatorAppRouter);
-  }
+  app.use(selectMFAOptionsRouter);
+  app.use(enterAuthenticatorAppCodeRouter);
+  app.use(setupAuthenticatorAppRouter);
   app.use(enterPhoneNumberRouter);
   app.use(registerAccountCreatedRouter);
   app.use(footerRouter);

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -8,14 +8,12 @@ import { ERROR_CODES, getNextPathAndUpdateJourney } from "../common/constants";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
-import { supportMFAOptions } from "../../config";
 
 const TEMPLATE_NAME = "check-your-phone/index.njk";
 
 export function checkYourPhoneGet(req: Request, res: Response): void {
   res.render(TEMPLATE_NAME, {
     phoneNumber: req.session.user.phoneNumber,
-    supportMFAOptions: supportMFAOptions() ? true : null,
   });
 }
 

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -24,7 +24,6 @@
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
-    <input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
     {{ govukInput({
   label: {
@@ -51,7 +50,6 @@
     </p>
     {% endset %}
 
-    {% if supportMFAOptions %}
       {% set detailsHTML %}
 
       {{detailsHTML | safe}}
@@ -61,7 +59,6 @@
       </p>
 
       {% endset %}
-    {% endif %}
 
     {{ govukDetails({
       summaryText: 'pages.checkYourPhone.details.summaryText' | translate,

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -62,7 +62,6 @@ const authStateMachine = createMachine(
       isIdentityRequired: false,
       prompt: OIDC_PROMPT.NONE,
       skipAuthentication: false,
-      supportMFAOptions: false,
       mfaMethodType: MFA_METHOD_TYPE.SMS,
       isMfaMethodVerified: true,
     },
@@ -165,10 +164,6 @@ const authStateMachine = createMachine(
             },
             {
               target: [PATH_NAMES.GET_SECURITY_CODES],
-              cond: "supportMFAOptionsAndIsAccountPartCreated", //TODO this is just to test drop offs
-            },
-            {
-              target: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
               cond: "isAccountPartCreated",
             },
             { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
@@ -213,10 +208,6 @@ const authStateMachine = createMachine(
           [USER_JOURNEY_EVENTS.PASSWORD_CREATED]: [
             {
               target: [PATH_NAMES.GET_SECURITY_CODES],
-              cond: "supportMFAOptions",
-            },
-            {
-              target: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
             },
           ],
         },
@@ -300,15 +291,11 @@ const authStateMachine = createMachine(
         on: {
           [USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED]: [
             {
-              target: [PATH_NAMES.GET_SECURITY_CODES],
-              cond: "supportMFAOptionsAndIsAccountPartCreated", //TODO this is just to test drop offs
-            },
-            {
               target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
               cond: "requiresMFAAuthAppCode",
             },
             {
-              target: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
+              target: [PATH_NAMES.GET_SECURITY_CODES],
               cond: "isAccountPartCreated",
             },
             { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
@@ -438,10 +425,6 @@ const authStateMachine = createMachine(
           [USER_JOURNEY_EVENTS.PASSWORD_CREATED]: [
             {
               target: [PATH_NAMES.GET_SECURITY_CODES],
-              cond: "supportMFAOptionsAndIsAccountPartCreated", //TODO this is just to test drop offs
-            },
-            {
-              target: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
               cond: "isAccountPartCreated",
             },
             { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
@@ -534,15 +517,9 @@ const authStateMachine = createMachine(
       skipAuthentication: (context) =>
         context.skipAuthentication === true &&
         context.isAuthenticated === false,
-      supportMFAOptions: (context) => context.supportMFAOptions === true,
       requiresMFAAuthAppCode: (context) =>
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
         context.isMfaMethodVerified === true,
-      supportMFAOptionsAndIsAccountPartCreated: (
-        context //TODO this should be removed before go live
-      ) =>
-        context.supportMFAOptions === true &&
-        context.isMfaMethodVerified === false,
     },
   }
 );

--- a/src/components/common/state-machine/tests/state-machine.test.ts
+++ b/src/components/common/state-machine/tests/state-machine.test.ts
@@ -113,14 +113,12 @@ describe("state-machine", () => {
       expect(nextState.value).to.equal(PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD);
     });
 
-    it("should move from create password to enter phone number when password created event", () => {
+    it("should move from create password to get security codes when password created event", () => {
       const nextState = getNextState(
         PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD,
         USER_JOURNEY_EVENTS.PASSWORD_CREATED
       );
-      expect(nextState.value).to.equal(
-        PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER
-      );
+      expect(nextState.value).to.equal(PATH_NAMES.GET_SECURITY_CODES);
     });
 
     it("should move from check your phone to account confirmation when phone number verified event", () => {

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -3,7 +3,6 @@ import { PATH_NAMES, SUPPORT_TYPE, ZENDESK_THEMES } from "../../app.constants";
 import { contactUsService } from "./contact-us-service";
 import { ContactUsServiceInterface, Questions, ThemeQuestions } from "./types";
 import { ExpressRouteFunc } from "../../types";
-import { supportMFAOptions } from "../../config";
 
 const themeToPageTitle = {
   [ZENDESK_THEMES.ACCOUNT_NOT_FOUND]:
@@ -81,7 +80,6 @@ export function furtherInformationGet(req: Request, res: Response): void {
   return res.render("contact-us/further-information/index.njk", {
     theme: req.query.theme,
     referer: req.query.referer,
-    supportMFAOptions: supportMFAOptions() ? true : null,
   });
 }
 
@@ -115,7 +113,6 @@ export function contactUsQuestionsGet(req: Request, res: Response): void {
     backurl: req.headers.referer,
     referer: req.query.referer,
     pageTitleHeading: pageTitle,
-    supportMFAOptions: supportMFAOptions() ? true : null,
   });
 }
 

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -2,23 +2,20 @@ import { body, check } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import { ZENDESK_THEMES } from "../../app.constants";
-import { supportMFAOptions } from "../../config";
 
 export function validateContactUsQuestionsRequest(): ValidationChainFunc {
   return [
     body("securityCodeSentMethod")
-      .if((value: string, { req }: any) => {
-        return req.body.theme == "account_creation" || supportMFAOptions();
-      })
+      .if(body("theme").equals("account_creation"))
       .if(check("radio_buttons").notEmpty())
       .notEmpty()
       .withMessage((value, { req }) => {
-        const section = supportMFAOptions()
-          ? req.body.formType + ".section1"
-          : "securityCodeSentMethod";
         const suffix = req.body.theme == "signing_in" ? "SignIn" : "";
         return req.t(
-          "pages.contactUsQuestions." + section + ".errorMessage" + suffix,
+          "pages.contactUsQuestions." +
+            req.body.formType +
+            ".section1.errorMessage" +
+            suffix,
           {
             value,
           }

--- a/src/components/contact-us/further-information/_account-creation-further-information.njk
+++ b/src/components/contact-us/further-information/_account-creation-further-information.njk
@@ -7,9 +7,7 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
-<input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
-    {% if supportMFAOptions %}
         {% set items = [
                 {
                     value: "no_uk_mobile_number",
@@ -37,31 +35,6 @@
                 }
             ]
         %}
-    {% else %}
-        {% set items = [
-            {
-                value: "no_uk_mobile_number",
-                text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio3' | translate
-            },
-            {
-                value: "no_security_code",
-                text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio1' | translate
-            },
-            {
-                value: "invalid_security_code",
-                text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio2' | translate
-            },
-            {
-                value: "technical_error",
-                text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio4' | translate
-            },
-            {
-                value: "something_else",
-                text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio5' | translate
-            }
-        ]
-        %}
-    {% endif %}
 
     {{ govukRadios({
         idPrefix: "account-creation",

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -10,7 +10,6 @@
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="invalidSecurityCode"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
-<input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
 {% set radioHeader = 'pages.contactUsQuestions.invalidSecurityCode.section1.header' | translate %}
 {% include "contact-us/questions/_security_send_method.njk" %}

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -10,7 +10,6 @@
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="noPhoneNumberAccess"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
-<input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
 {% set radioHeader = 'pages.contactUsQuestions.noPhoneNumberAccess.section1.header' | translate %}
 {% include "contact-us/questions/_security_send_method.njk" %}

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -10,7 +10,6 @@
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="noSecurityCode"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
-<input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
 
 {% set radioHeader = 'pages.contactUsQuestions.noSecurityCode.section1.header' | translate %}
 {% include "contact-us/questions/_security_send_method.njk" %}

--- a/src/components/contact-us/questions/_security_send_method.njk
+++ b/src/components/contact-us/questions/_security_send_method.njk
@@ -1,43 +1,38 @@
-{% if theme == 'account_creation' or supportMFAOptions %}
+{% set items = [] %}
 
-    {% set items = [] %}
+{% if theme == 'account_creation' %}
+    {% set items = (items.push({
+        value: "email",
+        checked: securityCodeSentMethod === 'email',
+        text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
+    }), items) %}
+{% endif %}
 
-    {% if theme == 'account_creation' %}
-        {% set items = (items.push({
-            value: "email",
-            checked: securityCodeSentMethod === 'email',
-            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translate
-        }), items) %}
-    {% endif %}
+{% set items = (items.push({
+    value: "text_message",
+    checked: securityCodeSentMethod === 'text_message',
+    text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
+}), items) %}
 
     {% set items = (items.push({
-        value: "text_message",
-        checked: securityCodeSentMethod === 'text_message',
-        text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translate
-    }), items) %}
+        value: "authenticator_app",
+        checked: securityCodeSentMethod === 'authenticator_app',
+        text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translate
+    }), items)
+    %}
 
-    {% if supportMFAOptions %}
-        {% set items = (items.push({
-            value: "authenticator_app",
-            checked: securityCodeSentMethod === 'authenticator_app',
-            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translate
-        }), items)
-        %}
-    {% endif %}
-
-    {{ govukRadios({
-        idPrefix: "securityCodeSentMethod",
-        name: "securityCodeSentMethod",
-        fieldset: {
-            legend: {
-                text: radioHeader,
-                isPageHeading: false,
-                classes: "govuk-fieldset__legend--m"
-            }
-        },
-        items: items,
-        errorMessage: {
-            text: errors['securityCodeSentMethod'].text
-        } if (errors['securityCodeSentMethod'])
-    }) }}
-{% endif %}
+{{ govukRadios({
+    idPrefix: "securityCodeSentMethod",
+    name: "securityCodeSentMethod",
+    fieldset: {
+        legend: {
+            text: radioHeader,
+            isPageHeading: false,
+            classes: "govuk-fieldset__legend--m"
+        }
+    },
+    items: items,
+    errorMessage: {
+        text: errors['securityCodeSentMethod'].text
+    } if (errors['securityCodeSentMethod'])
+}) }}

--- a/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
@@ -37,7 +37,6 @@ describe("contact us further information controller", () => {
         {
           theme: "signing_in",
           referer: REFERER,
-          supportMFAOptions: true,
         }
       );
     });
@@ -52,7 +51,6 @@ describe("contact us further information controller", () => {
         {
           theme: "account_creation",
           referer: REFERER,
-          supportMFAOptions: true,
         }
       );
     });

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -46,7 +46,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'GOV.UK email subscriptions' radio option was chosen", () => {
@@ -61,7 +60,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.emailSubscriptions.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'A suggestion or feedback' radio option was chosen", () => {
@@ -76,7 +74,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.suggestionOrFeedback.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
 
@@ -92,7 +89,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.provingIdentity.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
 
@@ -117,7 +113,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -133,7 +128,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'You do not have access to the phone number' radio option was chosen", () => {
@@ -149,7 +143,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noPhoneNumberAccess.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'You've forgotten your password' radio option was chosen", () => {
@@ -165,7 +158,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.forgottenPassword.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'Your account cannot be found' radio option was chosen", () => {
@@ -181,7 +173,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.accountNotFound.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -197,7 +188,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -213,7 +203,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
   });
@@ -232,7 +221,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -248,7 +236,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'You do not have a UK number' radio option was chosen", () => {
@@ -264,7 +251,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noUKMobile.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -280,7 +266,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -296,7 +281,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.accountCreation.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
     it("should render contact-us-questions if a 'problem with authenticator app' radio option was chosen", () => {
@@ -312,7 +296,6 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.authenticatorApp.title",
         referer: REFERER,
-        supportMFAOptions: true,
       });
     });
 

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -9,7 +9,6 @@ import {
   formatValidationError,
   renderBadRequest,
 } from "../../utils/validation";
-import { supportMFAOptions } from "../../config";
 
 export function createPasswordGet(req: Request, res: Response): void {
   res.render("create-password/index.njk");
@@ -48,7 +47,6 @@ export function createPasswordPost(
         USER_JOURNEY_EVENTS.PASSWORD_CREATED,
         {
           requiresTwoFactorAuth: true,
-          supportMFAOptions: supportMFAOptions(),
         },
         res.locals.sessionId
       )

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -15,7 +15,6 @@ import {
 } from "../common/constants";
 import { BadRequestError } from "../../utils/error";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
-import { supportMFAOptions } from "../../config";
 import { MFA_METHOD_TYPE } from "../../app.constants";
 
 const ENTER_PASSWORD_TEMPLATE = "enter-password/index.njk";
@@ -133,7 +132,6 @@ export function enterPasswordPost(
             req.session.user.isLatestTermsAndConditionsAccepted,
           requiresTwoFactorAuth: userLogin.data.mfaRequired,
           isConsentRequired: req.session.user.isConsentRequired,
-          supportMFAOptions: supportMFAOptions(),
           mfaMethodType: userLogin.data.mfaMethodType,
           isMfaMethodVerified: userLogin.data.mfaMethodVerified,
         },

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -33,7 +33,6 @@ describe("enter password controller", () => {
 
   afterEach(() => {
     sinon.restore();
-    delete process.env.SUPPORT_MFA_OPTIONS;
   });
 
   describe("enterEmailGet", () => {
@@ -54,6 +53,7 @@ describe("enter password controller", () => {
             consentRequired: false,
             latestTermsAndConditionsAccepted: true,
             mfaMethodVerified: true,
+            mfaMethodType: "SMS",
           },
           success: true,
         }),
@@ -91,6 +91,7 @@ describe("enter password controller", () => {
             redactedPhoneNumber: "******3456",
             mfaRequired: false,
             mfaMethodVerified: true,
+            mfaMethodType: "SMS",
           },
         }),
       };
@@ -112,44 +113,14 @@ describe("enter password controller", () => {
       expect(req.session.user.isAccountPartCreated).to.be.eq(false);
     });
 
-    it("should redirect to enter phone number when phone number is not verified", async () => {
-      const fakeService: EnterPasswordServiceInterface = {
-        loginUser: sinon.fake.returns({
-          success: true,
-          data: {
-            redactedPhoneNumber: "******3456",
-            mfaMethodVerified: false,
-          },
-        }),
-      };
-
-      res.locals.sessionId = "123456-djjad";
-      res.locals.clientSessionId = "00000-djjad";
-      res.locals.persistentSessionId = "dips-123456-abc";
-      req.session.user = {
-        email: "joe.bloggs@test.com",
-      };
-      req.body["password"] = "password";
-
-      await enterPasswordPost(false, fakeService)(
-        req as Request,
-        res as Response
-      );
-
-      expect(res.redirect).to.have.calledWith(
-        PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER
-      );
-      expect(req.session.user.isAccountPartCreated).to.be.eq(true);
-    });
-
     it("should redirect to get security codes page when 2fa method is not verified", async () => {
-      process.env.SUPPORT_MFA_OPTIONS = "1";
       const fakeService: EnterPasswordServiceInterface = {
         loginUser: sinon.fake.returns({
           success: true,
           data: {
             redactedPhoneNumber: "******3456",
             mfaMethodVerified: false,
+            mfaMethodType: "SMS",
           },
         }),
       };
@@ -178,6 +149,7 @@ describe("enter password controller", () => {
             redactedPhoneNumber: "******3456",
             latestTermsAndConditionsAccepted: false,
             mfaMethodVerified: true,
+            mfaMethodType: "SMS",
           },
           success: true,
         }),

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -16,12 +16,11 @@ import { SendNotificationServiceInterface } from "../common/send-notification/ty
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { prependInternationalPrefix } from "../../utils/phone-number";
-import { supportInternationalNumbers, supportMFAOptions } from "../../config";
+import { supportInternationalNumbers } from "../../config";
 
 export function enterPhoneNumberGet(req: Request, res: Response): void {
   res.render("enter-phone-number/index.njk", {
     supportInternationalNumbers: supportInternationalNumbers() ? true : null,
-    supportMFAOptions: supportMFAOptions() ? true : null,
     isAccountPartCreated: req.session.user.isAccountPartCreated,
   });
 }

--- a/src/components/enter-phone-number/index.njk
+++ b/src/components/enter-phone-number/index.njk
@@ -5,39 +5,26 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% if isAccountPartCreated and not supportMFAOptions %}
-  {% set pageTitleName = 'pages.enterPhoneNumber.returningUser.title' | translate %}
-{% else %}
-  {% set pageTitleName = 'pages.enterPhoneNumber.title' | translate %}
-{% endif %}
+ {% set pageTitleName = 'pages.enterPhoneNumber.title' | translate %}
 
-{% if supportMFAOptions %}
-  {% set showBack = true %}
-  {% set hrefBack = 'get-security-codes' %}
-{% endif %}
+
+{% set showBack = true %}
+{% set hrefBack = 'get-security-codes' %}
 
 {% block content %}
   {% include "common/errors/errorSummary.njk" %}
 
-  {% if isAccountPartCreated and not supportMFAOptions %}
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.returningUser.header' |
-        translate}}</h1>
-    <p class="govuk-body">{{'pages.enterPhoneNumber.returningUser.info.paragraph1' | translate}}</p>
-    <p class="govuk-body">{{'pages.enterPhoneNumber.returningUser.info.paragraph2' | translate}}</p>
-  {% else %}
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterPhoneNumber.header' |
          translate}}</h1>
     <p class="govuk-body">{{'pages.enterPhoneNumber.info.paragraph1' | translate}}</p>
     {% if not supportInternationalNumbers %}
         <p class="govuk-body">{{'pages.enterPhoneNumber.info.paragraph2' | translate}}</p>
     {% endif %}
-  {% endif %}
 
   <form action="/enter-phone-number" method="post" novalidate="novalidate">
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}"/>
-    <input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
     <input type="hidden" name="isAccountPartCreated" value="{{isAccountPartCreated}}"/>
 
     {{ govukInput({

--- a/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
@@ -42,7 +42,6 @@ describe("enter phone number controller", () => {
       expect(res.render).to.have.calledWith("enter-phone-number/index.njk", {
         supportInternationalNumbers: true,
         isAccountPartCreated: undefined,
-        supportMFAOptions: null,
       });
     });
 
@@ -55,7 +54,6 @@ describe("enter phone number controller", () => {
       expect(res.render).to.have.calledWith("enter-phone-number/index.njk", {
         supportInternationalNumbers: true,
         isAccountPartCreated: true,
-        supportMFAOptions: null,
       });
     });
   });

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -18,7 +18,6 @@ import { enterPasswordService } from "../enter-password/enter-password-service";
 import { MfaServiceInterface } from "../common/mfa/types";
 import { mfaService } from "../common/mfa/mfa-service";
 import { MFA_METHOD_TYPE } from "../../app.constants";
-import { supportMFAOptions } from "../../config";
 
 const resetPasswordTemplate = "reset-password/index.njk";
 
@@ -126,7 +125,6 @@ export function resetPasswordPost(
           requiresTwoFactorAuth: true,
           isLatestTermsAndConditionsAccepted:
             req.session.user.isLatestTermsAndConditionsAccepted,
-          supportMFAOptions: supportMFAOptions(),
           mfaMethodType: loginResponse.data.mfaMethodType,
           isMfaMethodVerified: loginResponse.data.mfaMethodVerified,
         },

--- a/src/components/reset-password/tests/reset-password-controller.test.ts
+++ b/src/components/reset-password/tests/reset-password-controller.test.ts
@@ -38,7 +38,6 @@ describe("reset password controller (in 6 digit code flow)", () => {
 
   afterEach(() => {
     sinon.restore();
-    delete process.env.SUPPORT_MFA_OPTIONS;
   });
 
   describe("resetPasswordRequestGet", () => {
@@ -102,49 +101,7 @@ describe("reset password controller (in 6 digit code flow)", () => {
       expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_MFA);
     });
 
-    it("should redirect to /enter-phone-number when password updated and phone number not verified", async () => {
-      const fakeResetService: ResetPasswordServiceInterface = {
-        updatePassword: sinon.fake.returns({ success: true }),
-      };
-      const fakeLoginService: EnterPasswordServiceInterface = {
-        loginUser: sinon.fake.returns({
-          success: true,
-          data: {
-            redactedPhoneNumber: "******1234",
-            consentRequired: false,
-            latestTermsAndConditionsAccepted: true,
-            mfaMethodVerified: false,
-            mfaRequired: true,
-          },
-        }),
-      };
-      fakeLoginService.loginUser;
-      const fakeMfAService: MfaServiceInterface = {
-        sendMfaCode: sinon.fake.returns({ success: true }),
-      };
-
-      req.session.user = {
-        email: "joe.bloggs@test.com",
-      };
-      req.body.password = "Password1";
-
-      await resetPasswordPost(
-        fakeResetService,
-        fakeLoginService,
-        fakeMfAService
-      )(req as Request, res as Response);
-
-      expect(fakeResetService.updatePassword).to.have.been.calledOnce;
-      expect(fakeLoginService.loginUser).to.have.been.calledOnce;
-      expect(fakeMfAService.sendMfaCode).to.not.have.been.called;
-
-      expect(res.redirect).to.have.calledWith(
-        PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER
-      );
-    });
-
     it("should redirect to /get-security-codes when password updated and mfa method not verified", async () => {
-      process.env.SUPPORT_MFA_OPTIONS = "1";
       const fakeResetService: ResetPasswordServiceInterface = {
         updatePassword: sinon.fake.returns({ success: true }),
       };

--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -31,10 +31,8 @@
   <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>{{ 'pages.signInOrCreate.bullet1' | translate }}</li>
-    {% if supportMFAOptions and supportInternationalNumbers %}
+    {% if supportInternationalNumbers %}
         <li>{{ 'pages.signInOrCreate.bullet2IntNumbers' | translate }}</li>
-    {% elif supportMFAOptions %}
-        <li>{{ 'pages.signInOrCreate.bullet2AuthApps' | translate }}</li>
     {% else %}
         <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
     {% endif %}
@@ -43,7 +41,6 @@
 <form action="/sign-in-or-create" method="post" novalidate>
 
   <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-  <input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
   <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}"/>
 
   {{ govukButton({

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -1,12 +1,11 @@
 import { Request, Response } from "express";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
-import { supportInternationalNumbers, supportMFAOptions } from "../../config";
+import { supportInternationalNumbers } from "../../config";
 
 export function signInOrCreateGet(req: Request, res: Response): void {
   res.render("sign-in-or-create/index.njk", {
     serviceType: req.session.client.serviceType,
-    supportMFAOptions: supportMFAOptions() ? true : null,
     supportInternationalNumbers: supportInternationalNumbers() ? true : null,
   });
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -113,8 +113,7 @@
       },
       "paragraph": "You’ll need:",
       "bullet1": "an email address",
-      "bullet2": "a UK mobile phone number",
-      "bullet2AuthApps": "a way to get security codes - this can be a UK mobile phone number or an authenticator app",
+      "bullet2": "a way to get security codes - this can be a UK mobile phone number or an authenticator app",
       "bullet2IntNumbers": "a way to get security codes - this can be a mobile phone number or an authenticator app",
       "insetAlternativeLanguage": {
         "paragraph1": "The GOV.UK account is also available ",
@@ -315,14 +314,6 @@
       "info": {
         "paragraph1": "We will send a 6 digit security code to the number you give us.",
         "paragraph2": "You must use a UK mobile phone number."
-      },
-      "returningUser": {
-        "title": "Finish creating your account",
-        "header": "Finish creating your account",
-        "info": {
-          "paragraph1": "You need to add a UK mobile phone number to your GOV.UK account.",
-          "paragraph2": "We will send a 6 digit security code to the number you give us."
-        }
       },
       "ukPhoneNumber": {
         "label": "UK mobile phone number",


### PR DESCRIPTION
## What?

- This required a few minor tweaks to the state-machine.ts to ensure that the users who dropped off would go to the GET_SECURITY_CODES screen instead of the CREATE_ACCOUNT_ENTER_PHONE_NUMBER screen.
- Remove content that is no longer required
- There will be further changes to remove the SUPPORT_MFA_OPTIONS from terraform and other files.

## Why?

- Auth Apps has now been deployed in every environment so now the feature flag can be removed.