### PR TITLE
BAU: Add a second stub launcher for no MFA

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       context: .
       dockerfile: local.Dockerfile
     ports:
-      - 3000:3000
-      - 9230:9230
+      - "3000:3000"
+      - "9230:9230"
     volumes:
       - ./:/app
     environment:
@@ -30,18 +30,18 @@ services:
   redis:
     image: redis:6.0.5-alpine
     ports:
-      - 6389:6379
+      - "6389:6379"
     networks:
       - di-net
 
-  di-auth-stub:
+  di-auth-stub-default:
     build:
       context: .
       dockerfile: Dockerfile-stub
     links:
       - di-auth-frontend
     ports:
-      - 2000:2000
+      - "2000:2000"
     environment:
       - ENVIRONMENT=${ENVIRONMENT}
       - API_BASE_URL=${API_BASE_URL}
@@ -49,6 +49,28 @@ services:
       - TEST_CLIENT_ID=${TEST_CLIENT_ID}
       - STUB_HOSTNAME=${STUB_HOSTNAME}
       - UI_LOCALES=${UI_LOCALES}
+      - PORT=2000
+    restart: on-failure
+    networks:
+      - di-net
+
+  di-auth-stub-no-mfa:
+    build:
+      context: .
+      dockerfile: Dockerfile-stub
+    links:
+      - di-auth-frontend
+    ports:
+      - "5000:5000"
+    environment:
+      - ENVIRONMENT=${ENVIRONMENT}
+      - API_BASE_URL=${API_BASE_URL}
+      - FRONTEND_API_BASE_URL=${FRONTEND_API_BASE_URL}
+      - TEST_CLIENT_ID=${TEST_CLIENT_ID}
+      - STUB_HOSTNAME=${STUB_HOSTNAME}
+      - UI_LOCALES=${UI_LOCALES}
+      - VTR=["Cl"]
+      - PORT=5000
     restart: on-failure
     networks:
       - di-net


### PR DESCRIPTION
## What?

- Add a second stub for local testing that requests no MFA
- Ensure new nonce and state values each time

## Why?

Eases local testing allowing you to have different stub launchers with different VTRs without needing to restart