### PR TITLE
PYIC-2128: Update app name

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1560,7 +1560,7 @@
           "linkHref": "?lng=en"
         },
         "insetTextEnglishOnly": "Ar hyn o bryd dim ond yn Saesneg mae’r gwasanaeth hwn ar gael.",
-        "insetAlternativeLanguageAppWarning": "Mae’r ap <span lang=\"en\">GOV.UK ID Check</span> ond ar gael yn Saesneg yn unig ar hyn o bryd."
+        "insetAlternativeLanguageAppWarning": "Mae’r ap <span lang=\"en\">GOV.UK One Login</span> ond ar gael yn Saesneg yn unig ar hyn o bryd."
       },
       "section2": {
         "paragraph1": "Byddwch angen:",
@@ -1568,7 +1568,7 @@
         "listItem1_2": "eich cyfeiriad presennol (efallai y byddwch angen eich cyfeiriad blaenorol hefyd os ydych wedi symud yn ddiweddar)",
         "listItem1_3": "eich ID gyda llun",
         "paragraph2": "Fe allwch wedyn naill ai:",
-        "listItem2_1": "llwytho llun o’ch ID gyda llun gan ddefnyddio’r ap <span lang=\"en\">GOV.UK ID Check</span> (dim ond yn Saesneg y mae’r ap ar gael ar hyn o bryd)",
+        "listItem2_1": "llwytho llun o’ch ID gyda llun gan ddefnyddio’r ap <span lang=\"en\">GOV.UK One Login</span> (dim ond yn Saesneg y mae’r ap ar gael ar hyn o bryd)",
         "listItem2_2": "rhoi y manylion o’ch ID gyda llun ac ateb rai cwestiynau diogelwch mai dim ond chi ddylai wybod yr atebion iddynt",
         "paragraph3": "Byddwn ond yn defnyddio’r wybodaeth rydych yn ei rhoi i ni i wneud yn siwr mai chi yw pwy rydych yn ei ddweud ydych chi."
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1561,7 +1561,7 @@
           "linkHref": "?lng=cy"
         },
         "insetTextEnglishOnly": "This service is currently only available in English.",
-        "insetAlternativeLanguageAppWarning": "The GOV.UK ID Check app is currently only available in English."
+        "insetAlternativeLanguageAppWarning": "The GOV.UK One Login app is currently only available in English."
       },
       "section2": {
         "paragraph1": "You’ll need:",
@@ -1569,7 +1569,7 @@
         "listItem1_2": "your current home address (you might also need your previous address if you’ve recently moved)",
         "listItem1_3": "your photo ID",
         "paragraph2": "You can then either:",
-        "listItem2_1": "upload a picture of your photo ID using the GOV.UK ID Check app (the app is currently only available in English)",
+        "listItem2_1": "upload a picture of your photo ID using the GOV.UK One Login app (the app is currently only available in English)",
         "listItem2_2": "enter details from your photo ID and answer some security questions that only you should know the answer to",
         "paragraph3": "We’ll only use the information you give us to make sure that you are who you say you are."
       },


### PR DESCRIPTION
## What?

Updated the app name to be GOV.UK One Login

## Why?

The App Team will be changing the name of the app to 
GOV.UK One Login this week, so we will need to update mentions of the app in our part of the journey.


