### PR TITLE
AUT-708: Pass `clientSessionId` header to backend where missing

### DIFF
--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -32,6 +32,7 @@ export function enterEmailPost(
       sessionId,
       email,
       req.ip,
+      res.locals.clientSessionId,
       res.locals.persistentSessionId
     );
 
@@ -63,6 +64,7 @@ export function enterEmailCreatePost(
       sessionId,
       email,
       req.ip,
+      clientSessionId,
       persistentSessionId
     );
 

--- a/src/components/enter-email/enter-email-service.ts
+++ b/src/components/enter-email/enter-email-service.ts
@@ -15,6 +15,7 @@ export function enterEmailService(
     sessionId: string,
     emailAddress: string,
     sourceIp: string,
+    clientSessionId: string,
     persistentSessionId: string
   ): Promise<ApiResponseResult<UserExists>> {
     const response = await axios.client.post<UserExists>(
@@ -25,6 +26,7 @@ export function enterEmailService(
       getRequestConfig({
         sessionId: sessionId,
         sourceIp: sourceIp,
+        clientSessionId: clientSessionId,
         persistentSessionId: persistentSessionId,
       })
     );

--- a/src/components/enter-email/types.ts
+++ b/src/components/enter-email/types.ts
@@ -10,6 +10,7 @@ export interface EnterEmailServiceInterface {
     sessionId: string,
     emailAddress: string,
     sourceIp: string,
+    clientSessionId: string,
     persistentSessionId: string
   ) => Promise<ApiResponseResult<UserExists>>;
 }

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -27,6 +27,7 @@ export function resetPasswordCheckEmailGet(
         email,
         sessionId,
         req.ip,
+        res.locals.clientSessionId,
         res.locals.persistentSessionId
       );
     }

--- a/src/components/reset-password-check-email/reset-password-check-email-service.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-service.ts
@@ -16,6 +16,7 @@ export function resetPasswordCheckEmailService(
     email: string,
     sessionId: string,
     sourceIp: string,
+    clientSessionId: string,
     persistentSessionId: string
   ): Promise<ApiResponseResult<DefaultApiResponse>> {
     const response = await axios.client.post<DefaultApiResponse>(
@@ -27,6 +28,7 @@ export function resetPasswordCheckEmailService(
       getRequestConfig({
         sessionId: sessionId,
         sourceIp: sourceIp,
+        clientSessionId: clientSessionId,
         persistentSessionId: persistentSessionId,
       })
     );

--- a/src/components/reset-password-check-email/types.ts
+++ b/src/components/reset-password-check-email/types.ts
@@ -5,6 +5,7 @@ export interface ResetPasswordCheckEmailServiceInterface {
     email: string,
     sessionId: string,
     sourceIp: string,
+    clientSessionId: string,
     persistentSessionId: string
   ) => Promise<ApiResponseResult<DefaultApiResponse>>;
 }

--- a/src/components/reset-password/reset-password-controller.ts
+++ b/src/components/reset-password/reset-password-controller.ts
@@ -40,6 +40,7 @@ export function resetPasswordPost(
       newPassword,
       req.ip,
       sessionId,
+      clientSessionId,
       persistentSessionId
     );
 

--- a/src/components/reset-password/reset-password-service.ts
+++ b/src/components/reset-password/reset-password-service.ts
@@ -15,6 +15,7 @@ export function resetPasswordService(
     newPassword: string,
     sourceIp: string,
     sessionId: string,
+    clientSessionId: string,
     persistentSessionId: string
   ): Promise<ApiResponseResult<DefaultApiResponse>> {
     const response = await axios.client.post<DefaultApiResponse>(
@@ -25,6 +26,7 @@ export function resetPasswordService(
       getRequestConfig({
         sourceIp: sourceIp,
         sessionId: sessionId,
+        clientSessionId: clientSessionId,
         persistentSessionId: persistentSessionId,
       })
     );

--- a/src/components/reset-password/types.ts
+++ b/src/components/reset-password/types.ts
@@ -5,6 +5,7 @@ export interface ResetPasswordServiceInterface {
     newPassword: string,
     sourceIp: string,
     sessionId: string,
+    clientSessionId: string,
     persistentSessionId: string
   ) => Promise<ApiResponseResult<DefaultApiResponse>>;
 }


### PR DESCRIPTION
## What?

- Add header to `userExists` backend call
- Add header to `resetPasswordRequest` backend call
- Add header to `resetPassword` backend call

## Why?

We need this header to identify the user journey so we can pass through to the audit service.
