### PR TITLE
AUT-712: Fix radio option focus on error

### DIFF
--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -14,30 +14,30 @@
 
     {% include "common/errors/errorSummary.njk" %}
 
-{% set html %}
-<p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translate }}</p>
-<a class="govuk-notification-banner__link" id="go-back-link" href="#">{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
-{% endset %}
+    {% set html %}
+    <p class="govuk-body">{{ 'pages.cookiePolicy.successBanner.paragraph1' | translate }}</p>
+    <a class="govuk-notification-banner__link" id="go-back-link" href="#">{{ 'pages.cookiePolicy.successBanner.linkText' | translate }}</a>
+    {% endset %}
 
-<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsPublic.header' | translate }}
-</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+        {{ 'pages.contactUsPublic.header' | translate }}
+    </h1>
 
-<p class="govuk-body">{{'pages.contactUsPublic.section1.paragraph1' | translate }}</p>
-<ul class="govuk-list govuk-list--bullet">
- <li>{{ 'pages.contactUsPublic.section1.bulletPoint1' | translate}}</li>
- <li>{{ 'pages.contactUsPublic.section1.bulletPoint2' | translate}}</li>
-</ul>
+    <p class="govuk-body">{{'pages.contactUsPublic.section1.paragraph1' | translate }}</p>
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.contactUsPublic.section1.bulletPoint1' | translate}}</li>
+        <li>{{ 'pages.contactUsPublic.section1.bulletPoint2' | translate}}</li>
+    </ul>
 
-<p class="govuk-body">{{'pages.contactUsPublic.section1.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{'pages.contactUsPublic.section1.paragraph2' | translate }}</p>
 
-<form action="/contact-us" method="post" novalidate>
+    <form action="/contact-us" method="post" novalidate="novalidate">
 
-<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-<input type="hidden" name="referer" value="{{referer}}"/>
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+        <input type="hidden" name="referer" value="{{referer}}"/>
 
-    {{ govukRadios({
-        idPrefix: "contact-us",
+        {{ govukRadios({
+        idPrefix: "theme",
         name: "theme",
         fieldset: {
             legend: {
@@ -77,16 +77,12 @@
           } if (errors['theme'])
     }) }}
 
-
-{{ govukButton({
+        {{ govukButton({
     "text": button_text|default('general.continue.label' | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}
 
-</form>
+    </form>
 
 {% endblock %}
-
-
-


### PR DESCRIPTION
## What?

- Applies only to public contact us page (first question in helpdesk flow)


## Why?

- When no radio is selected, the error summary hyperlink should move focus to the first radio:
<img width="364" alt="image" src="https://user-images.githubusercontent.com/106964077/188894196-3d5bd83d-e60c-4d43-87ca-c8d9ce4e88d3.png">

- This was not the case as the hyperlink was for "theme", the non-unique `name` given to each radio, but each individual radio also had a unique `id` (caused by setting the `idPrefix` parameter on the macro, so each `id` is the prefix + a number, apart from the first, which is just the prefix alone) 
- This means that when we have both `name` and `idPrefix` specified, `id` must be the more specific of the two, which perhaps means the browser prefers to attempt to interpred the `#theme` fragment as referring to an `id` - but then not being able to identify the correct element
- The `idPrefix` has therefore been changed to 'theme', which is the same as the first radio's ID for the reasons explained above. This means that the Express validator validation can check for 'theme' in the body (which it is being told to do here: https://github.com/alphagov/di-authentication-frontend/blob/9eeb044ce8eb93e14bedf54add2359190e750991/src/components/contact-us/contact-us-routes.ts#L22) - meaning the entire set of radios - and pass through the selected radio value to the POST controller. At the same time, the error navigation can still navigate to the first radio because its `id` now happens to match the hyperlink fragmentary reference of `#theme` as well, despite the two things not being automatically coupled.

## Alternative approach

- An alternative approach considered was simply to remove `idPrefix`. This would remove the navigation collision between `name` and `id` too. However, it would mean that the radios could not be identified by Google Analytics, nor selected as robustly by automated testing, as they would no longer have unique identifiers.