### PR TITLE
AUT-790: Permit reflow of user's email address

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -183,6 +183,6 @@
   text-align: center;
 }
 
-#secret-key {
+.permit-reflow {
   word-break: break-all;
 }

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -14,7 +14,7 @@
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourEmail.header' | translate}}</h1>
 
   {{ govukInsetText({
-    html: 'pages.checkYourEmail.text' | translate + '<span class="govuk-body govuk-!-font-weight-bold">' + email + '</span>'
+    html: 'pages.checkYourEmail.text' | translate + '<span class="govuk-body govuk-!-font-weight-bold permit-reflow">' + email + '</span>'
   }) }}
 
   <p class="govuk-body">{{'pages.checkYourEmail.info.paragraph1' | translate}}</p>

--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -33,7 +33,7 @@
 
   <p class="govuk-body">
     {{ 'pages.setupAuthenticatorApp.secretKeyLabelText' | translate }}
-    <span id="secret-key" class="govuk-body govuk-!-font-weight-bold">{{secretKey}}</span>
+    <span id="secret-key" class="govuk-body govuk-!-font-weight-bold permit-reflow">{{secretKey}}</span>
   </p>
   <p class="govuk-body">{{'pages.setupAuthenticatorApp.step3' | translate }}</p>
   <p class="govuk-body">{{'pages.setupAuthenticatorApp.step4' | translate }}</p>


### PR DESCRIPTION
## What?

Introduces CSS to make an accessibility enhancement picked up during recent testing. Rather than duplicating the existing CSS rule the extracts the necessary CSS to a utility class for reuse where needed.

## Why?

Accessibility enhancement to allow user's email address to reflow at high zoom levels on narrow screens. 
