### PR TITLE
Set current password autocomplete to off

### DIFF
--- a/src/components/enter-password/index-account-exists.njk
+++ b/src/components/enter-password/index-account-exists.njk
@@ -36,7 +36,7 @@
             announceShown: 'general.showPassword.announceShown' | translate,
             announceHidden: 'general.showPassword.announceHidden' | translate
         },
-        "current-password"
+        "off"
     ) }}
 <p class="govuk-body">
     <a href="/reset-password-request" class="govuk-link" rel="noreferrer noopener">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -27,7 +27,7 @@
         announceShown: 'general.showPassword.announceShown' | translate,
         announceHidden: 'general.showPassword.announceHidden' | translate
     },
-    "current-password"
+    "off"
 ) }}
 
 <p class="govuk-body">


### PR DESCRIPTION
## What?

Set autocomplete for current password entry fields from `"current-password"` to `"off"`

## Why?

Following the passwords meeting on 8/11 we're exploring how different browsers respond to autocomplete attributes to validate that implementations are consistently "opt-in" and the extent to which modern browsers do not support `"off"` as an autocomplete value for login fields. 

Further information is provided in the ticket. 
