### PR TITLE
AUT-791: Update email field to use GOV.UK pattern

### DIFF
--- a/src/components/enter-email/index-existing-account.njk
+++ b/src/components/enter-email/index-existing-account.njk
@@ -24,6 +24,9 @@
     id: "email",
     name: "email",
     value: email,
+    type: "email",
+    autocomplete: "email",
+    spellcheck: false,
     errorMessage: {
         text: errors['email'].text
     } if (errors['email'])})


### PR DESCRIPTION
## What?

This change:

* introduces `autocomplete="email"` to fix a WCAG 1.3.5 failure
* introduces the correct type and spellcheck attributes (as set out in the Design System)

## Why?

Fixes a WCAG failure and brings the component in line with the GOV.UK Design System.

