### PR TITLE
AUT-629: Preload translation text

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1515,6 +1515,11 @@
         "subHeading": "What you need to do",
         "paragraph1": "It will take you about 10 minutes to prove your identity this way.",
         "insetTextEnglishOnly": "This service is currently only available in English.",
+        "insetAlternativeLanguage": {
+          "paragraph1": "This service is also available in ",
+          "linkText": "Welsh (Cymraeg)",
+          "linkHref": ""
+        },
         "paragraph2": "You'll need to create or sign in to your GOV.UK account first. We'll then ask you for your current address and passport details.",
         "paragraph3": "We'll also ask you some security questions that only you should know the answers to. You might find it easier to answer these questions if you have information about:",
         "listItem1": "your mobile phone contract",


### PR DESCRIPTION
## What?

- Preload text for offering Welsh language via 'prove your identity' screen


## Why?

- No immediate function - purely to allow this text to be sent to translators