### PR TITLE
AUT-739/fix success title in success panel

### DIFF
--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -21,6 +21,7 @@
   govukNotificationBanner({
   html: html,
   type: 'success',
+  titleText: 'general.cookie.cookieBanner.cookieBannerTitleText' | translate,
   attributes: {
     "id": "save-success-banner"
   }
@@ -29,6 +30,7 @@
 {{ govukNotificationBanner({
   html: html,
   type: 'success',
+  titleText: 'general.cookie.cookieBanner.cookieBannerTitleText' | translate,
   attributes: {
     "id": "save-success-banner",
     "hidden": true

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -24,6 +24,7 @@
         "buttonAcceptText": "Derbyn cwcis dadansoddi",
         "buttonRejectText": "Gwrthod cwcis dadansoddi",
         "linkViewCookiesText": "Gweld cwcis",
+        "cookieBannerTitleText": "TBC",
         "cookieBannerHideLink": "Cuddio'r neges yma",
         "cookeBannerAccept": {
           "paragraph1": "Rydych wedi derbyn cwcis ychwanegol. Gallwch ",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -24,7 +24,7 @@
         "buttonAcceptText": "Derbyn cwcis dadansoddi",
         "buttonRejectText": "Gwrthod cwcis dadansoddi",
         "linkViewCookiesText": "Gweld cwcis",
-        "cookieBannerTitleText": "TBC",
+        "cookieBannerTitleText": "Llwyddiant",
         "cookieBannerHideLink": "Cuddio'r neges yma",
         "cookeBannerAccept": {
           "paragraph1": "Rydych wedi derbyn cwcis ychwanegol. Gallwch ",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -24,6 +24,7 @@
         "buttonAcceptText": "Accept analytics cookies",
         "buttonRejectText": "Reject analytics cookies",
         "linkViewCookiesText": "View cookies",
+        "cookieBannerTitleText": "Success",
         "cookieBannerHideLink": "Hide this message",
         "cookeBannerAccept": {
           "paragraph1": "You’ve accepted additional cookies. You can ",


### PR DESCRIPTION
## What?

Update notification banner to use a translation value and introduces the relevant value.

## Why?

To ensure the "Success" message is translated for users viewing the page in Welsh