### PR TITLE
AUT-881: Push language to data layer

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -91,6 +91,20 @@ var cookies = function (trackingId, analyticsCookieDomain) {
     loadGtmScript();
     initGtm();
     initLinkerHandlers();
+    pushLanguageToDataLayer();
+  }
+
+  function pushLanguageToDataLayer() {
+    var language = document.querySelector('html') &&
+        document.querySelector('html').getAttribute('lang');
+
+    if (language) {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        event: "langEvent",
+        language: language
+      });
+    }
   }
 
   function loadGtmScript() {


### PR DESCRIPTION
## What?

Push the value of `lang` attribute where: 

* The user has consented to analytics 
* The `lang` attribute exists

## Why?

So Performance Analysts have access to the language of page views via analytics language 
