### PR TITLE
BAU: Set ecs desired count to equal auto scaling min count

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -7,6 +7,7 @@ frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 frontend_auto_scaling_min_count = 4
 frontend_auto_scaling_max_count = 12
+ecs_desired_count               = 4
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",


### PR DESCRIPTION
## What?

BAU: Set ecs desired count to equal auto scaling min count.

1 of 2, next PR will tell Terraform to ignore external changes, but need to update the value first otherwise it will be ignored.

## Why?

Terraform has reset the service to the default as it had been changed by Fargate and did not match the Terraform state.

This happend during a deployment at 11.54

```
Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  aws_ecs_service.frontend_ecs_service has been changed
  ~ resource "aws_ecs_service" "frontend_ecs_service" {
      ~ desired_count                      = 2 -> 4
        id                                 = "arn:aws:ecs:eu-west-2:172348255554:service/production-app-cluster/production-frontend-ecs-service"
        name                               = "production-frontend-ecs-service"
        tags                               = {
            "application" = "auth-frontend"
            "environment" = "production"
        }
         (14 unchanged attributes hidden)

Terraform will perform the following actions:

   aws_ecs_service.frontend_ecs_service will be updated in-place
  ~ resource "aws_ecs_service" "frontend_ecs_service" {
      ~ desired_count                      = 4 -> 2
        id                                 = "arn:aws:ecs:eu-west-2:172348255554:service/production-app-cluster/production-frontend-ecs-service"
        name                               = "production-frontend-ecs-service"
        tags                               = {
            "application" = "auth-frontend"
            "environment" = "production"
        }
         (14 unchanged attributes hidden)

         (4 unchanged blocks hidden)
    }

```
## Related PRs

#789 
