### PR TITLE
AUT-672: Add translations for OGL and Crown Copyright

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -97,6 +97,12 @@
               text: 'general.footer.support.linkText' | translate
           }
         ]
+      },
+      contentLicence: {
+        text: 'general.footer.contentLicence.linkText' | translate | safe
+      },
+      copyright: {
+        text: 'general.footer.copyright.linkText' | translate
       }
     }) }}
     {% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -71,6 +71,12 @@
       "support": {
         "pageTitle": "Cefnogaeth",
         "linkText": "Cefnogaeth (agor mewn tab newydd)"
+      },
+      "copyright": {
+        "linkText": "© Hawlfraint y goron"
+      },
+      "contentLicence": {
+        "linkText": "Mae’r holl gynnwys ar gael o dan <a class=\"govuk-footer__link\" href=\"https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/\" rel=\"licence\">Trwydded Llywodraeth Agored v3.0</a>, oni nodir yn wahanol"
       }
     },
     "showPassword": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -71,6 +71,12 @@
       "support": {
         "pageTitle": "Support",
         "linkText": "Support (opens in new tab)"
+      },
+      "copyright": {
+        "linkText": "© Crown copyright"
+      },
+      "contentLicence": {
+        "linkText": "All content is available under the <a class=\"govuk-footer__link\" href=\"https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\" rel=\"licence\">Open Government Licence v3.0</a>, except where otherwise stated"
       }
     },
     "showPassword": {


### PR DESCRIPTION
## What?

Provides translated text and updates OGL link destination to reflect the language preference.

## Why?

So that these parts of the footer and links to the OGL reflect user language preferences