### PR TITLE
AUT-779: Add autocomplete attribute to OTP input

### DIFF
--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -34,6 +34,7 @@
     classes: "govuk-input--width-10",
     inputmode: "numeric",
     spellcheck: false,
+    autocomplete: "one-time-code",
     errorMessage: {
         text: errors['code'].text
     } if (errors['code'])})


### PR DESCRIPTION
## What?

Adds the "one-time-code" `autocomplete` attribute to the field users enter their OTP.

## Why?

Fixes a WCAG 2.1 failure of Success Criterion 1.3.5