### PR TITLE
AUT-690: Fix localisation for continue and back

### DIFF
--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -54,7 +54,7 @@
 }) }}
 
     {{ govukButton({
-    "text": button_text|default("Continue", true),
+    "text": button_text|default("general.continue.label" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -57,7 +57,7 @@
 	      {% block beforeContent %}{% endblock %}
 	      {% if showBack %}
 	        {{ govukBackLink({
-                text: "Back",
+                text: "general.back" | translate,
                 href: hrefBack
             }) }}
           {% endif %}

--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -41,7 +41,7 @@
   </ul>
 
 {{ govukButton({
-    "text": button_text|default("Continue", true),
+    "text": button_text|default("general.continue.label" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/enter-email/index-create-account.njk
+++ b/src/components/enter-email/index-create-account.njk
@@ -30,7 +30,7 @@
 }}
 
 {{ govukButton({
-    "text": button_text|default("Continue", true),
+    "text": button_text|default("general.continue.label" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/enter-email/index-existing-account.njk
+++ b/src/components/enter-email/index-existing-account.njk
@@ -30,7 +30,7 @@
 }}
 
 {{ govukButton({
-    "text": button_text|default("Continue", true),
+    "text": button_text|default("general.continue.label" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -55,7 +55,7 @@
     }) }}
 
         {{ govukButton({
-        "text": 'pages.resetPasswordCheckEmail.buttonText' | translate | default("Continue", true),
+        "text": 'pages.resetPasswordCheckEmail.buttonText' | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/reset-password/index.njk
+++ b/src/components/reset-password/index.njk
@@ -33,7 +33,7 @@
     }) }}
 
     {{ govukButton({
-        "text": button_text|default("Continue", true),
+        "text": button_text|default("general.continue.label" | translate, true),
         "type": "Submit",
         "preventDoubleClick": true
     }) }}


### PR DESCRIPTION
## What?

Replaces hardcoded "Continue" and "Back" within templates with translations. See Jira ticket for detail of changes made and screenshots. 

## Why?

Render of page in Welsh was showing English text.