### PR TITLE
AUT-714: Update "show password" component to support translations

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -111,7 +111,7 @@
   z-index: 0;
   display: table-cell; // IE fallback
   padding: govuk-spacing(1) govuk-spacing(3);
-  min-width: 5em; // stops the button width jumping when the text changes
+  min-width: 5.5em; // stops the button width jumping when the text changes
   color: $govuk-link-colour;
   text-decoration: underline;
   background: govuk-colour("white");

--- a/src/components/common/show-password/macro.njk
+++ b/src/components/common/show-password/macro.njk
@@ -1,13 +1,10 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% macro govukInputWithShowPassword(label, id, errors, hint) %}
-    <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password" data-hide-full-text="Hide password" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">
+{% macro govukInputWithShowPassword(label, id, errors, showSettings) %}
+    <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="{{ showSettings.show }}" data-hide-text="{{ showSettings.hide }}" data-show-full-text="{{ showSettings.showFullText }}" data-hide-full-text="{{ showSettings.hideFullText }}" data-announce-show="{{ showSettings.announceShown }}" data-announce-hide="{{ showSettings.announceHidden }}">
         {{ govukInput({
             label: {
                 text: label
-            },
-            hint: {
-                text: hint
             },
             classes: "govuk-!-width-two-thirds govuk-password-input",
             id: id,
@@ -21,16 +18,13 @@
     </div>
 {% endmacro %}
 
-{% macro govukInputWithShowPasswordWithLabelAsPageHeading(label, id, errors, hint) %}
-    <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="Show" data-hide-text="Hide" data-show-full-text="Show password" data-hide-full-text="Hide password" data-announce-show="Your password is shown" data-announce-hide="Your password is hidden">
+{% macro govukInputWithShowPasswordWithLabelAsPageHeading(label, id, errors, showSettings) %}
+    <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="{{ showSettings.show }}" data-hide-text="{{ showSettings.hide }}" data-show-full-text="{{ showSettings.showFullText }}" data-hide-full-text="{{ showSettings.hideFullText }}" data-announce-show="{{ showSettings.announceShown }}" data-announce-hide="{{ showSettings.announceHidden }}">
         {{ govukInput({
             label: {
                 text: label,
                 classes: "govuk-label--l",
                 isPageHeading: true
-            },
-            hint: {
-                text: hint
             },
             classes: "govuk-!-width-two-thirds govuk-password-input",
             id: id,

--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -24,8 +24,33 @@
 
      <p class="govuk-body">{{'pages.createPassword.password.paragraph2' | translate}}</p>
 
-    {{ govukInputWithShowPassword('pages.createPassword.password.label'  | translate, "password", errors ) }}
-    {{ govukInputWithShowPassword('pages.createPassword.confirmPassword.label' | translate, "confirm-password", errors) }}
+    {{ govukInputWithShowPassword(
+        'pages.createPassword.password.label'  | translate,
+        "password",
+        errors,
+        {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate
+        }
+    ) }}
+
+    {{ govukInputWithShowPassword(
+        'pages.createPassword.confirmPassword.label' | translate,
+        "confirm-password",
+        errors,
+        {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate
+        }
+    ) }}
 
 {{ govukDetails({
   summaryText: 'pages.createPassword.securePasswordDetails.summary' | translate,

--- a/src/components/enter-password/index-account-exists.njk
+++ b/src/components/enter-password/index-account-exists.njk
@@ -24,7 +24,19 @@
 </p>
 
 <p class="govuk-body">{{'pages.enterPasswordAccountExists.info' | translate}}</p>
-    {{ govukInputWithShowPassword('pages.enterPasswordAccountExists.password.label' | translate, "password", errors) }}
+    {{ govukInputWithShowPassword(
+        'pages.enterPasswordAccountExists.password.label' | translate,
+        "password",
+        errors,
+        {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate
+        }
+    ) }}
 <p class="govuk-body">
     <a href="/reset-password-request" class="govuk-link" rel="noreferrer noopener">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>
 </p>

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -15,7 +15,19 @@
 <form id="form-tracking" action="/enter-password" method="post" novalidate>
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
-{{ govukInputWithShowPasswordWithLabelAsPageHeading('pages.enterPassword.header' | translate, "password", errors) }}
+{{ govukInputWithShowPasswordWithLabelAsPageHeading(
+    'pages.enterPassword.header' | translate,
+    "password",
+    errors,
+    {
+        show: 'general.showPassword.show' | translate,
+        hide: 'general.showPassword.hide' | translate,
+        showFullText: 'general.showPassword.showFullText' | translate,
+        hideFullText: 'general.showPassword.hideFullText' | translate,
+        announceShown: 'general.showPassword.announceShown' | translate,
+        announceHidden: 'general.showPassword.announceHidden' | translate
+    }
+) }}
 
 <p class="govuk-body">
     <a href="/reset-password-request" class="govuk-link" rel="noreferrer noopener">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>

--- a/src/components/reset-password/index.njk
+++ b/src/components/reset-password/index.njk
@@ -24,8 +24,33 @@
 
      <p class="govuk-body">{{'pages.resetPassword.password.paragraph2' | translate}}</p>
 
-    {{ govukInputWithShowPassword('pages.resetPassword.password.label'  | translate, "password", errors) }}
-    {{ govukInputWithShowPassword('pages.resetPassword.confirmPassword.label' | translate, "confirm-password", errors)  }}
+    {{ govukInputWithShowPassword(
+        'pages.resetPassword.password.label'  | translate,
+        "password",
+        errors,
+        {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate
+        }
+    ) }}
+
+    {{ govukInputWithShowPassword(
+        'pages.resetPassword.confirmPassword.label' | translate,
+        "confirm-password",
+        errors,
+        {
+            show: 'general.showPassword.show' | translate,
+            hide: 'general.showPassword.hide' | translate,
+            showFullText: 'general.showPassword.showFullText' | translate,
+            hideFullText: 'general.showPassword.hideFullText' | translate,
+            announceShown: 'general.showPassword.announceShown' | translate,
+            announceHidden: 'general.showPassword.announceHidden' | translate
+        }
+    )  }}
 
     {{ govukDetails({
     summaryText: 'pages.resetPassword.securePasswordDetails.summary' | translate,

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -70,6 +70,14 @@
         "pageTitle": "Cefnogaeth",
         "linkText": "Cefnogaeth (agor mewn tab newydd)"
       }
+    },
+    "showPassword": {
+      "show": "Dangos",
+      "hide": "TBC",
+      "showFullText": "TBC",
+      "hideFullText": "TBC",
+      "announceShown": "TBC",
+      "announceHidden": "TBC"
     }
   },
   "error": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -73,11 +73,11 @@
     },
     "showPassword": {
       "show": "Dangos",
-      "hide": "TBC",
-      "showFullText": "TBC",
-      "hideFullText": "TBC",
-      "announceShown": "TBC",
-      "announceHidden": "TBC"
+      "hide": "Cuddio",
+      "showFullText": "Dangos cyfrinair",
+      "hideFullText": "Cuddio cyfrinair",
+      "announceShown": "Mae eich cyfrinair wedi'i ddangos",
+      "announceHidden": "Mae eich cyfrinair wedi'i guddio"
     }
   },
   "error": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -70,6 +70,14 @@
         "pageTitle": "Support",
         "linkText": "Support (opens in new tab)"
       }
+    },
+    "showPassword": {
+      "show": "Show",
+      "hide": "Hide",
+      "showFullText": "Show password",
+      "hideFullText": "Hide password",
+      "announceShown": "Your password is shown",
+      "announceHidden": "Your password is hidden"
     }
   },
   "error": {


### PR DESCRIPTION
## What?

This commit updates the two show password macros and all their implementations to:

1. Remove the unused 'hint' parameter that was causing an unnecessary element to be included in the HTML payload
2. Support translations via a new `showSettings` config object

## Why?

So that users viewing the page in Welsh have the component translated correctly. 