### PR TITLE
AUT-12: Add service name to account created page

### DIFF
--- a/src/components/account-created/index.njk
+++ b/src/components/account-created/index.njk
@@ -8,7 +8,7 @@
     
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.accountCreated.header' | translate}}</h1>
 
-<p class="govuk-body">{{'pages.accountCreated.text' | translate}}</p>
+<p class="govuk-body">{{'pages.accountCreated.text' | translate}} {{name}} {{'pages.accountCreated.textEnd' | translate}}</p>
 
 <form id="form-tracking" action="/account-created" method="post" novalidate>
 <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -373,7 +373,8 @@
     "accountCreated": {
       "title": "Rydych wedi creu eich cyfrif GOV.UK",
       "header": "Rydych wedi creu eich cyfrif GOV.UK",
-      "text": "Nawr ewch yn eich blaen i ddefnyddio’r gwasanaeth.",
+      "text": "Nawr ewch yn eich blaen i ddefnyddio’r ",
+      "textEnd": " gwasanaeth.",
       "inset": "Mae eich cynnydd ar ",
       "insetContinued": " wedi cael ei arbed.",
       "continue": "Parhau",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -371,9 +371,10 @@
       }
     },
     "accountCreated": {
-      "title": "You’ve created your GOV.UK account",
-      "header": "You’ve created your GOV.UK account",
-      "text": "Now continue to use the service.",
+      "title": "You've created your GOV.UK account",
+      "header": "You've created your GOV.UK account",
+      "text": "Now continue to use the ",
+      "textEnd": " service.",
       "inset": "Your progress on ",
       "insetContinued": " has been saved.",
       "continue": "Continue",


### PR DESCRIPTION
## What?

- Introduce a dynamic element on the ‘you’ve created your account’ screen, to show the user the name of the service the user came from.

## Why?

- To assist the user to understand what has happened, what will happen next and what they need to do.
