### PR TITLE
AUT-599: Remove pattern attribute from numeric inputs

### DIFF
--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -32,7 +32,6 @@
     id: "code",
     name: "code",
     inputmode: "numeric",
-    pattern: "[0-9]*",
     spellcheck: false,
     value: code,
     errorMessage: {

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -34,7 +34,6 @@
   id: "code",
   name: "code",
   inputmode: "numeric",
-  pattern: "[0-9]*",
   spellcheck: false,
   autocomplete:"off",
   value: code,

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -22,7 +22,6 @@
     id: "code",
     name: "code",
     inputmode: "numeric",
-    pattern: "[0-9]*",
     spellcheck: false,
     autocomplete:"off",
     errorMessage: {

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -26,7 +26,6 @@
   id: "code",
   name: "code",
   inputmode: "numeric",
-  pattern: "[0-9]*",
   spellcheck: false,
   autocomplete:"off",
   errorMessage: {

--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -32,7 +32,6 @@
         id: "code",
         name: "code",
         inputmode: "numeric",
-        pattern: "[0-9]*",
         spellcheck: false,
         autocomplete:"off",
         classes: "govuk-input--width-10 govuk-!-font-weight-bold",

--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -54,7 +54,6 @@
   id: "code",
   name: "code",
   inputmode: "numeric",
-  pattern: "[0-9]*",
   spellcheck: false,
   autocomplete:"off",
   errorMessage: {


### PR DESCRIPTION
## What?

Removes `pattern: "[0-9]*"` from all number inputs. 

## Why?

This update reflects a recent change to GOV.UK Design System recommendations for using pattern attributes on number inputs. The Design System update is described at: https://github.com/alphagov/govuk-design-system/pull/2323
