### PR TITLE
BAU: Switch on Welsh in integration

### DIFF
--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -5,6 +5,8 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
+support_language_cy = "1"
+
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]


### PR DESCRIPTION
## What?

Switch on Welsh in integration.

## Why?

DBS called-out that it was not switched-on.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2471
