### PR TITLE
AUT-670: Add Ticket Identifier to support form

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -4,6 +4,8 @@ import { contactUsService } from "./contact-us-service";
 import { ContactUsServiceInterface, Questions, ThemeQuestions } from "./types";
 import { ExpressRouteFunc } from "../../types";
 import { supportMFAOptions } from "../../config";
+import crypto from "crypto";
+import { logger } from "../../utils/logger";
 
 const themeToPageTitle = {
   [ZENDESK_THEMES.ACCOUNT_NOT_FOUND]:
@@ -129,6 +131,7 @@ export function contactUsQuestionsFormPost(
       req.body.theme,
       req.body.subtheme
     );
+    const ticketIdentifier = crypto.randomBytes(20).toString("base64url");
 
     await service.contactUsSubmitForm({
       descriptions: {
@@ -142,7 +145,7 @@ export function contactUsQuestionsFormPost(
       email: req.body.email,
       name: req.body.name,
       optionalData: {
-        sessionId: "",
+        ticketIdentifier: ticketIdentifier,
         userAgent: req.get("User-Agent"),
       },
       feedbackContact: req.body.contact === "true",
@@ -152,6 +155,9 @@ export function contactUsQuestionsFormPost(
       securityCodeSentMethod: req.body.securityCodeSentMethod,
     });
 
+    logger.info(
+      `Support ticket submitted with id ${ticketIdentifier} for session ${res.locals.sessionId}`
+    );
     return res.redirect(PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS);
   };
 }

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -100,8 +100,12 @@ export function contactUsService(
       htmlBody.push(`<p>${descriptions.moreDetailDescription}</p>`);
     }
 
-    htmlBody.push(`<span>[Session ID]</span>`);
-    htmlBody.push(`<p>${optionalData.sessionId}</p>`);
+    htmlBody.push(`<span>[Ticket Identifier]</span>`);
+    if (optionalData.ticketIdentifier) {
+      htmlBody.push(`<p>${optionalData.ticketIdentifier}</p>`);
+    } else {
+      htmlBody.push(`<p>Unable to capture ticket identifier</p>`);
+    }
 
     htmlBody.push(`<span>[From page]</span>`);
     if (referer) {

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -14,7 +14,7 @@ export interface ContactForm {
 
 export interface OptionalData {
   userAgent: string;
-  sessionId?: string;
+  ticketIdentifier?: string;
 }
 
 export interface Questions {


### PR DESCRIPTION
## What?

Add Ticket Identifier to support form.

A unique id is generated whenever a user submits a support ticket.  This id is then logged alongside the session id.

## Why?

Replaces Session Id in the form.
Enables support teams to trace errors in the logs corresponding to the ticket.
