### PR TITLE
BAU: Tell Terraform to ignore external changes to ecs desired count

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -170,6 +170,10 @@ resource "aws_ecs_service" "frontend_ecs_service" {
   desired_count   = var.ecs_desired_count
   launch_type     = "FARGATE"
 
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
   deployment_minimum_healthy_percent = var.deployment_min_healthy_percent
   deployment_maximum_percent         = var.deployment_max_percent
   health_check_grace_period_seconds  = var.health_check_grace_period_seconds


### PR DESCRIPTION
## What?

Tell Terraform to ignore external changes to ecs desired count.

## Why?

So that it won't overwrite changes made by the autoscaler.

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#ignoring-changes-to-desired-count

## Related PRs

PR 2 / 2

#793 
#789 