### PR TITLE
AUT-824: Fix international phone number validation rule

### DIFF
--- a/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
@@ -18,6 +18,8 @@ import {
   ResponseOutput,
 } from "mock-req-res";
 
+const OLD_ENV = process.env;
+
 describe("enter phone number controller", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
@@ -29,14 +31,18 @@ describe("enter phone number controller", () => {
       log: { info: sinon.fake() },
     });
     res = mockResponse();
+    process.env = { ...OLD_ENV };
   });
 
   afterEach(() => {
     sinon.restore();
+    process.env = OLD_ENV;
   });
 
   describe("enterPhoneNumberGet", () => {
     it("should render enter phone number view", () => {
+      process.env.SUPPORT_INTERNATIONAL_NUMBERS = "1";
+
       enterPhoneNumberGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("enter-phone-number/index.njk", {
@@ -46,6 +52,8 @@ describe("enter phone number controller", () => {
     });
 
     it("should render enter phone number returning user view when user has a partly created account", () => {
+      process.env.SUPPORT_INTERNATIONAL_NUMBERS = "1";
+
       req.session.user = {
         isAccountPartCreated: true,
       };

--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -1,4 +1,7 @@
-import { isValidPhoneNumber } from "libphonenumber-js/mobile";
+import {
+  isValidPhoneNumber,
+  parsePhoneNumberWithError,
+} from "libphonenumber-js/mobile";
 
 const ALLOWED_TEST_NUMBERS = [
   "07700900000",
@@ -10,10 +13,15 @@ const ALLOWED_TEST_NUMBERS = [
 ];
 
 export function containsUKMobileNumber(value: string): boolean {
-  return (
-    ALLOWED_TEST_NUMBERS.includes(value) ||
-    (isValidPhoneNumber(value, "GB") && /^([+?44]{2}|[07]{2}).*$/.test(value))
-  );
+  try {
+    return (
+      ALLOWED_TEST_NUMBERS.includes(value) ||
+      (isValidPhoneNumber(value, "GB") &&
+        parsePhoneNumberWithError(value, "GB").countryCallingCode === "44")
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function containsInternationalMobileNumber(value: string): boolean {

--- a/test/unit/utils/phone-number.test.ts
+++ b/test/unit/utils/phone-number.test.ts
@@ -25,6 +25,10 @@ describe("phone-number", () => {
       expect(containsUKMobileNumber("07911 123456")).to.equal(true);
     });
 
+    it("should return true when Isle of Man phone number entered", () => {
+      expect(containsUKMobileNumber("+44 7624 311111")).to.equal(true);
+    });
+
     it("should return false when invalid UK mobile phone number entered", () => {
       expect(containsUKMobileNumber("06911123456")).to.equal(false);
     });
@@ -71,6 +75,10 @@ describe("phone-number", () => {
 
     it("should return false when starting with +33 without 0", () => {
       expect(containsUKMobileNumber("+33645453322")).to.equal(false);
+    });
+
+    it("should return false when starting with 0033", () => {
+      expect(containsUKMobileNumber("0033 645453322")).to.equal(false);
     });
 
     it("should return false when only a single 4 is present", () => {


### PR DESCRIPTION
## What?
- Regex had previously accepted any phone number where first two numbers were 0 or 7.
- This includes many common international phone number formats e.h. 0033 for France.
- We are now relying on functions from our supporting library instead of regex to determine if a phone number is a UK one
- Note that we use country code rather than specifying country as GB, so as not to exclude Isle of Man and similar.

## Why?

- Whilst support international phone numbers feature flag is toggled to off ("0"), we do not wish to allow users to register with international phone numbers.