### PR TITLE
AUT-787: Update autocomplete to fix WCAG issue on auth app setup page

### DIFF
--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -55,7 +55,7 @@
   name: "code",
   inputmode: "numeric",
   spellcheck: false,
-  autocomplete:"off",
+  autocomplete: "one-time-code",
   errorMessage: {
   text: errors['code'].text
   } if (errors['code'])})


### PR DESCRIPTION
## What?

Update `autocomplete` attribute to indicate input purpose as "one-time-code".

## Why?

Fixes a failure of Success Criterion 1.3.5 by identifying the input purpose
