### PR TITLE
AUT-788: Set OTP field autocomplete attribute to use "one-time-code"

### DIFF
--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -34,7 +34,7 @@
   name: "code",
   inputmode: "numeric",
   spellcheck: false,
-  autocomplete:"off",
+  autocomplete:"one-time-code",
   errorMessage: {
   text: errors['code'].text
   } if (errors['code'])})


### PR DESCRIPTION
## What?

Changes `autocomplete` attribute from `"off"` to `"one-time-code"`.

## Why?

Fixes a WCAG 2.1 Level AA failure by identifying the input purpose. It's not clear why we would have set this to be `"off"` as I can't find a reference to this in Jira and have asked on the Slack channel. 
