### PR TITLE
BAU - Fix Auth App uplift scenario

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -76,6 +76,10 @@ const authStateMachine = createMachine(
               cond: "isIdentityRequired",
             },
             { target: [PATH_NAMES.ENTER_PASSWORD], cond: "requiresLogin" },
+            {
+              target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
+              cond: "requiresAuthAppUplift",
+            },
             { target: [PATH_NAMES.UPLIFT_JOURNEY], cond: "requiresUplift" },
             {
               target: [PATH_NAMES.SHARE_INFO],
@@ -110,6 +114,10 @@ const authStateMachine = createMachine(
             {
               target: [PATH_NAMES.ENTER_PASSWORD],
               cond: "requiresLogin",
+            },
+            {
+              target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
+              cond: "requiresAuthAppUplift",
             },
             { target: [PATH_NAMES.UPLIFT_JOURNEY], cond: "requiresUplift" },
             { target: [PATH_NAMES.PROVE_IDENTITY] },
@@ -534,6 +542,10 @@ const authStateMachine = createMachine(
         context.isLatestTermsAndConditionsAccepted === false,
       requiresUplift: (context) =>
         context.requiresUplift === true && context.isAuthenticated === true,
+      requiresAuthAppUplift: (context) =>
+        context.requiresUplift === true &&
+        context.isAuthenticated === true &&
+        context.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP,
       requiresTwoFactorAuth: (context) =>
         context.requiresTwoFactorAuth === true,
       isAccountPartCreated: (context) => context.isMfaMethodVerified === false,


### PR DESCRIPTION
## What?

-  Fix Auth App uplift scenario

## Why?

- When a user has auth apps as their 2FA method and logs into a low level service and then goes to uplift to a medium low level service the user gets a 500.
- This happens because the frontend attempts to call the MfaHandler which attempts to send the user an sms text. What should actually happen is the user should be displayed with a screen to enter their auth app code. Change the state machine to show the user the correct page in this scenario by adding a new condition.
