### PR TITLE
ACI-11: Display different "Account Not Found" page for internal services

### DIFF
--- a/src/components/account-not-found/account-not-found-controller.ts
+++ b/src/components/account-not-found/account-not-found-controller.ts
@@ -10,9 +10,14 @@ import {
 } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import xss from "xss";
+import { getServiceSignInLink } from "../../config";
 
 export function accountNotFoundGet(req: Request, res: Response): void {
-  if (req.session.client.serviceType === SERVICE_TYPE.OPTIONAL) {
+  if (req.session.client.isOneLoginService) {
+    res.render("account-not-found/index-one-login.njk", {
+      email: req.session.user.email,
+    });
+  } else if (req.session.client.serviceType === SERVICE_TYPE.OPTIONAL) {
     res.render("account-not-found/index-optional.njk");
   } else {
     res.render("account-not-found/index-mandatory.njk", {
@@ -25,6 +30,10 @@ export function accountNotFoundPost(
   service: SendNotificationServiceInterface = sendNotificationService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
+    if (req.body.optionSelected === "sign-in-to-a-service") {
+      return res.redirect(getServiceSignInLink());
+    }
+
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
 
     const result = await service.sendNotification(

--- a/src/components/account-not-found/index-one-login.njk
+++ b/src/components/account-not-found/index-one-login.njk
@@ -1,0 +1,49 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% set showBack = true %}
+{% set hrefBack = 'enter-email' %}
+{% set pageTitleName = 'pages.accountNotFoundOneLogin.title' | translate %}
+
+{% block content %}
+
+{% include "common/errors/errorSummary.njk" %}
+
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.accountNotFoundOneLogin.header' | translate}}</h1>
+
+<form action="/account-not-found" method="post" novalidate>
+
+<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+<p class="govuk-body">
+    {{ 'pages.accountNotFoundOneLogin.paragraph1' | translate }}
+    <span class="govuk-body govuk-!-font-weight-bold">{{email}}</span>
+</p>
+
+{% set insetTextHtml %}
+<p class="govuk-body">{{'pages.accountNotFoundOneLogin.insetText1' | translate}}</p>
+{% endset %}
+
+{{ govukInsetText({
+    html: insetTextHtml
+  }) }}
+
+<p class="govuk-body">
+    {{ 'pages.accountNotFoundOneLogin.paragraph2' | translate }}
+</p>
+
+{{ govukButton({
+    "text": button_text|default('pages.accountNotFoundOneLogin.signInToServiceButtonText' | translate, true),
+    "value": "sign-in-to-a-service",
+    "name": "optionSelected",
+    "preventDoubleClick": true
+}) }}
+
+<p class="govuk-body">
+    <a href="/enter-email" class="govuk-link" rel="noreferrer noopener">{{'pages.accountNotFoundOneLogin.tryAnotherLinkText' | translate }}</a>
+</p>
+
+</form>
+
+{% endblock %}
+

--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -70,6 +70,8 @@ export function landingGet(
     req.session.client.prompt = loginPrompt;
     req.session.client.redirectUri = startAuthResponse.data.client.redirectUri;
     req.session.client.state = startAuthResponse.data.client.state;
+    req.session.client.isOneLoginService =
+      startAuthResponse.data.client.isOneLoginService;
 
     req.session.user.isIdentityRequired =
       startAuthResponse.data.user.identityRequired;

--- a/src/components/landing/types.ts
+++ b/src/components/landing/types.ts
@@ -12,6 +12,7 @@ export interface ClientInfo {
   cookieConsentShared: boolean;
   redirectUri: string;
   state: string;
+  isOneLoginService?: boolean;
 }
 
 export interface UserSessionInfo {

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,3 +112,7 @@ export function getAnalyticsCookieDomain(): string {
 export function getServiceDomain(): string {
   return process.env.SERVICE_DOMAIN;
 }
+
+export function getServiceSignInLink(): string {
+  return process.env.SERVICE_SIGN_IN_LINK || "https://www.gov.uk/sign-in";
+}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -195,6 +195,16 @@
         "bulletPoint2": "rhif ffôn y DU sy'n gweithio gyda signal, fel y gallwn anfon cod diogelwch atoch"
       }
     },
+    "accountNotFoundOneLogin": {
+      "title": "No GOV.UK account found",
+      "header": "No GOV.UK account found",
+      "paragraph1": "There is no GOV.UK account for ",
+      "insetText1": "GOV.UK accounts are new. At the moment, they are separate from other government accounts.",
+      "paragraph2": "If you’re trying to access your account for a government service, such as Universal Credit or your personal tax account, sign in to your account for that service.",
+      "signInToServiceButtonText": "Sign in to a service",
+      "tryAnotherLinkText": "Try another email address",
+      "tryAnotherLinkHref": "/enter-email-existing-account"
+    },
     "accountNotFoundMandatory": {
       "title": "Ni ddarganfyddwyd cyfrif GOV.UK",
       "header": "Ni ddarganfyddwyd cyfrif GOV.UK",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -195,6 +195,16 @@
         "bulletPoint2": "a working UK phone number with signal, so we can send you a security code"
       }
     },
+    "accountNotFoundOneLogin": {
+      "title": "No GOV.UK account found",
+      "header": "No GOV.UK account found",
+      "paragraph1": "There is no GOV.UK account for ",
+      "insetText1": "GOV.UK accounts are new. At the moment, they are separate from other government accounts.",
+      "paragraph2": "If you’re trying to access your account for a government service, such as Universal Credit or your personal tax account, sign in to your account for that service.",
+      "signInToServiceButtonText": "Sign in to a service",
+      "tryAnotherLinkText": "Try another email address",
+      "tryAnotherLinkHref": "/enter-email-existing-account"
+    },
     "accountNotFoundMandatory": {
       "title": "No GOV.UK account found",
       "header": "No GOV.UK account found",

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,4 +58,5 @@ export interface UserSessionClient {
   prompt?: string;
   redirectUri?: string;
   state?: string;
+  isOneLoginService?: boolean;
 }


### PR DESCRIPTION
## What?

- If the service that sent the auth request is an internal One Login service (such as GOV.UK Accounts or Account Management) do no give the option to create an account.

## Why?

If a user has come from these accounts and does not have an account, the chances are that they have ended up there in error.

## Related PRs

TBC - there will be an accompanying API change that sets the `isOneLoginService` flag in the start response.