### PR TITLE
BAU: Switch on Welsh in build (and staging)

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -4,3 +4,5 @@ common_state_bucket = "digital-identity-dev-tfstate"
 frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
+
+support_language_cy = "1"

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -4,3 +4,5 @@ common_state_bucket = "di-auth-staging-tfstate"
 frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
+
+support_language_cy = "1"


### PR DESCRIPTION
## What?

Switch on Welsh in build (and staging).

## Why?

Make Welsh available so that accpetance tests can be built against it.
Flag had been omitted for staging.

