### PR TITLE
AUT-793: Add autocomplete to current password field

### DIFF
--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -26,7 +26,8 @@
         hideFullText: 'general.showPassword.hideFullText' | translate,
         announceShown: 'general.showPassword.announceShown' | translate,
         announceHidden: 'general.showPassword.announceHidden' | translate
-    }
+    },
+    "current-password"
 ) }}
 
 <p class="govuk-body">


### PR DESCRIPTION
## What?

Adds `autocomplete="current-password"` to password field in Sign In journey.

## Why?

Fixes a WCAG 2.1 Level AA failure by identifying the input purpose (Success Criterion 1.3.5)
