### PR TITLE
ACI-23: Add translation.json for new error screen

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -111,6 +111,18 @@
         "govUKHomepageButtonHref": "https://www.gov.uk/",
         "govUKHomepageButtonText": "Ewch i hafan GOV.UK"
       }
+    },
+    "sessionRequiredMidJourneyError": {
+      "title": "Sorry, you cannot access your account from this page",
+      "header": "Sorry, you cannot access your account from this page",
+      "content": {
+        "paragraph1": {
+          "text1": "Go to your GOV.UK account",
+          "text2": ", or find the service you need from the ",
+          "text3": "GOV.UK homepage"
+        },
+        "govUKHomepageButtonHref": "https://www.gov.uk/"
+      }
     }
   },
   "pages": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -111,6 +111,18 @@
         "govUKHomepageButtonHref": "https://www.gov.uk/",
         "govUKHomepageButtonText": "Go to the GOV.UK homepage"
       }
+    },
+    "sessionRequiredMidJourneyError": {
+      "title": "Sorry, you cannot access your account from this page",
+      "header": "Sorry, you cannot access your account from this page",
+      "content": {
+        "paragraph1": {
+          "text1": "Go to your GOV.UK account",
+          "text2": ", or find the service you need from the ",
+          "text3": "GOV.UK homepage"
+        },
+        "govUKHomepageButtonHref": "https://www.gov.uk/"
+      }
     }
   },
   "pages": {


### PR DESCRIPTION
## What?

- Add translation.json for new error screen
- Screen will display when a user attempts to view a page that requires a session directly via the URL
- Note: CY text is English placeholder for now. Will replace with translation at earliest opportunity.

## Why?

- Needed for a new screen (PR for that to follow later)
