### PR TITLE
AUT-691: Configure cookie domain for lng cookie

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -100,6 +100,10 @@ locals {
         name  = "ZENDESK_USERNAME"
         value = var.zendesk_username
       },
+      {
+        name  = "SERVICE_DOMAIN"
+        value = local.service_domain
+      },
     ]
   }
 

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -9,6 +9,8 @@ service_domain          = "sandpit.auth.ida.digital.cabinet-office.gov.uk"
 zone_id                 = "Z050645231Q0HZAX6FT5W"
 session_expiry          = 300000
 gtm_id                  = ""
+support_language_cy     = "1"
+support_mfa_options     = "1"
 
 support_international_numbers   = 0
 frontend_task_definition_cpu    = 256

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,3 +108,7 @@ export function getZendeskGroupIdPublic(): number {
 export function getAnalyticsCookieDomain(): string {
   return process.env.ANALYTICS_COOKIE_DOMAIN;
 }
+
+export function getServiceDomain(): string {
+  return process.env.SERVICE_DOMAIN;
+}

--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -1,5 +1,5 @@
 import { LOCALE } from "../app.constants";
-import { supportLanguageCY } from "../config";
+import { getServiceDomain, supportLanguageCY } from "../config";
 
 export function i18nextConfigurationOptions(
   path: string
@@ -21,6 +21,7 @@ export function i18nextConfigurationOptions(
       caches: ["cookie"],
       ignoreCase: true,
       cookieSecure: true,
+      cookieDomain: getServiceDomain(),
     },
   };
 }


### PR DESCRIPTION
## What?

Configure cookie domain for lng cookie.

## Why?

As the lng cookie is currently set to the default domain for each app it is not visible across different apps, such as Frontend and Account Management.  This means that when the user chooses a language in Frontend it is not reflected in Account Management as AM sets its own cookie.

Instead, set it to the service domain so that the cookie can be seen across the service.


