### PR TITLE
AUT-795: Add autocomplete attribute to OTP field

### DIFF
--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -23,7 +23,7 @@
     name: "code",
     inputmode: "numeric",
     spellcheck: false,
-    autocomplete:"off",
+    autocomplete:"one-time-code",
     errorMessage: {
       text: errors['code'].text
     } if (errors['code'])})


### PR DESCRIPTION
## What?

Adds an autocomplete attribute to the OTP field presented in the Sign In journey. It's not clear why we would have set this to be "off" as I can't find a reference to this in Jira and have asked on the Slack channel.

## Why?

Fixes a WCAG 2.1 Level AA failure by indicating the input purpose to user agents and assistive technology. 
