### PR TITLE
AUT-707: Add language information to logs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -26,6 +26,7 @@ import {
   supportMFAOptions,
 } from "./config";
 import { logErrorMiddleware } from "./middleware/log-error-middleware";
+import { getCookieLanguageMiddleware } from "./middleware/cookie-lang-middleware";
 import { enterEmailRouter } from "./components/enter-email/enter-email-routes";
 import { enterPasswordRouter } from "./components/enter-password/enter-password-routes";
 import { footerRouter } from "./components/common/footer/footer-pages-routes";
@@ -183,6 +184,8 @@ async function createApp(): Promise<express.Application> {
   app.use(crossDomainTrackingMiddleware);
 
   registerRoutes(app);
+
+  app.use(getCookieLanguageMiddleware);
 
   app.use(logErrorMiddleware);
   app.use(serverErrorHandler);

--- a/src/middleware/cookie-lang-middleware.ts
+++ b/src/middleware/cookie-lang-middleware.ts
@@ -1,0 +1,11 @@
+import { NextFunction, Request, Response } from "express";
+
+export function getCookieLanguageMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  res.locals.language = req.cookies?.lng;
+
+  next();
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -20,6 +20,7 @@ const logger = pino({
         sessionId: res.locals.sessionId,
         clientSessionId: res.locals.clientSessionId,
         persistentSessionId: res.locals.persistentSessionId,
+        languageFromCookie: res.locals.language?.toUpperCase(),
       };
     },
   },
@@ -46,6 +47,7 @@ const loggerMiddleware = PinoHttp({
       "/public/scripts/cookies.js",
       "/public/scripts/all.js",
       "/public/style.css",
+      "/public/scripts",
       "/public/scripts/application.js",
       "/assets/images/govuk-crest-2x.png",
       "/assets/fonts/bold-b542beb274-v2.woff2",


### PR DESCRIPTION
## What?

- Add language information to logs
- Middleware sets this as single-request-response-cycle local variable
- Pino logger picks this up and adds it as an extra dimension to logs

## Why?

- To allow performance analysts to analyse degree to which English vs Welsh languages versions are viewed on a per-page basis

