### PR TITLE
AUT-512: Wrap authCodeGet controller/handler in async handler wrapper

### DIFF
--- a/src/components/auth-code/auth-code-routes.ts
+++ b/src/components/auth-code/auth-code-routes.ts
@@ -4,6 +4,7 @@ import * as express from "express";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { authCodeGet } from "./auth-code-controller";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import { asyncHandler } from "../../utils/async";
 
 const router = express.Router();
 
@@ -11,7 +12,7 @@ router.get(
   PATH_NAMES.AUTH_CODE,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  authCodeGet()
+  asyncHandler(authCodeGet())
 );
 
 export { router as authCodeRouter };


### PR DESCRIPTION
## What?

- Use existing asyncHandler wrapper to wrap the GET function for `/auth-code` route
- This allows `next()` to be called in case of a failure e.g. API returns error code
- It is functionally equivalent to try/catch in the GET function, where `catch(error){...}` calls `next(error)`

## Why?

- Previously an API side error such as 502 would result in the browser displaying page not found (nothing visual) - something like this:

<img width="1659" alt="image" src="https://user-images.githubusercontent.com/106964077/187730256-803d9b0d-d627-4086-8820-38476c2e1bc9.png">

- Now, due to the `/auth-code` handler being hooked up to global error handling, an API failure redirects to this screen:

<img width="990" alt="image" src="https://user-images.githubusercontent.com/106964077/187730529-6fcbe7ba-0a19-4ba0-b307-680cc5795b0c.png">
