### PR TITLE
AUT-668: Tidy translation file usage in two templates

### DIFF
--- a/src/components/resend-email-code/index.njk
+++ b/src/components/resend-email-code/index.njk
@@ -7,7 +7,7 @@
 {% set hrefBack = 'enter-code' %}
 
 
-{% set emailMessage = 'pages.resendMfaCode.phoneNumber.isResendCodeRequest' | translate | replace("[mobile].", "") %}
+{% set emailMessage = 'pages.resendMfaCode.email.recipientMessage' | translate %}
 
 {% block content %}
     <form action="/resend-email-code" method="post" novalidate="novalidate">
@@ -19,9 +19,9 @@
             html: emailMessage + '<span class="govuk-body govuk-!-font-weight-bold">' + emailAddress + '</span>'
         }) }}
 
-        <p class="govuk-body">{{'pages.resetPasswordCheckEmail.paragraph3' | translate}}</p>
+        <p class="govuk-body">{{'pages.resendMfaCode.email.paragraph' | translate}}</p>
         {{ govukButton({
-        "text": button_text|default('pages.resendMfaCode.continue' | translate, true),
+        "text": 'pages.resendMfaCode.continue' | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/reset-password-check-email/index-reset-password-resend-code.njk
+++ b/src/components/reset-password-check-email/index-reset-password-resend-code.njk
@@ -5,20 +5,19 @@
 {% set showBack = true %}
 {% set hrefBack = 'reset-password-check-email?requestCode=false' %}
 {% block content %}
-
 <form action="/reset-password-check-email" method="get" novalidate>
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resendMfaCode.header' | translate }}</h1>
 
     {{ govukInsetText({
-        html: 'pages.resendMfaCode.phoneNumber.isResendCodeRequest' | translate | replace("[mobile].", "") + '<span class="govuk-body govuk-!-font-weight-bold">' + email + '</span>'
+        html: 'pages.resendMfaCode.email.recipientMessage' | translate + '<span class="govuk-body govuk-!-font-weight-bold">' + email + '</span>'
     }) }}
 
-    <p class="govuk-body">{{ 'pages.resetPasswordCheckEmail.paragraph3' | translate }}</p>
+    <p class="govuk-body">{{ 'pages.resendMfaCode.email.paragraph' | translate }}</p>
 
     {{ govukButton({
-        "text": button_text|default('pages.resendMfaCode.continue' | translate, true),
+        "text": 'pages.resendMfaCode.continue' | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -495,6 +495,10 @@
       "phoneNumber": {
         "default": "Byddwn yn anfon cod at y rhif ffôn sy'n gysylltiedig â'ch cyfrif",
         "isResendCodeRequest": "Byddwn yn anfon cod i: [mobile]."
+      },
+      "email": {
+        "recipientMessage": "Byddwn yn anfon cod i: ",
+        "paragraph": "Efallai y bydd eich e-bost yn cymryd ychydig funudau i gyrraedd. Os na chewch e-bost, edrychwch ar eich ffolder spam."
       }
     },
     "signedOut": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -495,6 +495,10 @@
       "phoneNumber": {
         "default": "We will send a code to the phone number linked to your account",
         "isResendCodeRequest": "We will send a code to: [mobile]."
+      },
+      "email": {
+        "recipientMessage": "We will send a code to: ",
+        "paragraph": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder."
       }
     },
     "signedOut": {


### PR DESCRIPTION
## What?

Does two things: 

* Restores 1:1 relationship between two templates and corresponding translation file values (fixing an issue where it had been necessary to borrow values from other parts of the app during the content freeze while we were awaiting translated text). 
* Fixes an issue where a non-existent `button_text` value is used falling back to the translation 

## Why?

Aids maintainability.