### PR TITLE
BAU: Add Welsh version of untranslated paragraph

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1551,7 +1551,7 @@
         "paragraph2": "Fe allwch wedyn naill ai:",
         "listItem2_1": "llwytho llun o’ch ID gyda llun gan ddefnyddio’r ap <span lang=\"en\">GOV.UK ID Check</span> (dim ond yn Saesneg y mae’r ap ar gael ar hyn o bryd)",
         "listItem2_2": "rhoi y manylion o'ch ID gyda llun ac ateb rai cwestiynau diogelwch mai dim ond chi ddylai wybod yr atebion iddynt",
-        "paragraph3": "We'll only use the information you give us to make sure that you are who you say you are."
+        "paragraph3": "Byddwn ond yn defnyddio'r wybodaeth rydych yn ei rhoi i ni i wneud yn siwr mai chi yw pwy rydych yn ei ddweud ydych chi."
       },
       "section3": {
         "subHeading": "Dewiswch ffordd i brofi pwy ydych chi",


### PR DESCRIPTION
## What?

Update `translation.json` file.

## Why?

Welsh translation file included untranslated English content.
