### PR TITLE
BAU: Fix Welsh resource typo on enter authenticator app code

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1612,7 +1612,7 @@
         "validationError": {
           "required": "Rhowch y cod diogelwch",
           "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
-          "InvalidCode": "Nid yw'r cod diogelwch rydych wedi'i roi yn gywir, ceisiwch ei roi i mewn eto neu aros i'ch ap dilysydd roi cod newydd i chi"
+          "invalidCode": "Nid yw'r cod diogelwch rydych wedi'i roi yn gywir, ceisiwch ei roi i mewn eto neu aros i'ch ap dilysydd roi cod newydd i chi"
         }
       }
     }


### PR DESCRIPTION
## What?

Fix Welsh resource typo on enter authenticator app code.

## Why?

The validation message for invalid code was being displayed in English rather than Welsh.
