### PR TITLE
AUT-639: Pass user language as header to sendNotification

### DIFF
--- a/src/components/account-not-found/account-not-found-controller.ts
+++ b/src/components/account-not-found/account-not-found-controller.ts
@@ -9,6 +9,7 @@ import {
   getNextPathAndUpdateJourney,
 } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import xss from "xss";
 
 export function accountNotFoundGet(req: Request, res: Response): void {
   if (req.session.client.serviceType === SERVICE_TYPE.OPTIONAL) {
@@ -32,7 +33,8 @@ export function accountNotFoundPost(
       req.session.user.email,
       NOTIFICATION_TYPE.VERIFY_EMAIL,
       req.ip,
-      persistentSessionId
+      persistentSessionId,
+      xss(req.cookies.lng as string)
     );
 
     if (!result.success) {

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -9,6 +9,7 @@ import { SendNotificationServiceInterface } from "../common/send-notification/ty
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { supportMFAOptions } from "../../config";
+import xss from "xss";
 
 const TEMPLATE_NAME = "check-your-phone/index.njk";
 
@@ -35,7 +36,8 @@ export const checkYourPhonePost = (
         req.session.user.email,
         NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION,
         req.ip,
-        res.locals.persistentSessionId
+        res.locals.persistentSessionId,
+        xss(req.cookies.lng as string)
       );
 
       return res.redirect(

--- a/src/components/common/send-notification/send-notification-service.ts
+++ b/src/components/common/send-notification/send-notification-service.ts
@@ -18,6 +18,7 @@ export function sendNotificationService(
     notificationType: string,
     sourceIp: string,
     persistentSessionId: string,
+    userLanguage: string,
     phoneNumber?: string
   ): Promise<ApiResponseResult<DefaultApiResponse>> {
     const payload: any = {
@@ -41,6 +42,7 @@ export function sendNotificationService(
           HTTP_STATUS_CODES.NO_CONTENT,
           HTTP_STATUS_CODES.BAD_REQUEST,
         ],
+        userLanguage: userLanguage,
       })
     );
 

--- a/src/components/common/send-notification/types.ts
+++ b/src/components/common/send-notification/types.ts
@@ -8,6 +8,7 @@ export interface SendNotificationServiceInterface {
     notificationType: string,
     sourceIp: string,
     persistentSessionId: string,
+    userLanguage: string,
     phoneNumber?: string
   ) => Promise<ApiResponseResult<DefaultApiResponse>>;
 }

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -11,6 +11,7 @@ import { BadRequestError } from "../../utils/error";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import xss from "xss";
 
 export function enterEmailGet(req: Request, res: Response): void {
   return res.render("enter-email/index-existing-account.njk");
@@ -91,7 +92,8 @@ export function enterEmailCreatePost(
       email,
       NOTIFICATION_TYPE.VERIFY_EMAIL,
       req.ip,
-      persistentSessionId
+      persistentSessionId,
+      xss(req.cookies.lng as string)
     );
 
     if (!sendNotificationResponse.success) {

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -17,6 +17,7 @@ import { sendNotificationService } from "../common/send-notification/send-notifi
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { prependInternationalPrefix } from "../../utils/phone-number";
 import { supportInternationalNumbers, supportMFAOptions } from "../../config";
+import xss from "xss";
 
 export function enterPhoneNumberGet(req: Request, res: Response): void {
   res.render("enter-phone-number/index.njk", {
@@ -76,6 +77,7 @@ export function enterPhoneNumberPost(
       NOTIFICATION_TYPE.VERIFY_PHONE_NUMBER,
       req.ip,
       persistentSessionId,
+      xss(req.cookies.lng as string),
       phoneNumber
     );
 

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -9,6 +9,7 @@ import { BadRequestError } from "../../utils/error";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
+import xss from "xss";
 
 export function resendEmailCodeGet(req: Request, res: Response): void {
   res.render("resend-email-code/index.njk", {
@@ -29,7 +30,8 @@ export function resendEmailCodePost(
       email,
       NOTIFICATION_TYPE.VERIFY_EMAIL,
       req.ip,
-      persistentSessionId
+      persistentSessionId,
+      xss(req.cookies.lng as string)
     );
 
     if (!sendNotificationResponse.success) {

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -19,6 +19,7 @@ import { AuthAppServiceInterface } from "./types";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { NOTIFICATION_TYPE } from "../../app.constants";
+import xss from "xss";
 
 const TEMPLATE = "setup-authenticator-app/index.njk";
 
@@ -103,7 +104,8 @@ export function setupAuthenticatorAppPost(
       req.session.user.email,
       NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION,
       req.ip,
-      res.locals.persistentSessionId
+      res.locals.persistentSessionId,
+      xss(req.cookies.lng as string)
     );
 
     return res.redirect(

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -24,6 +24,7 @@ export interface ConfigOptions {
   sourceIp?: string;
   persistentSessionId?: string;
   baseURL?: string;
+  userLanguage?: string;
 }
 
 export function createApiResponse<T>(
@@ -68,6 +69,10 @@ export function getRequestConfig(options: ConfigOptions): AxiosRequestConfig {
 
   if (options.baseURL) {
     config.baseURL = options.baseURL;
+  }
+
+  if (options.userLanguage) {
+    config.headers["User-Language"] = options.userLanguage;
   }
 
   return config;


### PR DESCRIPTION
## What?

Pass user language as header to sendNotification to enable sending Notify messages in both English and Welsh
Makes use of existing dormant changes to the oidc api.

Updates for the remaining frontend services that trigger notifications will follow.

## Why?

Enable the backend to choose Notify template by language.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2304
https://github.com/alphagov/di-authentication-api/pull/2318
