### PR TITLE
FIX: Make link destinations for resend email codes consistent

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -378,7 +378,7 @@
         "summaryText": "Problemau gyda'r cod?",
         "text1": "Gallwn ",
         "sendCodeLinkText": "anfon y cod eto",
-        "sendCodeLinkHref": "/resend-code?isResendCodeRequest=true",
+        "sendCodeLinkHref": "/resend-email-code",
         "text2": " neu gallwch ",
         "changeEmailLinkText": "ddefnyddio cyfeiriad e-bost gwahanol",
         "changeEmailLinkHref": "/enter-email-create"


### PR DESCRIPTION
## What?

Changes value for link destination in Welsh translation file to match value in English translation

## Why?

Fixes bug identified this afternoon where Welsh users clicking request new security code were not progressing to the page. This made it seem that the page didn't exist. 