### PR TITLE
BAU: Move "Send message" to translation file

### DIFF
--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -35,7 +35,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -51,7 +51,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -48,7 +48,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_authenticator-app-problem.njk
+++ b/src/components/contact-us/questions/_authenticator-app-problem.njk
@@ -48,7 +48,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_email-subscriptions-questions.njk
+++ b/src/components/contact-us/questions/_email-subscriptions-questions.njk
@@ -48,7 +48,7 @@
 
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -35,7 +35,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -39,7 +39,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -39,7 +39,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -39,7 +39,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_no-uk-mobile-questions.njk
+++ b/src/components/contact-us/questions/_no-uk-mobile-questions.njk
@@ -35,7 +35,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_proving-identity-problem-questions.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-questions.njk
@@ -47,7 +47,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_signing-in-problem-questions.njk
+++ b/src/components/contact-us/questions/_signing-in-problem-questions.njk
@@ -35,7 +35,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_suggestion-feedback-questions.njk
+++ b/src/components/contact-us/questions/_suggestion-feedback-questions.njk
@@ -31,7 +31,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -61,7 +61,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("Send message", true),
+    "text": button_text|default("general.sendMessage" | translate, true),
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -8,6 +8,7 @@
     "back": "Yn ôl",
     "warning": "Rhybudd",
     "errorSummaryTitle": "Mae problem",
+    "sendMessage": "TBC",
     "phaseBanner": {
       "tag": "beta",
       "content": "Mae hwn yn wasanaeth newydd – bydd eich <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella."

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -8,7 +8,7 @@
     "back": "Yn ôl",
     "warning": "Rhybudd",
     "errorSummaryTitle": "Mae problem",
-    "sendMessage": "TBC",
+    "sendMessage": "Anfon neges",
     "phaseBanner": {
       "tag": "beta",
       "content": "Mae hwn yn wasanaeth newydd – bydd eich <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -8,6 +8,7 @@
     "back": "Back",
     "warning": "Warning",
     "errorSummaryTitle": "There is a problem",
+    "sendMessage": "Send message",
     "phaseBanner": {
       "tag": "beta",
       "content": "This is a new service – your <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">feedback (opens in new tab)</a> will help us to improve it."


### PR DESCRIPTION
## What?

Moves "Send message" text to translation file and update all references

## Why?

To ensure the message is translated for users viewing the page in Welsh.
