### PR TITLE
ACI-7: Don't ask for email again after max verify code retries

### DIFF
--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -42,8 +42,9 @@ function getNewCodePath(actionType: SecurityCodeErrorType) {
       return PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER;
     case SecurityCodeErrorType.EmailMaxCodesSent:
     case SecurityCodeErrorType.EmailBlocked:
-    case SecurityCodeErrorType.EmailMaxRetries:
       return PATH_NAMES.ENTER_EMAIL_CREATE_ACCOUNT;
+    case SecurityCodeErrorType.EmailMaxRetries:
+      return PATH_NAMES.CHECK_YOUR_EMAIL;
     case SecurityCodeErrorType.AuthAppMfaMaxRetries:
       return PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE;
   }


### PR DESCRIPTION
## What?

Do not ask a new user to re-enter email when they request another code having exceeded the maximum number of retries when entering an email validation code.

To be deployed in conjunction with a server side change that does not block the email when the maximum number of retries has been reached.

**Before**:

1. User enters incorrect six digit email security code 6 times during account creation
2. User sees screen telling them they need to wait 15 mins to get a new code.
4. User clicks 'get a new code'
5. User enters same email address (again)
6. User sees screen telling them they need to wait 15 mins to get a new code.
7.  User waits 15 mins (30s in build).
8. User clicks 'get a new code' (or abandons and starts again)
9. User enters same email address (again)
10. User user selects 'continue'.
11. User is sent a security code and is redirected to ‘check your email’ screen
12. User can enter the code and continue their journey

**After** (both frontend and server side changes):

1. User enters incorrect six digit email security code 6 times during account creation
2. User sees screen telling them they need to get a new code. 
5. User selects ‘get new code’
6. User is sent a security code and is redirected to ‘check your email’ screen, without having to enter their email address again.
7. User can enter the code and continue their journey

Note that if the user abandons the journey before confirming their email address, they will be asked to enter their email address when they try again.

## Why?

No reason to block the account if the account does not already exist, this just means the user has to wait 15 mins before they can create the account.
Make it easier for the user by not asking them to enter their email again.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2408
https://github.com/alphagov/di-authentication-acceptance-tests/pull/147

