### PR TITLE
BAU: Add "English" to language switch

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -118,7 +118,7 @@
       "bullet2IntNumbers": "ffordd o gael codau diogelwch - gall hwn fod yn rhif ffôn symudol neu'n app dilysydd",
       "insetAlternativeLanguage": {
         "paragraph1": "Mae'r cyfrif GOV.UK hefyd ar gael ",
-        "linkText": "yn Saesneg",
+        "linkText": "yn Saesneg (English)",
         "linkHref": "?lng=en"
       },
       "paragraph2": "Os oes gennych gyfrif GOV.UK yn barod gallwch",


### PR DESCRIPTION
## What?

Adds "English" to language switch when page is in Welsh (mirroring the inclusion of "Welsh" in the link when the page is in English). 

## Why?

Noticed this while working on other translations and sought advice from Content Design who asked if I could change it. 
