### PR TITLE
AUT-599: Remove link from reset password change email

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -423,10 +423,7 @@ const authStateMachine = createMachine(
           ],
         },
         meta: {
-          optionalPaths: [
-            PATH_NAMES.RESET_PASSWORD_RESEND_CODE,
-            PATH_NAMES.ENTER_EMAIL_SIGN_IN,
-          ],
+          optionalPaths: [PATH_NAMES.RESET_PASSWORD_RESEND_CODE],
         },
       },
       [PATH_NAMES.RESET_PASSWORD_RESEND_CODE]: {

--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -48,8 +48,7 @@
     <p class="govuk-body">
       {{'pages.resetPasswordCheckEmail.details.text1' | translate}}
       <a href="{{'pages.resetPasswordCheckEmail.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.resetPasswordCheckEmail.details.sendCodeLinkText'| translate}}</a>
-      {{'pages.resetPasswordCheckEmail.details.text2' | translate}}
-      <a href="{{'pages.resetPasswordCheckEmail.details.changeEmailLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.resetPasswordCheckEmail.details.changeEmailLinkText'| translate}}</a>.
+      {{'pages.resetPasswordCheckEmail.details.text2' | translate}}.
     </p>
     {% endset %}
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -256,9 +256,7 @@
         "text1": "We can ",
         "sendCodeLinkText": "send the code again",
         "sendCodeLinkHref": "/resend-code?isResendCodeRequest=true",
-        "text2": " or you can ",
-        "changeEmailLinkText": "use a different email address",
-        "changeEmailLinkHref": "/enter-email"
+        "text2": " if the code is not working or you did not receive it"
       },
       "sendAnotherEmailLinkText": "Send another email",
       "requestNewCode": {


### PR DESCRIPTION
## What?

Removes link, content and state from the details element in this state. 

## Why?

New request received via comment on Jira Ticket

## Related PRs

Changes what was implemented in #715 
