### PR TITLE
BAU - Change elasticcache maitenance window

### DIFF
--- a/ci/terraform/redis.tf
+++ b/ci/terraform/redis.tf
@@ -31,7 +31,7 @@ resource "aws_elasticache_replication_group" "frontend_sessions_store" {
   engine_version                = "6.x"
   parameter_group_name          = "default.redis6.x"
   port                          = local.redis_port_number
-  maintenance_window            = "mon:02:00-mon:03:00"
+  maintenance_window            = "sun:22:00-sun:23:00"
   notification_topic_arn        = data.aws_sns_topic.slack_events.arn
 
   multi_az_enabled = true


### PR DESCRIPTION
## What?

- Change elasticcache maitenance window

## Why?

- Make the maintenance window earlier so that it still avoids high periods of traffic but so that it is not in the middle of the night should elasticcache maintenance caus e an incident.


