### PR TITLE
AUT-555 - Send email code again

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -31,6 +31,7 @@ export const PATH_NAMES = {
   SECURITY_CODE_WAIT: "/security-code-invalid-request",
   AUTH_CODE: "/auth-code",
   RESEND_MFA_CODE: "/resend-code",
+  RESEND_EMAIL_CODE: "/resend-email-code",
   SIGNED_OUT: "/signed-out",
   ACCOUNT_LOCKED: "/account-locked",
   UPLIFT_JOURNEY: "/uplift",

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,6 +43,7 @@ import { ENVIRONMENT_NAME } from "./app.constants";
 import { enterMfaRouter } from "./components/enter-mfa/enter-mfa-routes";
 import { authCodeRouter } from "./components/auth-code/auth-code-routes";
 import { resendMfaCodeRouter } from "./components/resend-mfa-code/resend-mfa-code-routes";
+import { resendEmailCodeRouter } from "./components/resend-email-code/resend-email-code-routes";
 import { signedOutRouter } from "./components/signed-out/signed-out-routes";
 import {
   getSessionIdMiddleware,
@@ -102,6 +103,7 @@ function registerRoutes(app: express.Application) {
   app.use(enterMfaRouter);
   app.use(authCodeRouter);
   app.use(resendMfaCodeRouter);
+  app.use(resendEmailCodeRouter);
   app.use(signedOutRouter);
   app.use(shareInfoRouter);
   app.use(updatedTermsConditionsRouter);

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -156,6 +156,11 @@ const authStateMachine = createMachine(
           optionalPaths: [PATH_NAMES.SIGN_IN_OR_CREATE],
         },
       },
+      [PATH_NAMES.RESEND_EMAIL_CODE]: {
+        on: {
+          [USER_JOURNEY_EVENTS.SEND_EMAIL_CODE]: [PATH_NAMES.CHECK_YOUR_EMAIL],
+        },
+      },
       [PATH_NAMES.ENTER_PASSWORD_ACCOUNT_EXISTS]: {
         on: {
           [USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED]: [
@@ -201,6 +206,7 @@ const authStateMachine = createMachine(
         meta: {
           optionalPaths: [
             PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT,
+            PATH_NAMES.RESEND_EMAIL_CODE,
             PATH_NAMES.SECURITY_CODE_WAIT,
             PATH_NAMES.SECURITY_CODE_INVALID,
             PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED,

--- a/src/components/resend-email-code/index.njk
+++ b/src/components/resend-email-code/index.njk
@@ -1,0 +1,30 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set pageTitleName = 'pages.resendEmailCode.title' | translate %}
+{% set showBack = true %}
+{% set hrefBack = 'enter-code' %}
+
+
+{% set phoneNumberMessage = 'pages.resendEmailCode.email.default' | translate + '<span class="govuk-body govuk-!-font-weight-bold">' + emailAddress + '</span>' %}
+
+{% block content %}
+    <form action="/resend-email-code" method="post" novalidate="novalidate">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resendEmailCode.header' | translate}}</h1>
+
+        {{ govukInsetText({
+            html: 'pages.resendEmailCode.email.default' | translate + '<span class="govuk-body govuk-!-font-weight-bold">' + emailAddress + '</span>'
+        }) }}
+
+        <p class="govuk-body">{{'pages.resendEmailCode.message' | translate}}</p>
+        {{ govukButton({
+        "text": button_text|default('pages.resendEmailCode.continue' | translate, true),
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
+
+    </form>
+{% endblock %}

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -1,0 +1,58 @@
+import { Request, Response } from "express";
+import { ExpressRouteFunc } from "../../types";
+import { NOTIFICATION_TYPE } from "../../app.constants";
+import {
+  getErrorPathByCode,
+  getNextPathAndUpdateJourney,
+} from "../common/constants";
+import { BadRequestError } from "../../utils/error";
+import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { SendNotificationServiceInterface } from "../common/send-notification/types";
+import { sendNotificationService } from "../common/send-notification/send-notification-service";
+
+export function resendEmailCodeGet(req: Request, res: Response): void {
+  res.render("resend-email-code/index.njk", {
+    emailAddress: req.session.user.email,
+  });
+}
+
+export function resendEmailCodePost(
+  notificationService: SendNotificationServiceInterface = sendNotificationService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const email = req.session.user.email.toLowerCase();
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+
+    const sendNotificationResponse = await notificationService.sendNotification(
+      sessionId,
+      clientSessionId,
+      email,
+      NOTIFICATION_TYPE.VERIFY_EMAIL,
+      req.ip,
+      persistentSessionId
+    );
+
+    if (!sendNotificationResponse.success) {
+      const path = getErrorPathByCode(sendNotificationResponse.data.code);
+
+      if (path) {
+        return res.redirect(path);
+      }
+
+      throw new BadRequestError(
+        sendNotificationResponse.data.message,
+        sendNotificationResponse.data.code
+      );
+    }
+
+    return res.redirect(
+      getNextPathAndUpdateJourney(
+        req,
+        req.path,
+        USER_JOURNEY_EVENTS.SEND_EMAIL_CODE,
+        null,
+        sessionId
+      )
+    );
+  };
+}

--- a/src/components/resend-email-code/resend-email-code-routes.ts
+++ b/src/components/resend-email-code/resend-email-code-routes.ts
@@ -1,0 +1,28 @@
+import { PATH_NAMES } from "../../app.constants";
+
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import {
+  resendEmailCodeGet,
+  resendEmailCodePost,
+} from "./resend-email-code-controller";
+import { asyncHandler } from "../../utils/async";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import express from "express";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.RESEND_EMAIL_CODE,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  resendEmailCodeGet
+);
+
+router.post(
+  PATH_NAMES.RESEND_EMAIL_CODE,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  asyncHandler(resendEmailCodePost())
+);
+
+export { router as resendEmailCodeRouter };

--- a/src/components/resend-email-code/tests/resend-email-code-controller.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-controller.test.ts
@@ -1,0 +1,70 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+
+import {
+  resendEmailCodePost,
+  resendEmailCodeGet,
+} from "../resend-email-code-controller";
+import { PATH_NAMES } from "../../../app.constants";
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
+import { SendNotificationServiceInterface } from "../../common/send-notification/types";
+
+describe("resend email controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = mockRequest({
+      path: PATH_NAMES.CHECK_YOUR_EMAIL,
+      session: { client: {}, user: {} },
+      log: { info: sinon.fake() },
+      t: sinon.fake(),
+      i18n: { language: "en" },
+    });
+    res = mockResponse();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("resendEmailCodeGet", () => {
+    it("should render resend email code view", () => {
+      resendEmailCodeGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("resend-email-code/index.njk");
+    });
+  });
+
+  describe("resendEmailCodePost", () => {
+    it("should send email code and redirect to /check-your-email view", async () => {
+      const fakeNotificationService: SendNotificationServiceInterface = {
+        sendNotification: sinon.fake.returns({
+          success: true,
+        }),
+      };
+
+      res.locals.sessionId = "123456-djjad";
+      req.session.user = {
+        email: "test@test.com",
+      };
+      req.path = PATH_NAMES.RESEND_EMAIL_CODE;
+
+      await resendEmailCodePost(fakeNotificationService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.CHECK_YOUR_EMAIL);
+      expect(fakeNotificationService.sendNotification).to.have.been.calledOnce;
+    });
+  });
+});

--- a/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
@@ -1,0 +1,157 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import nock = require("nock");
+import * as cheerio from "cheerio";
+import decache from "decache";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  PATH_NAMES,
+} from "../../../app.constants";
+import { ERROR_CODES } from "../../common/constants";
+
+describe("Integration:: resend email code", () => {
+  let token: string | string[];
+  let cookies: string;
+  let app: any;
+  let baseApi: string;
+
+  before(async () => {
+    decache("../../../app");
+    decache("../../../middleware/session-middleware");
+    const sessionMiddleware = require("../../../middleware/session-middleware");
+    sinon
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+
+        req.session.user = {
+          email: "test@test.com",
+          phoneNumber: "******7867",
+          journey: {
+            nextPath: PATH_NAMES.CREATE_ACCOUNT_CHECK_EMAIL,
+            optionalPaths: [PATH_NAMES.RESEND_EMAIL_CODE],
+          },
+        };
+
+        next();
+      });
+
+    app = await require("../../../app").createApp();
+    baseApi = process.env.FRONTEND_API_BASE_URL;
+
+    await request(app)
+      .get(PATH_NAMES.RESEND_EMAIL_CODE)
+      .then((res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("should return resend email code page", (done) => {
+    request(app).get(PATH_NAMES.RESEND_EMAIL_CODE).expect(200, done);
+  });
+
+  it("should return error when csrf not present", (done) => {
+    request(app)
+      .post(PATH_NAMES.RESEND_EMAIL_CODE)
+      .type("form")
+      .send({
+        code: "123456",
+      })
+      .expect(500, done);
+  });
+
+  it("should redirect to /check-your-email when new code requested as part of account creation journey", (done) => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.SEND_NOTIFICATION)
+      .once()
+      .reply(HTTP_STATUS_CODES.NO_CONTENT);
+
+    request(app)
+      .post(PATH_NAMES.RESEND_EMAIL_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+      })
+      .expect("Location", PATH_NAMES.CHECK_YOUR_EMAIL)
+      .expect(302, done);
+  });
+
+  it("should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active", () => {
+    const testSpecificCookies = cookies + "; re=true";
+    request(app)
+      .get(PATH_NAMES.RESEND_EMAIL_CODE)
+      .set("Cookie", testSpecificCookies)
+      .expect((res) => {
+        res.text.includes("You cannot get a new security code at the moment");
+      });
+  });
+
+  it("should return 500 error screen when API call fails", (done) => {
+    nock(baseApi).post(API_ENDPOINTS.SEND_NOTIFICATION).once().reply(500, {
+      errorCode: "1234",
+    });
+
+    request(app)
+      .post(PATH_NAMES.RESEND_EMAIL_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+      })
+      .expect(500, done);
+  });
+
+  it("should redirect to /security-code-requested-too-many-times when request OTP more than 5 times", (done) => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.SEND_NOTIFICATION)
+      .times(6)
+      .reply(400, { code: ERROR_CODES.VERIFY_EMAIL_MAX_CODES_SENT });
+
+    request(app)
+      .post(PATH_NAMES.RESEND_EMAIL_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+      })
+      .expect(
+        "Location",
+        "/security-code-requested-too-many-times?actionType=emailMaxCodesSent"
+      )
+      .expect(302, done);
+  });
+
+  it("should redirect to /security-code-invalid-request when exceeded OTP request limit", (done) => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.SEND_NOTIFICATION)
+      .once()
+      .reply(400, { code: ERROR_CODES.VERIFY_EMAIL_CODE_REQUEST_BLOCKED });
+
+    request(app)
+      .post(PATH_NAMES.RESEND_EMAIL_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+      })
+      .expect(
+        "Location",
+        "/security-code-invalid-request?actionType=emailBlocked"
+      )
+      .expect(302, done);
+  });
+});

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -378,7 +378,7 @@
         "summaryText": "Problems with the code?",
         "text1": "We can ",
         "sendCodeLinkText": "send the code again",
-        "sendCodeLinkHref": "/resend-code?isResendCodeRequest=true",
+        "sendCodeLinkHref": "/resend-email-code",
         "text2": " or you can ",
         "changeEmailLinkText": "use a different email address",
         "changeEmailLinkHref": "/enter-email-create"
@@ -485,6 +485,15 @@
       "phoneNumber": {
         "default": "We will send a code to the phone number linked to your account",
         "isResendCodeRequest": "We will send a code to: [mobile]."
+      }
+    },
+    "resendEmailCode": {
+      "title": "Get security code",
+      "header": "Get security code",
+      "continue": "Get security code",
+      "message": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
+      "email": {
+        "default": "We will send a code to: "
       }
     },
     "signedOut": {


### PR DESCRIPTION
## What?

- Create new component to send the email code again. Make this a different component to the send mfa code again to ensure it can only be accessed via the relevant state transition.
- When the user clicks `Get security code` on the resend-email-code component they will be redirected to /check-email

## Why?

- The changes will help guide the user to understand what steps they need to take to complete their respective journeys.