### PR TITLE
ACI-82: Update validity text for email OTP

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -369,7 +369,7 @@
       "info": {
         "paragraph1": "Mae'r e-bost yn cynnwys cod diogelwch 6 digid.",
         "paragraph2": "Efallai y bydd eich e-bost yn cymryd ychydig funudau i gyrraedd. Os na chewch e-bost, edrychwch ar eich ffolder spam.",
-        "paragraph3": "Bydd y cod yn dod i ben ar ôl 15 munud."
+        "paragraph3": "Bydd y cod yn dod i ben ar ôl 2 awr."
       },
       "code": {
         "label": "Rhowch y cod diogelwch 6 digid",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -369,7 +369,7 @@
       "info": {
         "paragraph1": "The email contains a 6 digit security code.",
         "paragraph2": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
-        "paragraph3": "The code will expire after 15 minutes."
+        "paragraph3": "The code will expire after 2 hours."
       },
       "code": {
         "label": "Enter the 6 digit security code",


### PR DESCRIPTION
## What?
- Update validity text for email OTP
- Applies only to email not SMS
- Applies only to account creation, not password reset
- Applies only to this repo, not the account management repo
- This scope was agreed as part of backend ticket ACI-76

## Why?
- The backend has already been changed to issue the same code for up to 2 hours in this scenario.
