### PR TITLE
AUT-682: Clear Incorrect OTP

### DIFF
--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -33,7 +33,6 @@
     name: "code",
     inputmode: "numeric",
     spellcheck: false,
-    value: code,
     errorMessage: {
         text: errors['code'].text
     } if (errors['code'])})

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -36,7 +36,6 @@
   inputmode: "numeric",
   spellcheck: false,
   autocomplete:"off",
-  value: code,
   errorMessage: {
   text: errors['code'].text
   } if (errors['code'])})

--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -35,7 +35,6 @@
         spellcheck: false,
         autocomplete:"off",
         classes: "govuk-input--width-10 govuk-!-font-weight-bold",
-        value: code,
         errorMessage: {
             text: errors['code'].text
         } if (errors['code'])})


### PR DESCRIPTION
## What?

We need to ensure that an incorrect OTP entered during Create account OR Sign in for both email address and phone number clears when the screen ‘refreshes’ with errors following the POST request

## Why?

So as to reduce the likelihood of a user trying to continue the journey using the same incorrect code

## Related PRs

[AUT-678](https://github.com/alphagov/di-authentication-account-management/pull/589)
