### PR TITLE
BAU - Fix bug so auth app mfa screen isn't shown during low level journeys

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -164,12 +164,12 @@ const authStateMachine = createMachine(
         on: {
           [USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED]: [
             {
-              target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
-              cond: "requiresMFAAuthAppCode",
-            },
-            {
               target: [PATH_NAMES.GET_SECURITY_CODES],
               cond: "isAccountPartCreated",
+            },
+            {
+              target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
+              cond: "requiresMFAAuthAppCode",
             },
             { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
             {
@@ -297,12 +297,12 @@ const authStateMachine = createMachine(
         on: {
           [USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED]: [
             {
-              target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
-              cond: "requiresMFAAuthAppCode",
-            },
-            {
               target: [PATH_NAMES.GET_SECURITY_CODES],
               cond: "isAccountPartCreated",
+            },
+            {
+              target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
+              cond: "requiresMFAAuthAppCode",
             },
             { target: [PATH_NAMES.ENTER_MFA], cond: "requiresTwoFactorAuth" },
             {
@@ -547,7 +547,7 @@ const authStateMachine = createMachine(
         context.isAuthenticated === false,
       requiresMFAAuthAppCode: (context) =>
         context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP &&
-        context.isMfaMethodVerified === true,
+        context.requiresTwoFactorAuth === true,
     },
   }
 );


### PR DESCRIPTION
## What?

-  - Fix bug so auth app mfa screen isn't shown during low level journeys
- Change the state machine so that the condition for requiresMFAAuthAppCode checks thats the journey requiresTwoFactorAuth.

## Why?

- If a user logs into a low level service with auth app as their 2fa method then they are shown the enter mfa screen. They not be shown this screen but be logged in instead.

