### PR TITLE
AUT-707: Tweak metric filter query tracking language changes

### DIFF
--- a/ci/terraform/cloudwatch.tf
+++ b/ci/terraform/cloudwatch.tf
@@ -87,7 +87,7 @@ resource "aws_cloudwatch_log_metric_filter" "get_requests_filter" {
 
 resource "aws_cloudwatch_log_metric_filter" "language_change_events_filter" {
   name           = "${var.environment}-language-change-events"
-  pattern        = "{$.req.method = \"GET\" && $.req.url = \"*lng*\" && $.req.url != \"/healthcheck/\"}"
+  pattern        = "{$.req.method = \"GET\" && $.req.url = \"*lng=\" && $.req.url != \"/healthcheck/\"}"
   log_group_name = aws_cloudwatch_log_group.ecs_frontend_task_log.name
 
   metric_transformation {


### PR DESCRIPTION


## What?

Tweak metric filter query tracking language changes.

## Why?

Current query is picking /contact-us-questions submits where the language change page is the referrer, for example:

contact-us-questions?theme=proving_identity&referer=https%3A%2F%2Fsignin.account.gov.uk%2Fsign-in-or-create%3Flng%3Den


