### PR TITLE
BAU: Switch on frontend auto scaling in production

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -1,7 +1,12 @@
 environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
-ecs_desired_count   = 4
 redis_node_size     = "cache.m4.xlarge"
+
+frontend_auto_scaling_enabled   = true
+frontend_task_definition_cpu    = 512
+frontend_task_definition_memory = 1024
+frontend_auto_scaling_min_count = 4
+frontend_auto_scaling_max_count = 12
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",


### PR DESCRIPTION
## What?

Switch on frontend auto scaling in production.

## Why?

Scale down but scale out.
CPU is peaking at 7.5%.
Memory is static under 7%.
This leaves ample headroom to scale down even without scaling out. Keep minimum 4 instances so at least one per AZ.  Can look to reduce this to 3.

Auto scaling is already enabled in the test environments, and proven in build by running the performance tests to make it scale.


<img width="1394" alt="Screenshot 2022-10-07 at 15 07 50" src="https://user-images.githubusercontent.com/38218115/194573171-a8e62c12-2e4f-437b-8448-0387222d01ca.png">


