### PR TITLE
PYIC-1980 Build content & design changes to pre-auth pages

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -50,6 +50,8 @@ export const PATH_NAMES = {
   CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP: "/setup-authenticator-app",
   COOKIES_POLICY: "/cookies",
   ERROR_PAGE: "/error",
+  PHOTO_ID: "/photo-id",
+  NO_PHOTO_ID: "/no-photo-id"
 };
 
 export const HTTP_STATUS_CODES = {

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -51,7 +51,7 @@ export const PATH_NAMES = {
   COOKIES_POLICY: "/cookies",
   ERROR_PAGE: "/error",
   PHOTO_ID: "/photo-id",
-  NO_PHOTO_ID: "/no-photo-id"
+  NO_PHOTO_ID: "/no-photo-id",
 };
 
 export const HTTP_STATUS_CODES = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -117,7 +117,7 @@ function registerRoutes(app: express.Application) {
   app.use(docCheckingAppRouter);
   app.use(docCheckingAppCallbackRouter);
   app.use(errorPageRouter);
-  app.use(photoIdRouter)
+  app.use(photoIdRouter);
 }
 
 async function createApp(): Promise<express.Application> {

--- a/src/app.ts
+++ b/src/app.ts
@@ -75,6 +75,7 @@ import { setupAuthenticatorAppRouter } from "./components/setup-authenticator-ap
 import { enterAuthenticatorAppCodeRouter } from "./components/enter-authenticator-app-code/enter-authenticator-app-code-routes";
 import { cookiesRouter } from "./components/common/cookies/cookies-routes";
 import { errorPageRouter } from "./components/common/errors/error-routes";
+import { photoIdRouter } from "./components/photo-id/photo-id-routes";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -116,6 +117,7 @@ function registerRoutes(app: express.Application) {
   app.use(docCheckingAppRouter);
   app.use(docCheckingAppCallbackRouter);
   app.use(errorPageRouter);
+  app.use(photoIdRouter)
 }
 
 async function createApp(): Promise<express.Application> {

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -47,6 +47,8 @@ const USER_JOURNEY_EVENTS = {
   MFA_OPTION_SMS_SELECTED: "MFA_OPTION_SMS_SELECTED",
   VERIFY_AUTH_APP_CODE: "VERIFY_AUTH_APP_CODE",
   AUTH_APP_CODE_VERIFIED: "AUTH_APP_CODE_VERIFIED",
+  PHOTO_ID: "PHOTO_ID",
+  NO_PHOTO_ID: "NO_PHOTO_ID"
 };
 
 const authStateMachine = createMachine(
@@ -114,6 +116,9 @@ const authStateMachine = createMachine(
           ],
           [USER_JOURNEY_EVENTS.CREATE_OR_SIGN_IN]: [
             PATH_NAMES.SIGN_IN_OR_CREATE,
+          ],
+          [USER_JOURNEY_EVENTS.PHOTO_ID]: [
+            PATH_NAMES.PHOTO_ID,
           ],
         },
       },
@@ -506,6 +511,35 @@ const authStateMachine = createMachine(
       [PATH_NAMES.AUTH_CODE]: {
         type: "final",
       },
+      [PATH_NAMES.PHOTO_ID]: {
+        on : {
+          [USER_JOURNEY_EVENTS.EXISTING_SESSION]: [
+            {
+              target: [PATH_NAMES.ENTER_PASSWORD],
+              cond: "requiresLogin",
+            },
+            { target: [PATH_NAMES.UPLIFT_JOURNEY], cond: "requiresUplift" },
+            { target: [PATH_NAMES.PROVE_IDENTITY] },
+          ],
+          [USER_JOURNEY_EVENTS.CREATE_OR_SIGN_IN]: [
+            PATH_NAMES.SIGN_IN_OR_CREATE,
+          ],
+          [USER_JOURNEY_EVENTS.NO_PHOTO_ID]: [
+            PATH_NAMES.NO_PHOTO_ID,
+          ],
+        },
+        meta: {
+          optionalPaths: [
+            PATH_NAMES.PROVE_IDENTITY_WELCOME,
+            PATH_NAMES.NO_PHOTO_ID
+          ],
+        },
+      },
+      [PATH_NAMES.NO_PHOTO_ID] : {
+        meta: {
+          optionalPaths: [PATH_NAMES.PHOTO_ID]
+        }
+      }
     },
   },
   {

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -114,9 +114,6 @@ const authStateMachine = createMachine(
             { target: [PATH_NAMES.UPLIFT_JOURNEY], cond: "requiresUplift" },
             { target: [PATH_NAMES.PROVE_IDENTITY] },
           ],
-          [USER_JOURNEY_EVENTS.CREATE_OR_SIGN_IN]: [
-            PATH_NAMES.SIGN_IN_OR_CREATE,
-          ],
           [USER_JOURNEY_EVENTS.PHOTO_ID]: [
             PATH_NAMES.PHOTO_ID,
           ],

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -48,7 +48,7 @@ const USER_JOURNEY_EVENTS = {
   VERIFY_AUTH_APP_CODE: "VERIFY_AUTH_APP_CODE",
   AUTH_APP_CODE_VERIFIED: "AUTH_APP_CODE_VERIFIED",
   PHOTO_ID: "PHOTO_ID",
-  NO_PHOTO_ID: "NO_PHOTO_ID"
+  NO_PHOTO_ID: "NO_PHOTO_ID",
 };
 
 const authStateMachine = createMachine(
@@ -114,9 +114,7 @@ const authStateMachine = createMachine(
             { target: [PATH_NAMES.UPLIFT_JOURNEY], cond: "requiresUplift" },
             { target: [PATH_NAMES.PROVE_IDENTITY] },
           ],
-          [USER_JOURNEY_EVENTS.PHOTO_ID]: [
-            PATH_NAMES.PHOTO_ID,
-          ],
+          [USER_JOURNEY_EVENTS.PHOTO_ID]: [PATH_NAMES.PHOTO_ID],
         },
       },
       [PATH_NAMES.ENTER_EMAIL_SIGN_IN]: {
@@ -509,26 +507,24 @@ const authStateMachine = createMachine(
         type: "final",
       },
       [PATH_NAMES.PHOTO_ID]: {
-        on : {
+        on: {
           [USER_JOURNEY_EVENTS.CREATE_OR_SIGN_IN]: [
             PATH_NAMES.SIGN_IN_OR_CREATE,
           ],
-          [USER_JOURNEY_EVENTS.NO_PHOTO_ID]: [
-            PATH_NAMES.NO_PHOTO_ID,
-          ],
+          [USER_JOURNEY_EVENTS.NO_PHOTO_ID]: [PATH_NAMES.NO_PHOTO_ID],
         },
         meta: {
           optionalPaths: [
             PATH_NAMES.PROVE_IDENTITY_WELCOME,
-            PATH_NAMES.NO_PHOTO_ID
+            PATH_NAMES.NO_PHOTO_ID,
           ],
         },
       },
-      [PATH_NAMES.NO_PHOTO_ID] : {
+      [PATH_NAMES.NO_PHOTO_ID]: {
         meta: {
-          optionalPaths: [PATH_NAMES.PHOTO_ID]
-        }
-      }
+          optionalPaths: [PATH_NAMES.PHOTO_ID],
+        },
+      },
     },
   },
   {

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -510,14 +510,6 @@ const authStateMachine = createMachine(
       },
       [PATH_NAMES.PHOTO_ID]: {
         on : {
-          [USER_JOURNEY_EVENTS.EXISTING_SESSION]: [
-            {
-              target: [PATH_NAMES.ENTER_PASSWORD],
-              cond: "requiresLogin",
-            },
-            { target: [PATH_NAMES.UPLIFT_JOURNEY], cond: "requiresUplift" },
-            { target: [PATH_NAMES.PROVE_IDENTITY] },
-          ],
           [USER_JOURNEY_EVENTS.CREATE_OR_SIGN_IN]: [
             PATH_NAMES.SIGN_IN_OR_CREATE,
           ],

--- a/src/components/photo-id/index-no-photo-id.njk
+++ b/src/components/photo-id/index-no-photo-id.njk
@@ -1,0 +1,35 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set showBack = true %}
+{% set hrefBack = 'photo-id' %}
+{% set pageTitleName = 'pages.noPhotoId.title' | translate %}
+
+{% block content %}
+
+    {% include "common/errors/errorSummary.njk" %}
+
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.photoId.header' | translate}}</h1>
+
+    <p class="govuk-body">{{'pages.noPhotoId.section1.paragraph1' | translate}}</p>
+
+    <h2 class="govuk-heading-s">{{'pages.noPhotoId.section2.subHeading' | translate}}</h2>
+
+    <p class="govuk-body">{{'pages.noPhotoId.section2.paragraph1' | translate}}</p>
+
+    <form id="form-tracking" action="/no-photo-id" method="post" novalidate="novalidate">
+
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+        {{ govukButton({
+            "text": button_text|default('general.continue.label' | translate, true),
+            "type": "Submit",
+            "preventDoubleClick": true
+        }) }}
+
+    </form>
+{% endblock %}

--- a/src/components/photo-id/index.njk
+++ b/src/components/photo-id/index.njk
@@ -1,0 +1,64 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set showBack = true %}
+{% set hrefBack = 'prove-identity-welcome' %}
+{% set pageTitleName = 'pages.photoId.title' | translate %}
+
+{% block content %}
+
+    {% include "common/errors/errorSummary.njk" %}
+
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.photoId.header' | translate}}</h1>
+
+    <p class="govuk-body">{{'pages.photoId.section1.paragraph1' | translate}}</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{'pages.photoId.section1.listItem1' | translate}}</li>
+        <li>{{'pages.photoId.section1.listItem2' | translate}}</li>
+    </ul>
+
+    {{ govukInsetText({
+        html: 'pages.photoId.section1.insetPassportExpiry' | translate
+    }) }}
+
+    <form id="form-tracking" action="/photo-id" method="post" novalidate="novalidate">
+
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+        {{ govukRadios({
+            name:"havePhotoId",
+            fieldset: {
+                legend: {
+                    text: 'pages.photoId.section2.subHeading' | translate,
+                    isPageHeading: false,
+                    classes: "govuk-fieldset__legend--m"
+                }
+            },
+            items: [
+                {
+                    value: "true",
+                    text: 'pages.photoId.section2.radioOption1' | translate
+                },
+                {
+                    value: "false",
+                    text: 'pages.photoId.section2.radioOption2' | translate
+                }
+            ],
+            errorMessage: {
+                text: errors['havePhotoId'].text
+            } if (errors['havePhotoId'])
+        }) }}
+
+        {{ govukButton({
+            "text": button_text|default('general.continue.label' | translate, true),
+            "type": "Submit",
+            "preventDoubleClick": true
+        }) }}
+
+    </form>
+{% endblock %}

