### PR TITLE
AUT-731: Fix radio button focus behaviour from error summary link

### DIFF
--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -357,7 +357,6 @@
 <form method="post" id="cookie-preferences-form" novalidate hidden="true">
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 {{ govukRadios({
-  idPrefix: "cookie-preferences",
   name: "cookie_preferences",
   attributes: {
     "id": "radio-cookie-preferences"

--- a/src/components/common/footer/support.njk
+++ b/src/components/common/footer/support.njk
@@ -19,7 +19,6 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
 {{ govukRadios({
-  idPrefix: "support",
   name: "supportType",
   attributes: {
     "id": "radio-support"

--- a/src/components/contact-us/further-information/_account-creation-further-information.njk
+++ b/src/components/contact-us/further-information/_account-creation-further-information.njk
@@ -64,7 +64,6 @@
     {% endif %}
 
     {{ govukRadios({
-        idPrefix: "account-creation",
         name: "subtheme",
         fieldset: {
             legend: {

--- a/src/components/contact-us/further-information/_signing-in-further-information.njk
+++ b/src/components/contact-us/further-information/_signing-in-further-information.njk
@@ -9,7 +9,6 @@
 <input type="hidden" name="referer" value="{{referer}}"/>
 
     {{ govukRadios({
-        idPrefix: "signing-in",
         name: "subtheme",
         fieldset: {
             legend: {

--- a/src/components/contact-us/questions/_reply_by_email.njk
+++ b/src/components/contact-us/questions/_reply_by_email.njk
@@ -32,7 +32,6 @@
 {% endset -%}
 
 {{ govukRadios({
-  idPrefix: "contact",
   name: "contact",
   fieldset: {
     legend: {

--- a/src/components/contact-us/questions/_security_send_method.njk
+++ b/src/components/contact-us/questions/_security_send_method.njk
@@ -26,7 +26,6 @@
     {% endif %}
 
     {{ govukRadios({
-        idPrefix: "securityCodeSentMethod",
         name: "securityCodeSentMethod",
         fieldset: {
             legend: {

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -105,7 +105,7 @@ describe("Integration:: contact us - public user", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#signing-in-error").text()).to.contains(
+        expect($("#subtheme-error").text()).to.contains(
           "Select the problem you had when signing in to your account"
         );
       })

--- a/src/components/prove-identity-welcome/index-existing-session.njk
+++ b/src/components/prove-identity-welcome/index-existing-session.njk
@@ -50,7 +50,6 @@
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
         {{ govukRadios({
-            idPrefix: "chooseWayPyi",
             name:"chooseWayPyi",
             fieldset: {
                 legend: {

--- a/src/components/prove-identity-welcome/index.njk
+++ b/src/components/prove-identity-welcome/index.njk
@@ -53,7 +53,6 @@
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
         {{ govukRadios({
-            idPrefix: "chooseWayPyi",
             name:"chooseWayPyi",
             fieldset: {
                 legend: {

--- a/src/components/select-mfa-options/index.njk
+++ b/src/components/select-mfa-options/index.njk
@@ -33,20 +33,14 @@
 <input type="hidden" name="isAccountPartCreated" value="{{isAccountPartCreated}}"/>
 
 {{ govukRadios({
-  idPrefix: "mfa-options",
   name: "mfaOptions",
-  attributes: {
-    "id": "radio-mfa-options"
-  },
   items: [
     {
       text: 'pages.getSecurityCodes.secondFactorRadios.textMessageText' | translate,
-      id: "mfa-options-text-message",
       value: "SMS"
     },
     {
       text: 'pages.getSecurityCodes.secondFactorRadios.authAppText' | translate,
-      id: "mfa-options-auth-app",
       value: "AUTH_APP"
     }
   ],

--- a/src/components/select-mfa-options/tests/select-mfa-options-integration.test.ts
+++ b/src/components/select-mfa-options/tests/select-mfa-options-integration.test.ts
@@ -78,7 +78,7 @@ describe("Integration::select-mfa-options", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#mfa-options-error").text()).to.contains(
+        expect($("#mfaOptions-error").text()).to.contains(
           "Select how you want to get security codes"
         );
       })

--- a/src/components/share-info/index.njk
+++ b/src/components/share-info/index.njk
@@ -30,11 +30,7 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
 {{ govukRadios({
-  idPrefix: "share-info",
   name: "consentValue",
-  attributes: {
-    "id": "radio-share-info-preferences"
-  },
   fieldset: {
     legend: {
       text: 'pages.shareInfo.essentialHeader' | translate,
@@ -45,12 +41,10 @@
   items: [
     {
       text: 'pages.shareInfo.radios.radioText.agree' | translate,
-      id: "share-info-accepted",
       value: "true"
     },
     {
       text: 'pages.shareInfo.radios.radioText.doNotAgree' | translate,
-      id: "share-info-rejected",
       value: "false"
     }
   ],

--- a/src/components/share-info/tests/share-info-integration.test.ts
+++ b/src/components/share-info/tests/share-info-integration.test.ts
@@ -89,7 +89,7 @@ describe("Integration::share info", () => {
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
-        expect($("#share-info-error").text()).to.contains(
+        expect($("#consentValue-error").text()).to.contains(
           "Select if you want to share your email address and phone number or not"
         );
       })


### PR DESCRIPTION
## What?

- Fix radio button focus behaviour from error summary link
- Before commit, error summary href does not target anything
- After commit, error href targets first radio button of set with error
- Mirrors change in commit 6654c47/PR #756 - but now with broader scope

Note: Some integration tests needed to be tweaked because they were targetting by `id` and this change affects the `id` names

## Why?

- The failure to focus when clicking the link in error summary is a WCAG 2.1 accessibility failure.

## Related PRs

This was originally reported and fixed for a single contact-us page (same fix now, but just in more places): https://github.com/alphagov/di-authentication-frontend/pull/756
