### PR TITLE
AUT-599: Amend resend code href in forgotten password screen

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -479,7 +479,6 @@ const authStateMachine = createMachine(
         meta: {
           optionalPaths: [
             PATH_NAMES.ENTER_EMAIL_SIGN_IN,
-            PATH_NAMES.RESET_PASSWORD_CHECK_EMAIL,
             PATH_NAMES.ACCOUNT_LOCKED,
             PATH_NAMES.SIGN_IN_OR_CREATE,
           ],

--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -7,25 +7,25 @@
 {% set pageTitleName = 'pages.resetPasswordCheckEmail.title' | translate %}
 {% block content %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resetPasswordCheckEmail.header' | translate}}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resetPasswordCheckEmail.header' | translate}}</h1>
 
-<p class="govuk-body">
-    {{ govukInsetText({
+    <p class="govuk-body">
+        {{ govukInsetText({
         html: 'pages.resetPasswordCheckEmail.paragraph1' | translate + '<span class="govuk-body govuk-!-font-weight-bold">' + email + '</span>'
     }) }}
-</p>
+    </p>
 
-<p class="govuk-body">{{'pages.resetPasswordCheckEmail.paragraph2' | translate}}</p>
+    <p class="govuk-body">{{'pages.resetPasswordCheckEmail.paragraph2' | translate}}</p>
 
-<p class="govuk-body">{{'pages.resetPasswordCheckEmail.paragraph3' | translate}}</p>
+    <p class="govuk-body">{{'pages.resetPasswordCheckEmail.paragraph3' | translate}}</p>
 
-<p class="govuk-body">{{'pages.resetPasswordCheckEmail.paragraph4' | translate}}</p>
+    <p class="govuk-body">{{'pages.resetPasswordCheckEmail.paragraph4' | translate}}</p>
 
-<form action="/reset-password-check-email" method="post" novalidate>
+    <form action="/reset-password-check-email" method="post" novalidate="novalidate">
 
-    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-    <input type="hidden" name="email" value="{{email}}"/>
-    {{ govukInput({
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+        <input type="hidden" name="email" value="{{email}}"/>
+        {{ govukInput({
         label: {
             text: 'pages.resetPasswordCheckEmail.code.label' | translate
         },
@@ -33,39 +33,32 @@
         name: "code",
         type: "number",
         autocomplete:"off",
-        classes: "govuk-!-width-two-thirds govuk-!-font-weight-bold",
+        classes: "govuk-input--width-10 govuk-!-font-weight-bold",
         value: code,
         errorMessage: {
             text: errors['code'].text
         } if (errors['code'])})
     }}
 
-    {% set resendLinkParagraph %}
-        <a href="/reset-password-resend-code" class="govuk-link" rel="noreferrer">{{ 'pages.resetPasswordCheckEmail.requestNewCode.link' | translate }}</a>{{ 'pages.resetPasswordCheckEmail.requestNewCode.paragraph1' | translate }}
-    {%  endset %}
+        {% set detailsHTML %}
+        <p class="govuk-body">
+            {{'pages.resetPasswordCheckEmail.details.text1' | translate}}
+            <a href="{{'pages.resetPasswordCheckEmail.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.resetPasswordCheckEmail.details.sendCodeLinkText'| translate}}</a>
+            {{'pages.resetPasswordCheckEmail.details.text2' | translate}}.
+        </p>
+        {% endset %}
 
-    {% set detailsHTML %}
-    <p class="govuk-body">
-      {{'pages.resetPasswordCheckEmail.details.text1' | translate}}
-      <a href="{{'pages.resetPasswordCheckEmail.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.resetPasswordCheckEmail.details.sendCodeLinkText'| translate}}</a>
-      {{'pages.resetPasswordCheckEmail.details.text2' | translate}}.
-    </p>
-    {% endset %}
-
-    {{ govukDetails({
+        {{ govukDetails({
       summaryText: 'pages.resetPasswordCheckEmail.details.summaryText' | translate,
       html: detailsHTML
     }) }}
 
-
-    {{ govukButton({
+        {{ govukButton({
         "text": 'pages.resetPasswordCheckEmail.buttonText' | translate | default("Continue", true),
         "type": "Submit",
         "preventDoubleClick": true
     }) }}
 
-</form>
+    </form>
 
 {% endblock %}
-
-

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -255,7 +255,7 @@
         "summaryText": "Problems with the code?",
         "text1": "We can ",
         "sendCodeLinkText": "send the code again",
-        "sendCodeLinkHref": "/resend-code?isResendCodeRequest=true",
+        "sendCodeLinkHref": "/reset-password-resend-code",
         "text2": " if the code is not working or you did not receive it"
       },
       "sendAnotherEmailLinkText": "Send another email",


### PR DESCRIPTION
## What?

- Route resend code hyperlink to `/reset-password-resend-code` on forgotten password 'check your email' screen
- This was already the case before #715
- However, it was erroneously changed to point at `/resend-code`
- For this reason no new screens needed
- State machine also removes option to go back to the enter code screen once a correct OTP has been entered, as otherwise the resend code hyperlink routes straight to the reset password screen (bottom screenshot below) as it does not need to resend a code when a correct one has already been input. This creates a strange user experience.

Starting screen (unchanged apart from hyperlink destination):
<img width="1007" alt="image" src="https://user-images.githubusercontent.com/106964077/185105116-4f75580f-1053-4238-b182-2e744eabd6ad.png">

Resend code screen:
<img width="970" alt="image" src="https://user-images.githubusercontent.com/106964077/185105143-e15a386b-2ce4-4dd8-b3a9-1263633f1823.png">

If resend code clicked too many times:
<img width="965" alt="image" src="https://user-images.githubusercontent.com/106964077/185105284-5dc10502-e97a-4c48-9246-609bca8311a3.png">

If reset password hyperlink clicked whilst still within 15 minute window:
<img width="974" alt="image" src="https://user-images.githubusercontent.com/106964077/185105459-01a752f5-5cda-4bdb-a802-6170d5186a8e.png">

Reset password:
<img width="971" alt="image" src="https://user-images.githubusercontent.com/106964077/185105768-54896297-3082-4f24-ab2c-96f9ae1c6c23.png">



## Why?

- Href change meant that code was being resent, but state machine made it then just refresh the same forgotten password 'check your email' screen. 
- As a result, none of the 'extra' screens asking for a button click to resend OTP were being displayed.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/715 - PR which introduced the routing bug
