### PR TITLE
AUT-782: Add autocomplete attribute to fix WCAG failure

### DIFF
--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -35,7 +35,8 @@
             hideFullText: 'general.showPassword.hideFullText' | translate,
             announceShown: 'general.showPassword.announceShown' | translate,
             announceHidden: 'general.showPassword.announceHidden' | translate
-        }
+        },
+        'new-password'
     ) }}
 
     {{ govukInputWithShowPassword(
@@ -49,7 +50,8 @@
             hideFullText: 'general.showPassword.hideFullText' | translate,
             announceShown: 'general.showPassword.announceShown' | translate,
             announceHidden: 'general.showPassword.announceHidden' | translate
-        }
+        },
+        'new-password'
     ) }}
 
 {{ govukDetails({


### PR DESCRIPTION
## What?

Adds "new-password" to the Nunjucks call which results in `autocomplete="new-password"` attribute being included in the HTML for password and password confirmation fields presented during account creation.

## Why?

Fixes a failure of WCAG Success Criterion 1.3.5 Identify Input Purpose.
