### PR TITLE
AUT-696: Decrease width of email OTP code input field

### DIFF
--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -31,6 +31,7 @@
     },
     id: "code",
     name: "code",
+    classes: "govuk-input--width-10",
     inputmode: "numeric",
     spellcheck: false,
     errorMessage: {


### PR DESCRIPTION
## What?

- Decrease width of email OTP code input field
- Use govuk-input--width-10 class, just like elsewhere

<img width="1471" alt="image" src="https://user-images.githubusercontent.com/106964077/189302509-bcf079b8-d4b7-4639-b54a-703a013776b6.png">


## Why?

- Width was inconsistent stylistically with rest of user experience
