### PR TITLE
AUT-707: Remove url dimension from all-get-requests-with-language-dimension metric

### DIFF
--- a/ci/terraform/cloudwatch.tf
+++ b/ci/terraform/cloudwatch.tf
@@ -79,8 +79,7 @@ resource "aws_cloudwatch_log_metric_filter" "get_requests_filter" {
     name      = "${var.environment}-all-get-requests-with-language-dimension"
     namespace = "Authentication"
     dimensions = {
-      language = "$.res.languageFromCookie",
-      urlPath  = "$.req.url"
+      language = "$.res.languageFromCookie"
     }
     value = "1"
   }


### PR DESCRIPTION


## What?

Remove url dimension from all-get-requests-with-language-dimension metric
## Why?

Grafana + Cloudwatch restrictions mean it's difficult to report or chart when there are so many values in a dimension.  This will simplify the metric so we can show some meaningful numbers.

## Related PRs

#822 
