### PR TITLE
AUT-689: Remove lang from cookie description to reflect cookies available

### DIFF
--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -272,20 +272,6 @@
       text: 'pages.cookiePolicy.settingsCookies.table.rows.row1.col3' | translate,
       classes: 'govuk-body-s'
     }
-    ],
-    [
-    {
-      text: "lang",
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.settingsCookies.table.rows.row2.col2' | translate,
-      classes: 'govuk-body-s'
-    },
-    {
-      text: 'pages.cookiePolicy.settingsCookies.table.rows.row2.col3' | translate,
-      classes: 'govuk-body-s'
-    }
     ]
   ]
 }) }}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -673,10 +673,6 @@
             "row1": {
               "col2": "Cofio'r iaith rydych yn defnyddio'r cyfrif ynddi",
               "col3": "1 flwyddyn"
-            },
-            "row2": {
-              "col2": "Cofio'r iaith rydych yn defnyddio'r cyfrif ynddi",
-              "col3": "Pan fyddwch yn cau eich porwr gwe"
             }
           }
         }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -673,10 +673,6 @@
             "row1": {
               "col2": "Remembers the language you use the account in",
               "col3": "1 year"
-            },
-            "row2": {
-              "col2": "Remembers the language you use the account in",
-              "col3": "When you close your web browser"
             }
           }
         }


### PR DESCRIPTION
## What?

Remove the `lang` row from cookie description

## Why?

This reflects the cookies available for clients
