### PR TITLE
AUT-751: Add additional lang attributes where necessary

### DIFF
--- a/src/components/prove-identity-welcome/index-existing-session.njk
+++ b/src/components/prove-identity-welcome/index-existing-session.njk
@@ -22,7 +22,10 @@
     {% if supportLanguageCY %}
         {% set insetTextInnerHtml %}
         {{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.paragraph1' | translate }}
-        <a href="{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText' | translate }}</a>.
+        <a href="{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">
+            {{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
+            <span lang="{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span>
+        </a>.
         {% endset %}
 
         {{ govukInsetText({

--- a/src/components/prove-identity-welcome/index.njk
+++ b/src/components/prove-identity-welcome/index.njk
@@ -25,7 +25,10 @@
     {% if supportLanguageCY %}
         {% set insetTextInnerHtml %}
         {{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.paragraph1' | translate }}
-        <a href="{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText' | translate }}</a>.
+        <a href="{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">
+            {{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
+            <span lang="{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span>
+        </a>.
         {% endset %}
 
         {{ govukInsetText({

--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -42,7 +42,10 @@
   {% if supportLanguageCY %}
     {% set altLangInsetHtml %}
     {{ 'pages.signInOrCreate.insetAlternativeLanguage.paragraph1' | translate }}
-    <a href="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText' | translate }}</a>.
+    <a href="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">
+      {{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
+      <span lang="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span>
+    </a>.
     {% endset %}
     {{ govukInsetText({
       html: altLangInsetHtml

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -41,10 +41,6 @@
       "cookieLink": "#",
       "cookieLinkText": "Darganfyddwch fwy am gwcis"
     },
-    "language": {
-      "english": "English",
-      "welsh": "Cymraeg (Welsh)"
-    },
     "continue": {
       "label": "Parhau"
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -124,7 +124,11 @@
       "bullet2IntNumbers": "ffordd o gael codau diogelwch - gall hwn fod yn rhif ffôn symudol neu'n ap dilysydd",
       "insetAlternativeLanguage": {
         "paragraph1": "Mae'r cyfrif GOV.UK hefyd ar gael ",
-        "linkText": "yn Saesneg (English)",
+        "linkText": {
+          "inPageLanguage": "yn Saesneg",
+          "inDestinationLanguage": "(English)",
+          "destinationLanguageCode": "en"
+        },
         "linkHref": "?lng=en"
       },
       "paragraph2": "Os oes gennych gyfrif GOV.UK yn barod gallwch",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1537,7 +1537,11 @@
         "insetTextEnglishOnly": "Ar hyn o bryd dim ond yn Saesneg mae'r gwasanaeth hwn ar gael.",
         "insetAlternativeLanguage": {
           "paragraph1": "Mae'r gwasanaeth hwn hefyd ar gael yn ",
-          "linkText": "Saesneg",
+          "linkText": {
+            "inPageLanguage": "Saesneg",
+            "inDestinationLanguage": "(English)",
+            "destinationLanguageCode": "en"
+          },
           "linkHref": "?lng=en"
         },
         "paragraph2": "Bydd angen i chi greu neu fewngofnodi i'ch cyfrif GOV.UK yn gyntaf. Yna byddwn yn gofyn i chi am eich cyfeiriad presennol a manylion pasbort.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -124,7 +124,11 @@
       "bullet2IntNumbers": "a way to get security codes - this can be a mobile phone number or an authenticator app",
       "insetAlternativeLanguage": {
         "paragraph1": "The GOV.UK account is also available ",
-        "linkText": "in Welsh (Cymraeg)",
+        "linkText": {
+          "inPageLanguage": "in Welsh",
+          "inDestinationLanguage": "(Cymraeg)",
+          "destinationLanguageCode": "cy"
+        },
         "linkHref": "?lng=cy"
       },
       "paragraph2": "If you already have a GOV.UK account you can",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -41,10 +41,6 @@
       "cookieLink": "#",
       "cookieLinkText": "Find out more about cookies"
     },
-    "language": {
-      "english": "English",
-      "welsh": "Cymraeg (Welsh)"
-    },
     "continue": {
       "label": "Continue"
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1537,7 +1537,11 @@
         "insetTextEnglishOnly": "This service is currently only available in English.",
         "insetAlternativeLanguage": {
           "paragraph1": "This service is also available in ",
-          "linkText": "Welsh (Cymraeg)",
+          "linkText": {
+            "inPageLanguage": "Welsh",
+            "inDestinationLanguage": "(Cymraeg)",
+            "destinationLanguageCode": "cy"
+          },
           "linkHref": "?lng=cy"
         },
         "paragraph2": "You'll need to create or sign in to your GOV.UK account first. We'll then ask you for your current address and passport details.",


### PR DESCRIPTION
## What?

Introduces `lang` attributes where the page switches between Welsh and English

## Why?

This is necessary to meet WCAG 2.1 Success Criterion 3.1.2 Language of Parts (AA)