### PR TITLE
AUT-898 - The prompt param should be lower case

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -173,8 +173,8 @@ export const EXTERNAL_LINKS = {
 };
 
 export const OIDC_PROMPT = {
-  LOGIN: "LOGIN",
-  NONE: "NONE",
+  LOGIN: "login",
+  NONE: "none",
 };
 
 export const OIDC_ERRORS = {


### PR DESCRIPTION
## What?

- Make the prompts in our app.constants file lower case


## Why?

- As per the OIDC spec https://openid.net/specs/openid-connect-core-1_0.html. The prompt param consists of a list of " Space delimited, case sensitive list of ASCII string values that specifies whether the Authorization Server prompts the End-User for reauthentication and consent"