### PR TITLE
AUT-684: Change sign-in button to link on landing page

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -4,57 +4,58 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
-{% if serviceType === 'OPTIONAL'  %}
+{% if serviceType === 'OPTIONAL' %}
   {% set pageTitleVariableName = 'pages.signInOrCreate.optional.title' %}
 {% endif %}
-{% if serviceType === 'MANDATORY'  %}
+{% if serviceType === 'MANDATORY' %}
   {% set pageTitleVariableName = 'pages.signInOrCreate.mandatory.title' %}
 {% endif %}
 
 {% set pageTitleName = pageTitleVariableName | translate %}
 
 {% set moreAboutTextHtml %}
-  <p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph1' | translate}}</p>
-  <p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph2' | translate}}</p>
-  <p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph3' | translate}}</p>
+<p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph1' | translate}}</p>
+<p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph2' | translate}}</p>
+<p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph3' | translate}}</p>
 {% endset %}
 
 {% block content %}
-{% include "common/errors/errorSummary.njk" %}
+  {% include "common/errors/errorSummary.njk" %}
 
-{% if serviceType === 'OPTIONAL' %}
-  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.signInOrCreate.optional.header' | translate}}</h1>
-{% else %}
-  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.signInOrCreate.mandatory.header' | translate}}</h1>
-{% endif %}
+  {% if serviceType === 'OPTIONAL' %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.signInOrCreate.optional.header' | translate}}</h1>
+  {% else %}
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.signInOrCreate.mandatory.header' | translate}}</h1>
+  {% endif %}
 
   <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet">
     <li>{{ 'pages.signInOrCreate.bullet1' | translate }}</li>
     {% if supportMFAOptions and supportInternationalNumbers %}
-        <li>{{ 'pages.signInOrCreate.bullet2IntNumbers' | translate }}</li>
+      <li>{{ 'pages.signInOrCreate.bullet2IntNumbers' | translate }}</li>
     {% elif supportMFAOptions %}
-        <li>{{ 'pages.signInOrCreate.bullet2AuthApps' | translate }}</li>
+      <li>{{ 'pages.signInOrCreate.bullet2AuthApps' | translate }}</li>
     {% else %}
-        <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
+      <li>{{ 'pages.signInOrCreate.bullet2' | translate }}</li>
     {% endif %}
   </ul>
   {% if supportLanguageCY %}
     {% set altLangInsetHtml %}
-      {{ 'pages.signInOrCreate.insetAlternativeLanguage.paragraph1' | translate }} <a href="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText' | translate }}</a>.
-    {%  endset %}
+    {{ 'pages.signInOrCreate.insetAlternativeLanguage.paragraph1' | translate }}
+    <a href="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText' | translate }}</a>.
+    {% endset %}
     {{ govukInsetText({
       html: altLangInsetHtml
     }) }}
   {% endif %}
 
-<form action="/sign-in-or-create" method="post" novalidate>
+  <form action="/sign-in-or-create" method="post" novalidate="novalidate">
 
-  <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-  <input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
-  <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}"/>
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="supportMFAOptions" value="{{supportMFAOptions}}"/>
+    <input type="hidden" name="supportInternationalNumbers" value="{{supportInternationalNumbers}}"/>
 
-  {{ govukButton({
+    {{ govukButton({
     text: 'pages.signInOrCreate.createButtonText' | translate,
     value: "create",
     name: "optionSelected",
@@ -63,14 +64,17 @@
     }
   }) }}
 
-  <p class="govuk-body">
-    {{ 'pages.signInOrCreate.paragraph2' | translate }} <button value="signin" type="Submit" name="optionSelected" data-prevent-double-click="true" class="govuk-button govuk-link govuk-btn-as-link" data-module="govuk-button" id="sign-in-link">{{ 'pages.signInOrCreate.signInText' | translate }}</button>.
-  </p>
+    <p class="govuk-body">
+      {{ 'pages.signInOrCreate.paragraph2' | translate }}
+      <a href="/sign-in-or-create?redirectPost=true" class="govuk-link">{{ 'pages.signInOrCreate.signInText' | translate }}</a>
+      .
+    </p>
 
-</form>
-{{ govukDetails({
+  </form>
+
+  {{ govukDetails({
   summaryText: 'pages.signInOrCreate.moreAbout.header' | translate,
   html: moreAboutTextHtml
-}) }}
+  }) }}
 
 {% endblock %}

--- a/src/components/sign-in-or-create/sign-in-or-create-controller.ts
+++ b/src/components/sign-in-or-create/sign-in-or-create-controller.ts
@@ -8,6 +8,10 @@ import {
 } from "../../config";
 
 export function signInOrCreateGet(req: Request, res: Response): void {
+  if (req.query.redirectPost) {
+    return signInOrCreatePost(req, res);
+  }
+
   res.render("sign-in-or-create/index.njk", {
     serviceType: req.session.client.serviceType,
     supportMFAOptions: supportMFAOptions() ? true : null,


### PR DESCRIPTION
## What?
- Change sign-in HTML element from `button` to `a` on landing page meaning text stays in line with sentence rather than being centred when 640px screen size breakpoint is reached. Also means that the 'focus' highlight highlights only text and not a button (see screenshot):

After ('sign-in' link in focus):
<img width="624" alt="image" src="https://user-images.githubusercontent.com/106964077/188851429-da798cad-5f75-4b4f-80de-c1c1fb3c1e38.png">
 
- Change controller to allow it to apply the same logic as when the request was a POST

## Why?
- This text was previously a button (albeit styled as a link) to allow request to be POST request
- However, this 'broke' certain styling, such as making the text be centred on the screen at screen width under 640px
- Changing to a 'normal' link means that the request is now GET
- As a result, I added a query parameter, which allows the GET controller to apply the POST logic in this circumstance
- Referencing once controller from another like this is generally seen as an antipattern. However, I considered that doing this rather than repeating the logic from the POST controller keeps the intent of the code clearer