--- a/src/components/photo-id/photo-id-controller.ts
+++ b/src/components/photo-id/photo-id-controller.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from "express";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { getNextPathAndUpdateJourney } from "../common/constants";
-import { PATH_NAMES } from "../../app.constants";
+import { IPV_ERROR_CODES, OIDC_ERRORS, PATH_NAMES } from "../../app.constants";
+import { createServiceRedirectErrorUrl } from "../../utils/error";
 
 export function photoIdGet(req: Request, res: Response) : void {
  res.render("photo-id/index.njk")
@@ -25,4 +26,15 @@ export function photoIdPost(req: Request, res: Response) : void {
 
 export function noPhotoIdGet(req: Request, res: Response) : void {
  res.render("photo-id/index-no-photo-id.njk")
+}
+
+export function noPhotoIdPost(req: Request, res: Response) : void {
+ return res.redirect(
+   createServiceRedirectErrorUrl(
+     req.session.client.redirectUri,
+     OIDC_ERRORS.ACCESS_DENIED,
+     IPV_ERROR_CODES.ACCOUNT_NOT_CREATED,
+     req.session.client.state
+   )
+ );
 }

--- a/src/components/photo-id/photo-id-controller.ts
+++ b/src/components/photo-id/photo-id-controller.ts
@@ -4,37 +4,38 @@ import { getNextPathAndUpdateJourney } from "../common/constants";
 import { IPV_ERROR_CODES, OIDC_ERRORS, PATH_NAMES } from "../../app.constants";
 import { createServiceRedirectErrorUrl } from "../../utils/error";
 
-export function photoIdGet(req: Request, res: Response) : void {
- res.render("photo-id/index.njk")
+export function photoIdGet(req: Request, res: Response): void {
+  res.render("photo-id/index.njk");
 }
 
-export function photoIdPost(req: Request, res: Response) : void {
+export function photoIdPost(req: Request, res: Response): void {
+  const event =
+    req.body.havePhotoId?.toLowerCase() === "true"
+      ? USER_JOURNEY_EVENTS.CREATE_OR_SIGN_IN
+      : USER_JOURNEY_EVENTS.NO_PHOTO_ID;
 
- const event = req.body.havePhotoId?.toLowerCase() === 'true'
-   ? USER_JOURNEY_EVENTS.CREATE_OR_SIGN_IN : USER_JOURNEY_EVENTS.NO_PHOTO_ID;
+  const nextPath = getNextPathAndUpdateJourney(
+    req,
+    PATH_NAMES.PHOTO_ID,
+    event,
+    {},
+    res.locals.sessionId
+  );
 
- const nextPath = getNextPathAndUpdateJourney(
-   req,
-   PATH_NAMES.PHOTO_ID,
-   event,
-   {},
-   res.locals.sessionId
- );
-
- res.redirect(nextPath);
+  res.redirect(nextPath);
 }
 
-export function noPhotoIdGet(req: Request, res: Response) : void {
- res.render("photo-id/index-no-photo-id.njk")
+export function noPhotoIdGet(req: Request, res: Response): void {
+  res.render("photo-id/index-no-photo-id.njk");
 }
 
-export function noPhotoIdPost(req: Request, res: Response) : void {
- return res.redirect(
-   createServiceRedirectErrorUrl(
-     req.session.client.redirectUri,
-     OIDC_ERRORS.ACCESS_DENIED,
-     IPV_ERROR_CODES.ACCOUNT_NOT_CREATED,
-     req.session.client.state
-   )
- );
+export function noPhotoIdPost(req: Request, res: Response): void {
+  return res.redirect(
+    createServiceRedirectErrorUrl(
+      req.session.client.redirectUri,
+      OIDC_ERRORS.ACCESS_DENIED,
+      IPV_ERROR_CODES.ACCOUNT_NOT_CREATED,
+      req.session.client.state
+    )
+  );
 }

--- a/src/components/photo-id/photo-id-controller.ts
+++ b/src/components/photo-id/photo-id-controller.ts
@@ -8,15 +8,9 @@ export function photoIdGet(req: Request, res: Response) : void {
 }
 
 export function photoIdPost(req: Request, res: Response) : void {
- const hasPhotoId = req.body.havePhotoId?.toLowerCase() === 'true';
 
- let event = req.session.user.isAuthenticated
-   ? USER_JOURNEY_EVENTS.EXISTING_SESSION
-   : USER_JOURNEY_EVENTS.CREATE_OR_SIGN_IN;
-
- if (!hasPhotoId) {
-  event = USER_JOURNEY_EVENTS.NO_PHOTO_ID
- }
+ const event = req.body.havePhotoId?.toLowerCase() === 'true'
+   ? USER_JOURNEY_EVENTS.CREATE_OR_SIGN_IN : USER_JOURNEY_EVENTS.NO_PHOTO_ID;
 
  const nextPath = getNextPathAndUpdateJourney(
    req,

--- a/src/components/photo-id/photo-id-controller.ts
+++ b/src/components/photo-id/photo-id-controller.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from "express";
+import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { getNextPathAndUpdateJourney } from "../common/constants";
+import { PATH_NAMES } from "../../app.constants";
+
+export function photoIdGet(req: Request, res: Response) : void {
+ res.render("photo-id/index.njk")
+}
+
+export function photoIdPost(req: Request, res: Response) : void {
+ const hasPhotoId = req.body.havePhotoId?.toLowerCase() === 'true';
+
+ let event = req.session.user.isAuthenticated
+   ? USER_JOURNEY_EVENTS.EXISTING_SESSION
+   : USER_JOURNEY_EVENTS.CREATE_OR_SIGN_IN;
+
+ if (!hasPhotoId) {
+  event = USER_JOURNEY_EVENTS.NO_PHOTO_ID
+ }
+
+ const nextPath = getNextPathAndUpdateJourney(
+   req,
+   PATH_NAMES.PHOTO_ID,
+   event,
+   {},
+   res.locals.sessionId
+ );
+
+ res.redirect(nextPath);
+}
+
+export function noPhotoIdGet(req: Request, res: Response) : void {
+ res.render("photo-id/index-no-photo-id.njk")
+}

--- a/src/components/photo-id/photo-id-routes.ts
+++ b/src/components/photo-id/photo-id-routes.ts
@@ -6,7 +6,7 @@ import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-
 import {
   photoIdGet,
   photoIdPost,
-  noPhotoIdGet
+  noPhotoIdGet, noPhotoIdPost,
 } from "./photo-id-controller";
 import { validatePhotoIdRequest } from "./photo-id-validation";
 
@@ -34,5 +34,13 @@ router.get(
   allowUserJourneyMiddleware,
   noPhotoIdGet
 );
+
+router.post(
+  PATH_NAMES.NO_PHOTO_ID,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  noPhotoIdPost
+);
+
 
 export { router as photoIdRouter };

--- a/src/components/photo-id/photo-id-routes.ts
+++ b/src/components/photo-id/photo-id-routes.ts
@@ -1,0 +1,38 @@
+import { PATH_NAMES } from "../../app.constants";
+import * as express from "express";
+
+import { validateSessionMiddleware } from "../../middleware/session-middleware";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
+import {
+  photoIdGet,
+  photoIdPost,
+  noPhotoIdGet
+} from "./photo-id-controller";
+import { validatePhotoIdRequest } from "./photo-id-validation";
+
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.PHOTO_ID,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  photoIdGet
+);
+
+router.post(
+  PATH_NAMES.PHOTO_ID,
+  validatePhotoIdRequest(),
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  photoIdPost
+);
+
+router.get(
+  PATH_NAMES.NO_PHOTO_ID,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  noPhotoIdGet
+);
+
+export { router as photoIdRouter };

--- a/src/components/photo-id/photo-id-routes.ts
+++ b/src/components/photo-id/photo-id-routes.ts
@@ -6,10 +6,10 @@ import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-
 import {
   photoIdGet,
   photoIdPost,
-  noPhotoIdGet, noPhotoIdPost,
+  noPhotoIdGet,
+  noPhotoIdPost,
 } from "./photo-id-controller";
 import { validatePhotoIdRequest } from "./photo-id-validation";
-
 
 const router = express.Router();
 
@@ -41,6 +41,5 @@ router.post(
   allowUserJourneyMiddleware,
   noPhotoIdPost
 );
-
 
 export { router as photoIdRouter };

--- a/src/components/photo-id/photo-id-validation.ts
+++ b/src/components/photo-id/photo-id-validation.ts
@@ -1,0 +1,17 @@
+import { body, check } from "express-validator";
+import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
+import { ValidationChainFunc } from "../../types";
+
+export function validatePhotoIdRequest(): ValidationChainFunc {
+  return [
+    body("havePhotoId")
+      .if(check("auth").isEmpty())
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t("pages.photoId.section2.errorMessage", {
+          value,
+        });
+      }),
+    validateBodyMiddleware("photo-id/index.njk"),
+  ];
+}

--- a/src/components/photo-id/tests/photo-id-controller.test.ts
+++ b/src/components/photo-id/tests/photo-id-controller.test.ts
@@ -15,7 +15,12 @@ import {
   OIDC_ERRORS,
   PATH_NAMES,
 } from "../../../app.constants";
-import { noPhotoIdGet, noPhotoIdPost, photoIdGet, photoIdPost } from "../photo-id-controller";
+import {
+  noPhotoIdGet,
+  noPhotoIdPost,
+  photoIdGet,
+  photoIdPost,
+} from "../photo-id-controller";
 
 describe("photo-id controller", () => {
   let req: RequestOutput;
@@ -47,30 +52,34 @@ describe("photo-id controller", () => {
   describe("photoIdGet", () => {
     it("Should render photo-id page for user to confirm they have a photo id", async () => {
       photoIdGet(req as Request, res as Response);
-      expect(res.render).to.have.been.calledWith("photo-id/index.njk")
-    })
-  })
+      expect(res.render).to.have.been.calledWith("photo-id/index.njk");
+    });
+  });
 
   describe("photoIdPost", () => {
     it("Should redirect to Create or sign in when use selects Yes", () => {
       req.body.havePhotoId = "true";
       photoIdPost(req as Request, res as Response);
-      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.SIGN_IN_OR_CREATE)
-    })
+      expect(res.redirect).to.have.been.calledWith(
+        PATH_NAMES.SIGN_IN_OR_CREATE
+      );
+    });
 
     it("Should redirect to no photo id when use selects No", () => {
       req.body.havePhotoId = "false";
       photoIdPost(req as Request, res as Response);
-      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.NO_PHOTO_ID)
-    })
-  })
+      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.NO_PHOTO_ID);
+    });
+  });
 
   describe("noPhotoIdGet", () => {
     it("Should render no-photo-id page", async () => {
       noPhotoIdGet(req as Request, res as Response);
-      expect(res.render).to.have.been.calledWith("photo-id/index-no-photo-id.njk")
-    })
-  })
+      expect(res.render).to.have.been.calledWith(
+        "photo-id/index-no-photo-id.njk"
+      );
+    });
+  });
 
   describe("noPhotoIdPost", () => {
     it("Should red", async () => {
@@ -83,8 +92,6 @@ describe("photo-id controller", () => {
           IPV_ERROR_CODES.ACCOUNT_NOT_CREATED
         )}&state=${encodeURIComponent(STATE)}`
       );
-
-    })
-  })
-
-})
+    });
+  });
+});

--- a/src/components/photo-id/tests/photo-id-controller.test.ts
+++ b/src/components/photo-id/tests/photo-id-controller.test.ts
@@ -1,0 +1,73 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
+
+import {
+  PATH_NAMES,
+} from "../../../app.constants";
+import { noPhotoIdGet, photoIdGet, photoIdPost } from "../photo-id-controller";
+
+describe("photo-id controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  const STATE = "ndhd7d7d";
+
+  beforeEach(() => {
+    req = mockRequest({
+      path: PATH_NAMES.PROVE_IDENTITY_WELCOME,
+      session: {
+        client: {
+          redirectUri: "http://someservice.com/auth",
+          state: STATE,
+        },
+        user: {},
+      },
+      log: { info: sinon.fake() },
+      t: sinon.fake(),
+      i18n: { language: "en" },
+    });
+    res = mockResponse();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("photoIdGet", () => {
+    it("Should render photo-id page for user to confirm they have a photo id", async () => {
+      photoIdGet(req as Request, res as Response);
+      expect(res.render).to.have.been.calledWith("photo-id/index.njk")
+    })
+  })
+
+  describe("photoIdPost", () => {
+    it("Should redirect to Create or sign in when use selects Yes", () => {
+      req.body.havePhotoId = "true";
+      photoIdPost(req as Request, res as Response);
+      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.SIGN_IN_OR_CREATE)
+    })
+
+    it("Should redirect to no photo id when use selects No", () => {
+      req.body.havePhotoId = "false";
+      photoIdPost(req as Request, res as Response);
+      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.NO_PHOTO_ID)
+    })
+  })
+
+  describe("noPhotoIdGet", () => {
+    it("Should render no-photo-id page", async () => {
+      noPhotoIdGet(req as Request, res as Response);
+      expect(res.render).to.have.been.calledWith("photo-id/index-no-photo-id.njk")
+    })
+  })
+
+})

--- a/src/components/photo-id/tests/photo-id-controller.test.ts
+++ b/src/components/photo-id/tests/photo-id-controller.test.ts
@@ -11,9 +11,11 @@ import {
 } from "mock-req-res";
 
 import {
+  IPV_ERROR_CODES,
+  OIDC_ERRORS,
   PATH_NAMES,
 } from "../../../app.constants";
-import { noPhotoIdGet, photoIdGet, photoIdPost } from "../photo-id-controller";
+import { noPhotoIdGet, noPhotoIdPost, photoIdGet, photoIdPost } from "../photo-id-controller";
 
 describe("photo-id controller", () => {
   let req: RequestOutput;
@@ -67,6 +69,21 @@ describe("photo-id controller", () => {
     it("Should render no-photo-id page", async () => {
       noPhotoIdGet(req as Request, res as Response);
       expect(res.render).to.have.been.calledWith("photo-id/index-no-photo-id.njk")
+    })
+  })
+
+  describe("noPhotoIdPost", () => {
+    it("Should red", async () => {
+      noPhotoIdPost(req as Request, res as Response);
+
+      expect(res.redirect).to.have.been.calledWith(
+        `http://someservice.com/auth?error=${
+          OIDC_ERRORS.ACCESS_DENIED
+        }&error_description=${encodeURIComponent(
+          IPV_ERROR_CODES.ACCOUNT_NOT_CREATED
+        )}&state=${encodeURIComponent(STATE)}`
+      );
+
     })
   })
 

--- a/src/components/prove-identity-welcome/index-existing-session.njk
+++ b/src/components/prove-identity-welcome/index-existing-session.njk
@@ -37,16 +37,21 @@
         }) }}
     {% endif %}
 
-    <p class="govuk-body">{{'pages.proveIdentityWelcome.existingSession.section2.paragraph2' | translate}}</p>
-    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph3' | translate}}</p>
+    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph1' | translate}}</p>
 
     <ul class="govuk-list govuk-list--bullet">
-        <li>{{'pages.proveIdentityWelcome.section2.listItem1' | translate}}</li>
-        <li>{{'pages.proveIdentityWelcome.section2.listItem2' | translate}}</li>
-        <li>{{'pages.proveIdentityWelcome.section2.listItem3' | translate}}</li>
+        <li>{{'pages.proveIdentityWelcome.section2.listItem1_2' | translate}}</li>
+        <li>{{'pages.proveIdentityWelcome.section2.listItem1_3' | translate}}</li>
     </ul>
 
-    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph4' | translate}}</p>
+    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph2' | translate}}</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{'pages.proveIdentityWelcome.section2.listItem2_1' | translate}}</li>
+        <li>{{'pages.proveIdentityWelcome.section2.listItem2_2' | translate}}</li>
+    </ul>
+
+    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph3' | translate}}</p>
 
     <form id="form-tracking" action="/prove-identity-welcome" method="post" novalidate="novalidate">
 

--- a/src/components/prove-identity-welcome/index.njk
+++ b/src/components/prove-identity-welcome/index.njk
@@ -14,42 +14,40 @@
 
     <p class="govuk-body">{{'pages.proveIdentityWelcome.section1.paragraph1' | translate}}</p>
 
-    {{ govukInsetText({
-    html: 'pages.proveIdentityWelcome.section1.insetTextPassport' | translate
-}) }}
-
-    <h2 class="govuk-heading-m">{{'pages.proveIdentityWelcome.section2.subHeading' | translate}}</h2>
-
-    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph1' | translate}}</p>
-
     {% if supportLanguageCY %}
         {% set insetTextInnerHtml %}
-        {{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.paragraph1' | translate }}
-        <a href="{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">
-            {{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
-            <span lang="{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.proveIdentityWelcome.section2.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span>
+        {{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.paragraph1' | translate }}
+        <a href="{{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">
+            {{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
+            <span lang="{{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span>
         </a>.
         {% endset %}
 
         {{ govukInsetText({
-        html: insetTextInnerHtml
+            html: insetTextInnerHtml
         }) }}
     {% else %}
         {{ govukInsetText({
-            text: 'pages.proveIdentityWelcome.section2.insetTextEnglishOnly' | translate
+            text: 'pages.proveIdentityWelcome.section1.insetTextEnglishOnly' | translate
         }) }}
     {% endif %}
 
-    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph2' | translate}}</p>
-    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph3' | translate}}</p>
+    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph1' | translate}}</p>
 
     <ul class="govuk-list govuk-list--bullet">
-        <li>{{'pages.proveIdentityWelcome.section2.listItem1' | translate}}</li>
-        <li>{{'pages.proveIdentityWelcome.section2.listItem2' | translate}}</li>
-        <li>{{'pages.proveIdentityWelcome.section2.listItem3' | translate}}</li>
+        <li>{{'pages.proveIdentityWelcome.section2.listItem1_1' | translate}}</li>
+        <li>{{'pages.proveIdentityWelcome.section2.listItem1_2' | translate}}</li>
+        <li>{{'pages.proveIdentityWelcome.section2.listItem1_3' | translate}}</li>
     </ul>
 
-    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph4' | translate}}</p>
+    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph2' | translate}}</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{'pages.proveIdentityWelcome.section2.listItem2_1' | translate}}</li>
+        <li>{{'pages.proveIdentityWelcome.section2.listItem2_2' | translate}}</li>
+    </ul>
+
+    <p class="govuk-body">{{'pages.proveIdentityWelcome.section2.paragraph3' | translate}}</p>
 
     <form id="form-tracking" action="/prove-identity-welcome" method="post" novalidate="novalidate">
 

--- a/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
+++ b/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
@@ -36,7 +36,9 @@ export function proveIdentityWelcomePost(req: Request, res: Response): void {
     );
   }
 
-  const event = USER_JOURNEY_EVENTS.PHOTO_ID;
+  const event = req.session.user.isAuthenticated
+    ? USER_JOURNEY_EVENTS.EXISTING_SESSION
+    : USER_JOURNEY_EVENTS.PHOTO_ID;
 
   const nextPath = getNextPathAndUpdateJourney(
     req,

--- a/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
+++ b/src/components/prove-identity-welcome/prove-identity-welcome-controller.ts
@@ -36,9 +36,7 @@ export function proveIdentityWelcomePost(req: Request, res: Response): void {
     );
   }
 
-  const event = req.session.user.isAuthenticated
-    ? USER_JOURNEY_EVENTS.EXISTING_SESSION
-    : USER_JOURNEY_EVENTS.CREATE_OR_SIGN_IN;
+  const event = USER_JOURNEY_EVENTS.PHOTO_ID;
 
   const nextPath = getNextPathAndUpdateJourney(
     req,

--- a/src/components/prove-identity-welcome/tests/prove-identity-welcome-controller.test.ts
+++ b/src/components/prove-identity-welcome/tests/prove-identity-welcome-controller.test.ts
@@ -6,7 +6,8 @@ import { Request, Response } from "express";
 
 import {
   IPV_ERROR_CODES,
-  OIDC_ERRORS, OIDC_PROMPT,
+  OIDC_ERRORS,
+  OIDC_PROMPT,
   PATH_NAMES,
 } from "../../../app.constants";
 import {
@@ -70,9 +71,7 @@ describe("prove your identity welcome controller", () => {
     it("should redirect to photo-id when user not authenticated", async () => {
       proveIdentityWelcomePost(req as Request, res as Response);
 
-      expect(res.redirect).to.have.been.calledWith(
-        PATH_NAMES.PHOTO_ID
-      );
+      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.PHOTO_ID);
     });
 
     it("should redirect to RP redirect URI when using alternative way to prove your identity", async () => {
@@ -110,6 +109,5 @@ describe("prove your identity welcome controller", () => {
 
       expect(res.redirect).to.have.been.calledWith(PATH_NAMES.ENTER_PASSWORD);
     });
-
   });
 });

--- a/src/components/prove-identity-welcome/tests/prove-identity-welcome-controller.test.ts
+++ b/src/components/prove-identity-welcome/tests/prove-identity-welcome-controller.test.ts
@@ -6,8 +6,7 @@ import { Request, Response } from "express";
 
 import {
   IPV_ERROR_CODES,
-  OIDC_ERRORS,
-  OIDC_PROMPT,
+  OIDC_ERRORS, OIDC_PROMPT,
   PATH_NAMES,
 } from "../../../app.constants";
 import {
@@ -68,11 +67,11 @@ describe("prove your identity welcome controller", () => {
   });
 
   describe("proveIdentityWelcomePost", () => {
-    it("should redirect to sign-in or create page when user not authenticated", async () => {
+    it("should redirect to photo-id when user not authenticated", async () => {
       proveIdentityWelcomePost(req as Request, res as Response);
 
       expect(res.redirect).to.have.been.calledWith(
-        PATH_NAMES.SIGN_IN_OR_CREATE
+        PATH_NAMES.PHOTO_ID
       );
     });
 
@@ -111,5 +110,6 @@ describe("prove your identity welcome controller", () => {
 
       expect(res.redirect).to.have.been.calledWith(PATH_NAMES.ENTER_PASSWORD);
     });
+
   });
 });

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1530,12 +1530,6 @@
       "header": "Profi pwy ydych chi gyda chyfrif GOV.UK",
       "section1": {
         "paragraph1": "Ar hyn o bryd gallwch ond profi pwy ydych chi gyda'ch cyfrif GOV.UK os oes gennych basbort y DU.",
-        "insetTextPassport": "Os yw'ch pasbort wedi dod i ben, gallwch ddal ei ddefnyddio i brofi pwy ydych chi hyd at 18 mis ar ôl y dyddiad dod i ben."
-      },
-      "section2": {
-        "subHeading": "Beth sydd angen i chi ei wneud",
-        "paragraph1": "Bydd yn cymryd tua 10 munud i chi brofi pwy ydych chi yn y ffordd hyn.",
-        "insetTextEnglishOnly": "Ar hyn o bryd dim ond yn Saesneg mae'r gwasanaeth hwn ar gael.",
         "insetAlternativeLanguage": {
           "paragraph1": "Mae'r gwasanaeth hwn hefyd ar gael yn ",
           "linkText": {
@@ -1545,25 +1539,27 @@
           },
           "linkHref": "?lng=en"
         },
-        "paragraph2": "Bydd angen i chi greu neu fewngofnodi i'ch cyfrif GOV.UK yn gyntaf. Yna byddwn yn gofyn i chi am eich cyfeiriad presennol a manylion pasbort.",
-        "paragraph3": "Byddwn hefyd yn gofyn rhai cwestiynau diogelwch i chi mai dim ond chi ddylai wybod yr atebion iddynt. Efallai y byddwch yn ei chael hi'n haws ateb y cwestiynau hyn os oes gennych chi wybodaeth am:",
-        "listItem1": "eich contract ffôn symudol",
-        "listItem2": "eich cyfrif banc",
-        "listItem3": "unrhyw gardiau credyd, benthyciadau neu forgeisi sydd gennych",
-        "paragraph4": "Byddwn ond yn defnyddio'r wybodaeth rydych yn ei rhoi i ni i wneud yn siwr mai chi yw pwy rydych yn ei ddweud ydych chi."
+        "insetTextEnglishOnly": "Ar hyn o bryd dim ond yn Saesneg mae'r gwasanaeth hwn ar gael."
+      },
+      "section2": {
+        "paragraph1": "Byddwch angen:",
+        "listItem1_1": "cyfrif GOV.UK - byddwn yn gofyn i chi greu neu fewngofnodi i'ch cyfrif pan fyddwch yn parhau",
+        "listItem1_2": "eich cyfeiriad presennol (efallai y byddwch angen eich cyfeiriad blaenorol hefyd os ydych wedi symud yn ddiweddar)",
+        "listItem1_3": "eich ID gyda llun",
+        "paragraph2": "Fe allwch wedyn naill ai:",
+        "listItem2_1": "lwytho llun o'ch ID gyda llun gan ddefnyddio'r ap Gwirio ID GOV.UK",
+        "listItem2_2": "rhoi y manylion o'ch ID gyda llun ac ateb rai cwestiynau diogelwch mai dim ond chi ddylai wybod yr atebion iddynt",
+        "paragraph3": "We'll only use the information you give us to make sure that you are who you say you are."
       },
       "section3": {
         "subHeading": "Dewiswch ffordd i brofi pwy ydych chi",
         "radioOption1": "Parhau i fewngofnodi neu greu cyfrif GOV.UK",
-        "radioOption1HintText": "Gwnewch yn siwr bod gennych eich pasbort DU gyda chi cyn i chi barhau. Efallai y byddwch yn dal i allu profi pwy ydych chi os nad oes gennych eich pasbort ond yn gwybod y manylion sydd arno.",
+        "radioOption1HintText": "You'll need your photo ID to prove your identity this way.",
         "radioOption2": "Profi pwy ydych chi mewn ffordd arall",
         "radioOption2HintText": "Gallwch brofi pwy ydych chi ar-lein gyda GOV.UK Verify neu fynd â'ch dogfennau adnabod i gael eu gwirio yn bersonol.",
         "errorMessage": "Dewiswch opsiwn"
       },
       "existingSession": {
-        "section2": {
-          "paragraph2": "Byddwn yn gofyn i chi am eich cyfeiriad presennol a manylion pasbort."
-        },
         "section3": {
           "radioOption1": "Parhau gyda'ch cyfrif GOV.UK"
         }
@@ -1629,6 +1625,33 @@
           "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
           "invalidCode": "Nid yw'r cod diogelwch rydych wedi'i roi yn gywir, ceisiwch ei roi i mewn eto neu aros i'ch ap dilysydd roi cod newydd i chi"
         }
+      }
+    },
+    "photoId" : {
+      "title": "Mae'n rhaid i chi gael ID gyda llun i brofi pwy ydych chi yn y ffordd yma",
+      "header": "Mae'n rhaid i chi gael ID gyda llun i brofi pwy ydych chi yn y ffordd yma",
+      "section1": {
+        "paragraph1" : "Gallwch ond profi pwy ydych chi gyda'ch cyfrif GOV.UK os oes gennych un o'r canlynol:",
+        "listItem1": "trwydded yrru'r DU",
+        "listItem2": "pasbort y DU",
+        "insetPassportExpiry" : "Os yw eich pasbort wedi dod i ben, gallwch barhau i'w ddefnyddio i brofi pwy ydych chi hyd at 18 mis ar ôl y dyddiad dod i ben."
+      },
+      "section2": {
+        "subHeading" : "Oes gennych chi ID gyda llun?",
+        "radioOption1" : "Oes",
+        "radioOption2" : "Na",
+        "errorMessage": "Dewiswch opsiwn"
+      }
+    },
+    "noPhotoId" : {
+      "title": "Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi",
+      "header": "Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi",
+      "section1": {
+        "paragraph1" : "Ar hyn o bryd gallwch ond profi pwy ydych chi gyda'ch cyfrif GOV.UK os oes gennych ID gyda llun."
+      },
+      "section2": {
+        "subHeading" : "Beth allwch chi ei wneud",
+        "paragraph1" : "Parhau i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi."
       }
     }
   }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1626,6 +1626,34 @@
           "invalidCode": "The security code you entered is not correct, try entering it again or wait for your authenticator app to give you a new code"
         }
       }
+    },
+    "photoId" : {
+      "title": "Confirm you have photo id",
+      "header": "You must have a photo ID to prove your identity this way",
+      "section1": {
+        "paragraph1" : "You can only prove your identity with your GOV.UK account if you have one of the following:",
+        "listItem1": "a UK driving licence",
+        "listItem2": "a UK passport",
+        "insetPassportExpiry" : "If your passport has expired, you can still use it to prove your identity up until 18 months after the expiry date."
+      },
+      "section2": {
+        "subHeading" : "Do you have a photo ID?",
+        "insetPassportExpiry" : "If your passport has expired, you can still use it to prove your identity up until 18 months after the expiry date.",
+        "radioOption1" : "Yes",
+        "radioOption2" : "No",
+        "errorMessage": "Select an option"
+      }
+    },
+    "noPhotoId" : {
+      "title": "No photo id",
+      "header": "Sorry, we cannot prove your identity",
+      "section1": {
+        "paragraph1" : "You can currently only prove your identity with your GOV.UK account if you have a photo ID."
+      },
+      "section2": {
+        "subHeading" : "What you can do",
+        "paragraph1" : "If your passport has expired, you can still use it to prove your identity up until 18 months after the expiry date."
+      }
     }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1529,13 +1529,7 @@
       "title": "Prove your identity with a GOV.UK account",
       "header": "Prove your identity with a GOV.UK account",
       "section1": {
-        "paragraph1": "You can currently only prove your identity with your GOV.UK account if you have a UK passport.",
-        "insetTextPassport": "If your passport has expired, you can still use it to prove your identity up until 18 months after the expiry date."
-      },
-      "section2": {
-        "subHeading": "What you need to do",
         "paragraph1": "It will take you about 10 minutes to prove your identity this way.",
-        "insetTextEnglishOnly": "This service is currently only available in English.",
         "insetAlternativeLanguage": {
           "paragraph1": "This service is also available in ",
           "linkText": {
@@ -1545,25 +1539,27 @@
           },
           "linkHref": "?lng=cy"
         },
-        "paragraph2": "You'll need to create or sign in to your GOV.UK account first. We'll then ask you for your current address and passport details.",
-        "paragraph3": "We'll also ask you some security questions that only you should know the answers to. You might find it easier to answer these questions if you have information about:",
-        "listItem1": "your mobile phone contract",
-        "listItem2": "your bank account",
-        "listItem3": "any credit cards, loans or mortgages you have",
-        "paragraph4": "We'll only use the information you give us to make sure that you are who you say you are."
+        "insetTextEnglishOnly": "This service is currently only available in English."
+      },
+      "section2": {
+        "paragraph1": "You'll need:",
+        "listItem1_1": "a GOV.UK account - we'll ask you to create or sign in to your account when you continue",
+        "listItem1_2": "your current home address (you might also need your previous address if you've recently moved)",
+        "listItem1_3": "your photo ID",
+        "paragraph2": "You can then either:",
+        "listItem2_1": "upload a picture of your photo ID using the GOV.UK ID Check app",
+        "listItem2_2": "enter details from your photo ID and answer some security questions that only you should know the answer to",
+        "paragraph3": "We'll only use the information you give us to make sure that you are who you say you are."
       },
       "section3": {
         "subHeading": "Choose a way to prove your identity",
         "radioOption1": "Continue to sign in or create a GOV.UK account",
-        "radioOption1HintText": "Make sure you have your UK passport with you before you continue. You might still be able to prove your identity if you do not have your passport but know the details on it.",
+        "radioOption1HintText": "You'll need your photo ID to prove your identity this way.",
         "radioOption2": "Prove your identity another way",
         "radioOption2HintText": "You can prove your identity online with GOV.UK Verify or take your identity documents to be checked in person.",
         "errorMessage": "Select an option"
       },
       "existingSession": {
-        "section2": {
-          "paragraph2": "We'll ask you for your current address and passport details."
-        },
         "section3": {
           "radioOption1": "Continue with your GOV.UK account"
         }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1628,7 +1628,7 @@
       }
     },
     "photoId" : {
-      "title": "Confirm you have photo id",
+      "title": "You must have a photo ID to prove your identity this way",
       "header": "You must have a photo ID to prove your identity this way",
       "section1": {
         "paragraph1" : "You can only prove your identity with your GOV.UK account if you have one of the following:",
@@ -1638,7 +1638,6 @@
       },
       "section2": {
         "subHeading" : "Do you have a photo ID?",
-        "insetPassportExpiry" : "If your passport has expired, you can still use it to prove your identity up until 18 months after the expiry date.",
         "radioOption1" : "Yes",
         "radioOption2" : "No",
         "errorMessage": "Select an option"


### PR DESCRIPTION
## What?

Content changes to the ‘Prove your identity with a [GOV.UK](http://gov.uk/) account page’ to mention app functionality 

Modified proveIdentityWelcomePost and state-machine to redirect to photo-id if the user is not already authenticated

Added routes and controller for the two new pages
- photo-id
- no-photo-id 

[PYIC-1980](https://govukverify.atlassian.net/browse/PYIC-1980)

## Why?

Now that users will be able to prove their identity using the app, we need to set users' expectations about this early on in the journey to make sure they are prepared.

Both Core & App teams made the collective decision that we do not want users to be creating an account if they do not have a Photo ID, as they will not be able to prove their identity with us and would then be returned to Verify to create another account which is convoluted and unnecessary. This is why we are adding a new page to screen for Photo ID.

