### PR TITLE
AUT-629: Add Welsh language toggle to prove identity welcome screen

### DIFF
--- a/src/components/prove-identity-welcome/index-existing-session.njk
+++ b/src/components/prove-identity-welcome/index-existing-session.njk
@@ -19,9 +19,20 @@
 
     <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph1' | translate}}</p>
 
-    {{ govukInsetText({
-        html: 'pages.proveIdentityWelcome.section2.insetTextEnglishOnly' | translate
-    }) }}
+    {% if supportLanguageCY %}
+        {% set insetTextInnerHtml %}
+        {{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.paragraph1' | translate }}
+        <a href="{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText' | translate }}</a>.
+        {% endset %}
+
+        {{ govukInsetText({
+        html: insetTextInnerHtml
+        }) }}
+    {% else %}
+        {{ govukInsetText({
+            html: 'pages.proveIdentityWelcome.section2.insetTextEnglishOnly' | translate
+        }) }}
+    {% endif %}
 
     <p class="govuk-body">{{'pages.proveIdentityWelcome.existingSession.section2.paragraph2' | translate}}</p>
     <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph3' | translate}}</p>

--- a/src/components/prove-identity-welcome/index.njk
+++ b/src/components/prove-identity-welcome/index.njk
@@ -8,38 +8,49 @@
 
 {% block content %}
 
-{% include "common/errors/errorSummary.njk" %}
+    {% include "common/errors/errorSummary.njk" %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.proveIdentityWelcome.header' | translate}}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.proveIdentityWelcome.header' | translate}}</h1>
 
-<p class="govuk-body">{{'pages.proveIdentityWelcome.section1.paragraph1' | translate}}</p>
+    <p class="govuk-body">{{'pages.proveIdentityWelcome.section1.paragraph1' | translate}}</p>
 
-{{ govukInsetText({
+    {{ govukInsetText({
     html: 'pages.proveIdentityWelcome.section1.insetTextPassport' | translate
 }) }}
 
-<h2 class="govuk-heading-m">{{'pages.proveIdentityWelcome.section2.subHeading' | translate}}</h2>
+    <h2 class="govuk-heading-m">{{'pages.proveIdentityWelcome.section2.subHeading' | translate}}</h2>
 
-<p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph1' | translate}}</p>
+    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph1' | translate}}</p>
 
-{{ govukInsetText({
-    html: 'pages.proveIdentityWelcome.section2.insetTextEnglishOnly' | translate
-}) }}
+    {% if supportLanguageCY %}
+        {% set insetTextInnerHtml %}
+        {{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.paragraph1' | translate }}
+        <a href="{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText' | translate }}</a>.
+        {% endset %}
 
-<p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph2' | translate}}</p>
-<p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph3' | translate}}</p>
+        {{ govukInsetText({
+        html: insetTextInnerHtml
+        }) }}
+    {% else %}
+        {{ govukInsetText({
+            text: 'pages.proveIdentityWelcome.section2.insetTextEnglishOnly' | translate
+        }) }}
+    {% endif %}
 
-<ul class="govuk-list govuk-list--bullet">
-    <li>{{'pages.proveIdentityWelcome.section2.listItem1' | translate}}</li>
-    <li>{{'pages.proveIdentityWelcome.section2.listItem2' | translate}}</li>
-    <li>{{'pages.proveIdentityWelcome.section2.listItem3' | translate}}</li>
-</ul>
+    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph2' | translate}}</p>
+    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph3' | translate}}</p>
 
-<p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph4' | translate}}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{'pages.proveIdentityWelcome.section2.listItem1' | translate}}</li>
+        <li>{{'pages.proveIdentityWelcome.section2.listItem2' | translate}}</li>
+        <li>{{'pages.proveIdentityWelcome.section2.listItem3' | translate}}</li>
+    </ul>
 
-<form id="form-tracking" action="/prove-identity-welcome" method="post" novalidate>
+    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph4' | translate}}</p>
 
-<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <form id="form-tracking" action="/prove-identity-welcome" method="post" novalidate="novalidate">
+
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
         {{ govukRadios({
             idPrefix: "chooseWayPyi",
@@ -72,11 +83,11 @@
             } if (errors['chooseWayPyi'])
         }) }}
 
-    {{ govukButton({
+        {{ govukButton({
         "text": button_text|default('general.continue.label' | translate, true),
         "type": "Submit",
         "preventDoubleClick": true
     }) }}
 
-</form>
+    </form>
 {% endblock %}

--- a/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
+++ b/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
@@ -3,6 +3,7 @@ import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { IPV_ERROR_CODES, OIDC_ERRORS, PATH_NAMES } from "../../app.constants";
 import { createServiceRedirectErrorUrl } from "../../utils/error";
+import { supportLanguageCY } from "../../config";
 
 export function proveIdentityWelcomeGet(req: Request, res: Response): void {
   res.render(
@@ -16,6 +17,7 @@ export function proveIdentityWelcomeGet(req: Request, res: Response): void {
         IPV_ERROR_CODES.ACCOUNT_NOT_CREATED,
         req.session.client.state
       ),
+      supportLanguageCY: supportLanguageCY() ? true : null,
     }
   );
 }

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1527,8 +1527,8 @@
         "insetTextEnglishOnly": "This service is currently only available in English.",
         "insetAlternativeLanguage": {
           "paragraph1": "This service is also available in ",
-          "linkText": "Welsh (Cymraeg)",
-          "linkHref": ""
+          "linkText": "Saesneg (English)",
+          "linkHref": "?lng=en"
         },
         "paragraph2": "You'll need to create or sign in to your GOV.UK account first. We'll then ask you for your current address and passport details.",
         "paragraph3": "We'll also ask you some security questions that only you should know the answers to. You might find it easier to answer these questions if you have information about:",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1528,7 +1528,7 @@
         "insetAlternativeLanguage": {
           "paragraph1": "This service is also available in ",
           "linkText": "Welsh (Cymraeg)",
-          "linkHref": ""
+          "linkHref": "?lng=cy"
         },
         "paragraph2": "You'll need to create or sign in to your GOV.UK account first. We'll then ask you for your current address and passport details.",
         "paragraph3": "We'll also ask you some security questions that only you should know the answers to. You might find it easier to answer these questions if you have information about:",


### PR DESCRIPTION
## What?

- Add Welsh language toggle to prove identity welcome screen
- This works by redirecting to the same page with `lng=cy` as a query param (note: it does get rid of any existing params e.g. google analytics).
- I18Next does the work of changing cookie off the back of this (cookie also called `lng`)
- Add same change in the opposite direction (`lng=en`) to switch back

When `supportLanguageCY` environment variable is turned off/absent:

<img width="708" alt="image" src="https://user-images.githubusercontent.com/106964077/186116861-38725ef3-b964-4cf8-a7ea-af74df525678.png">

When  `supportLanguageCY` environment variable is turned on:

<img width="692" alt="image" src="https://user-images.githubusercontent.com/106964077/186117003-b0f8514c-8fa5-4913-9181-bca61f1aad05.png">


## Why?

To provide a mechanism for users to switch languages between English and Welsh.

## Related PRs

Some text was preloaded in translation.json so that the file could be shared earlier with translators: https://github.com/alphagov/di-authentication-frontend/pull/716
