### PR TITLE
ACI-88: Display email following validation error

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -89,7 +89,8 @@ export function enterPasswordPost(
         fromAccountExists
           ? ENTER_PASSWORD_ACCOUNT_EXISTS_TEMPLATE
           : ENTER_PASSWORD_TEMPLATE,
-        error
+        error,
+        { email }
       );
     }
 


### PR DESCRIPTION
## What?

Passes the email from the session through as a `postValidationLocal` so that it is available to the view at the time of render. This is more 'backend' than I'm used to so grateful for any feedback on how I've achieved this. 

## Why?

Fixes a bug where the address is not shown.
