### PR TITLE
AUT-639: Send User-Language to 'mfa' service.

### DIFF
--- a/src/components/common/mfa/mfa-service.ts
+++ b/src/components/common/mfa/mfa-service.ts
@@ -15,7 +15,8 @@ export function mfaService(axios: Http = http): MfaServiceInterface {
     emailAddress: string,
     sourceIp: string,
     persistentSessionId: string,
-    isResendCodeRequest: boolean
+    isResendCodeRequest: boolean,
+    userLanguage: string
   ): Promise<ApiResponseResult<DefaultApiResponse>> {
     const response = await axios.client.post<DefaultApiResponse>(
       API_ENDPOINTS.MFA,
@@ -28,6 +29,7 @@ export function mfaService(axios: Http = http): MfaServiceInterface {
         clientSessionId: clientSessionId,
         sourceIp: sourceIp,
         persistentSessionId: persistentSessionId,
+        userLanguage: userLanguage,
       })
     );
 

--- a/src/components/common/mfa/send-mfa-controller.ts
+++ b/src/components/common/mfa/send-mfa-controller.ts
@@ -6,6 +6,7 @@ import { BadRequestError } from "../../../utils/error";
 import { USER_JOURNEY_EVENTS } from "../state-machine/state-machine";
 import { PATH_NAMES } from "../../../app.constants";
 import { sanitize } from "../../../utils/strings";
+import xss from "xss";
 
 export function sendMfaGeneric(
   mfaCodeService: MfaServiceInterface
@@ -21,7 +22,8 @@ export function sendMfaGeneric(
       email,
       req.ip,
       persistentSessionId,
-      isResendCodeRequest
+      isResendCodeRequest,
+      xss(req.cookies.lng as string)
     );
 
     if (!result.success) {

--- a/src/components/common/mfa/types.ts
+++ b/src/components/common/mfa/types.ts
@@ -7,6 +7,7 @@ export interface MfaServiceInterface {
     emailAddress: string,
     sourceIp: string,
     persistentSessionId: string,
-    isResendCodeRequest: boolean
+    isResendCodeRequest: boolean,
+    userLanguage: string
   ) => Promise<ApiResponseResult<DefaultApiResponse>>;
 }

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -17,6 +17,7 @@ import { BadRequestError } from "../../utils/error";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { supportMFAOptions } from "../../config";
 import { MFA_METHOD_TYPE } from "../../app.constants";
+import xss from "xss";
 
 const ENTER_PASSWORD_TEMPLATE = "enter-password/index.njk";
 const ENTER_PASSWORD_VALIDATION_KEY =
@@ -110,7 +111,8 @@ export function enterPasswordPost(
         email,
         req.ip,
         persistentSessionId,
-        false
+        false,
+        xss(req.cookies.lng as string)
       );
 
       if (!result.success) {

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -19,6 +19,7 @@ import { MfaServiceInterface } from "../common/mfa/types";
 import { mfaService } from "../common/mfa/mfa-service";
 import { MFA_METHOD_TYPE } from "../../app.constants";
 import { supportMFAOptions } from "../../config";
+import xss from "xss";
 
 const resetPasswordTemplate = "reset-password/index.njk";
 
@@ -101,7 +102,8 @@ export function resetPasswordPost(
         email,
         req.ip,
         persistentSessionId,
-        false
+        false,
+        xss(req.cookies.lng as string)
       );
 
       if (!mfaResponse.success) {


### PR DESCRIPTION
## What?

Send User-Language to 'mfa' service.

## Why?

Completes the changes required to Fronted to send language specific Notify templates according to the user's language.

## Related PRs

#749 
