### PR TITLE
AUT-618: Add also available in Welsh to the 'en' resource file before translation

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -115,6 +115,11 @@
       "bullet1": "an email address",
       "bullet2": "a UK mobile phone number",
       "bullet2AuthApps": "a way to get security codes - this can be a UK mobile phone number or an authenticator app",
+      "insetAlternativeLanguage": {
+        "paragraph1": "The GOV.UK account is also available ",
+        "linkText": "in Welsh (Cymraeg)",
+        "linkHref": ""
+      },
       "paragraph2": "If you already have a GOV.UK account you can",
       "signInText": "sign in",
       "moreAbout": {


### PR DESCRIPTION
## What?

Add also available in Welsh to the 'en' resource file before translation.

## Why?

Get as much text in as possible before the files are sent.
