### PR TITLE
AUT-599: Update content for get security code resend code

### DIFF
--- a/src/components/reset-password-check-email/index-reset-password-resend-code.njk
+++ b/src/components/reset-password-check-email/index-reset-password-resend-code.njk
@@ -1,6 +1,7 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% set pageTitleName = 'pages.resetPasswordResendCode.title' | translate %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% set pageTitleName = 'pages.resendMfaCode.title' | translate %}
 {% set showBack = true %}
 {% set hrefBack = 'reset-password-check-email?requestCode=false' %}
 {% block content %}
@@ -8,10 +9,16 @@
 <form action="/reset-password-check-email" method="get" novalidate>
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resetPasswordResendCode.header' | translate }}</h1>
-    <p class="govuk-body">{{'pages.resetPasswordResendCode.email' | translate }}<span class="govuk-body govuk-!-font-weight-bold">{{email}}</span>.</p>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resendMfaCode.header' | translate }}</h1>
+
+    {{ govukInsetText({
+        html: 'pages.resendMfaCode.phoneNumber.isResendCodeRequest' | translate | replace("[mobile].", "") + '<span class="govuk-body govuk-!-font-weight-bold">' + email + '</span>'
+    }) }}
+
+    <p class="govuk-body">{{ 'pages.resetPasswordCheckEmail.paragraph3' | translate }}</p>
+
     {{ govukButton({
-        "text": button_text|default('pages.resetPasswordResendCode.send' | translate, true),
+        "text": button_text|default('pages.resendMfaCode.continue' | translate, true),
         "type": "Submit",
         "preventDoubleClick": true
     }) }}


### PR DESCRIPTION
## What?

Updates content for the forgotten password resend code page (See "Accessing the page" below) to reflect what is in the image (also below)

I've also created a [new Jira ticket](https://govukverify.atlassian.net/browse/AUT-668) to capture the need for the page to have its own entries within `translation.json` (See "Borrowing translations" below)

<img width="401" alt="Screenshot 2022-08-19 at 11 46 55" src="https://user-images.githubusercontent.com/16000203/185602621-fe9ab8b6-fede-45e7-8b10-507de0d302dd.png">

### Accessing the page
This page is accessed by: visiting `/sign-in-or-create` and clicking "Sign in"; then entering an existing email address and clicking "Continue"; then clicking "I've forgotten my password"; then expanding "Problems with the code" and clicking "Send the code again"

### Borrowing translations
This PR is being raised during a freeze to the content of `translation.json` (while the team awaits the translators to provide a Welsh version). For this reason the template has borrowed existing values from other components. Once the freeze has lifted we'll need to go back and untangle things.  

## Why?

Part of AUT-599

## Related PRs

#722 #717 #715
