### PR TITLE
AUT-684: Add ID to anchor tag for sign-in link

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -66,7 +66,7 @@
 
     <p class="govuk-body">
       {{ 'pages.signInOrCreate.paragraph2' | translate }}
-      <a href="/sign-in-or-create?redirectPost=true" class="govuk-link">{{ 'pages.signInOrCreate.signInText' | translate }}</a>
+      <a href="/sign-in-or-create?redirectPost=true" class="govuk-link" id="sign-in-link">{{ 'pages.signInOrCreate.signInText' | translate }}</a>
       .
     </p>
 


### PR DESCRIPTION
## What?

- Add ID to anchor tag for sign-in link


## Why?

- Matches ID previously given to the button this replaces, so that Acceptance Tests can recognise it

## Related PRs

Amends: https://github.com/alphagov/di-authentication-frontend/pull/753
