### PR TITLE
AUT-802 - Receive MfaMethodType from the /start endpoint

### DIFF
--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -95,6 +95,7 @@ export function landingGet(
         isAuthenticated: req.session.user.isAuthenticated,
         prompt: req.session.client.prompt,
         skipAuthentication: req.session.user.docCheckingAppUser,
+        mfaMethodType: startAuthResponse.data.user.mfaMethodType,
       },
       sessionId
     );

--- a/src/components/landing/tests/landing-controller.test.ts
+++ b/src/components/landing/tests/landing-controller.test.ts
@@ -102,7 +102,7 @@ describe("landing controller", () => {
       expect(res.redirect).to.have.calledWith(PATH_NAMES.SIGN_IN_OR_CREATE);
     });
 
-    it("should redirect to /uplift page when uplift query param set", async () => {
+    it("should redirect to /uplift page when uplift query param set and MfaType is SMS", async () => {
       const fakeLandingService: LandingServiceInterface = {
         start: sinon.fake.returns({
           data: {
@@ -112,7 +112,11 @@ describe("landing controller", () => {
               clientName: "Test client",
               cookieConsentShared: true,
             },
-            user: { upliftRequired: true, authenticated: true },
+            user: {
+              upliftRequired: true,
+              authenticated: true,
+              mfaMethodType: "SMS",
+            },
           },
           success: true,
         }),
@@ -129,6 +133,41 @@ describe("landing controller", () => {
       );
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.UPLIFT_JOURNEY);
+    });
+
+    it("should redirect to /enter-authenticator-app-code page when uplift query param set and MfaMethodType is AUTH_APP", async () => {
+      const fakeLandingService: LandingServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            client: {
+              scopes: ["openid", "profile"],
+              serviceType: "MANDATORY",
+              clientName: "Test client",
+              cookieConsentShared: true,
+            },
+            user: {
+              upliftRequired: true,
+              authenticated: true,
+              mfaMethodType: "AUTH_APP",
+            },
+          },
+          success: true,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await landingGet(fakeLandingService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(
+        PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE
+      );
     });
 
     it("should redirect to /auth-code when existing session", async () => {

--- a/src/components/landing/types.ts
+++ b/src/components/landing/types.ts
@@ -22,6 +22,7 @@ export interface UserSessionInfo {
   cookieConsent?: string;
   gaCrossDomainTrackingId?: string;
   docCheckingAppUser: boolean;
+  mfaMethodType?: string;
 }
 
 export interface LandingServiceInterface {


### PR DESCRIPTION
## What?

- Receive MfaMethodType from the /start endpoint
- Add additional tests.

## Why?

- We were currently using the MfaMethodType in the state machine but this was not being returned from the start handler. Now that it is we need to ensure it is populated in the context.