### PR TITLE
PYIC-2135 Update content on no-photo-id unhappy path

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1649,7 +1649,7 @@
       },
       "section2": {
         "subHeading" : "What you can do",
-        "paragraph1" : "If your passport has expired, you can still use it to prove your identity up until 18 months after the expiry date."
+        "paragraph1" : "Continue to the service you were trying to use and look for other ways to prove your identity."
       }
     },
     "securityCodeEnteredExceeded": {


### PR DESCRIPTION
## What?

One value in `en/translation.json` has been updated.

## Why?

This change removes misleading content for the user.
