### PR TITLE
AUT-730: Fix password reset flow for auth app users

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -450,6 +450,10 @@ const authStateMachine = createMachine(
               target: [PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER],
               cond: "isAccountPartCreated",
             },
+            {
+              target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
+              cond: "requiresMFAAuthAppCode",
+            },
             { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
             {
               target: [PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS],


### PR DESCRIPTION
## What?

- Fix password reset flow for auth app users
- State machine previously always redirected to enter phone code, making password reset impossible for auth app users
- Now additional condition is checked, which redirects to enter auth app code if auth app is enabled

Additional note: As currently written in state machine, the condition (`requiresMFAAuthAppCode`) that is being checked to decide to route to auth app flow is:

```
requiresMFAAuthAppCode: (context) =>
        context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
        context.isMfaMethodVerified === true,
```

Both of these fields are being returned via the `loginResponse` in the `reset-password-controller` file.

## Why?

- Status quo results in auth app users being unable to recover from a forgotten password

