### PR TITLE
AUT-780: Add autocomplete attribute for password on account exists

### DIFF
--- a/src/components/common/show-password/macro.njk
+++ b/src/components/common/show-password/macro.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% macro govukInputWithShowPassword(label, id, errors, showSettings) %}
+{% macro govukInputWithShowPassword(label, id, errors, showSettings, autocomplete) %}
     <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="{{ showSettings.show }}" data-hide-text="{{ showSettings.hide }}" data-show-full-text="{{ showSettings.showFullText }}" data-hide-full-text="{{ showSettings.hideFullText }}" data-announce-show="{{ showSettings.announceShown }}" data-announce-hide="{{ showSettings.announceHidden }}">
         {{ govukInput({
             label: {
@@ -10,6 +10,7 @@
             id: id,
             name: id,
             type: "password",
+            autocomplete: autocomplete,
             spellcheck: false,
             errorMessage: {
                 text: errors[id].text
@@ -18,7 +19,7 @@
     </div>
 {% endmacro %}
 
-{% macro govukInputWithShowPasswordWithLabelAsPageHeading(label, id, errors, showSettings) %}
+{% macro govukInputWithShowPasswordWithLabelAsPageHeading(label, id, errors, showSettings, autocomplete) %}
     <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="{{ showSettings.show }}" data-hide-text="{{ showSettings.hide }}" data-show-full-text="{{ showSettings.showFullText }}" data-hide-full-text="{{ showSettings.hideFullText }}" data-announce-show="{{ showSettings.announceShown }}" data-announce-hide="{{ showSettings.announceHidden }}">
         {{ govukInput({
             label: {
@@ -30,6 +31,7 @@
             id: id,
             name: id,
             type: "password",
+            autocomplete: autocomplete,
             spellcheck: false,
             errorMessage: {
                 text: errors[id].text

--- a/src/components/enter-password/index-account-exists.njk
+++ b/src/components/enter-password/index-account-exists.njk
@@ -35,7 +35,8 @@
             hideFullText: 'general.showPassword.hideFullText' | translate,
             announceShown: 'general.showPassword.announceShown' | translate,
             announceHidden: 'general.showPassword.announceHidden' | translate
-        }
+        },
+        "current-password"
     ) }}
 <p class="govuk-body">
     <a href="/reset-password-request" class="govuk-link" rel="noreferrer noopener">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>


### PR DESCRIPTION
## What?

This PR:

* Updates the `govukInputWithShowPassword` and `govukInputWithShowPasswordWithLabelAsPageHeading` Nunjucks macros to permit the inclusion of an `autocomplete` attribute
* Passes "current-password" to the call in `index-account-exists.njk`

Note: I have tested that the macro update does not impact calls where no `autocomplete` argument is passed. These simply ignore it.

## Why?

This addresses a WCAG 2.1 Level AA failure relating to the password field on "You have a GOV.UK account". 
