### PR TITLE
AUT-712: Fix radio focus from error summary href (contact-us)

### DIFF
--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -37,7 +37,6 @@
 <input type="hidden" name="referer" value="{{referer}}"/>
 
     {{ govukRadios({
-        idPrefix: "contact-us",
         name: "theme",
         fieldset: {
             legend: {


### PR DESCRIPTION
## What?

- Due to clash between IDs (indirect result of `idPrefix` macro config) and `name`, the `<a>` in the error summary box when clicked does not focus on first radio button.
- Removing `idPrefix` removes the clash, and allows the focus to work as intended.
- Note: this bug still applies on other pages, but ticket relates only to this one page

<img width="664" alt="image" src="https://user-images.githubusercontent.com/106964077/189079493-5c9fdd9d-d386-401f-8bb5-8a3224cbbe0b.png">

## Why?

- To improve accessibility

## Related PRs

- I started a draft PR, since closed, here: https://github.com/alphagov/di-authentication-frontend/pull/755
- This was on the erroneous understanding that removing `idPrefix` would mean radio buttons would not have unique IDs. Whilst this turned out to be wrong, since `id` is still uniquely populated using the `name` value as the base `id` - hence closing the PR - that approach is still possible if there is a good reason to keep `id` names the same as they previously were.
