### PR TITLE
ACI-133 Remove stray space from link

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -42,8 +42,7 @@
     {{ 'pages.signInOrCreate.insetAlternativeLanguage.paragraph1' | translate }}
     <a href="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkHref' | translate }}" class="govuk-link" rel="noreferrer">
       {{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
-      <span lang="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span>
-    </a>.
+      <span lang="{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.signInOrCreate.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span></a>.
     {% endset %}
     {{ govukInsetText({
       html: altLangInsetHtml
@@ -66,8 +65,7 @@
 
     <p class="govuk-body">
       {{ 'pages.signInOrCreate.paragraph2' | translate }}
-      <a href="/sign-in-or-create?redirectPost=true" class="govuk-link" id="sign-in-link">{{ 'pages.signInOrCreate.signInText' | translate }}</a>
-      .
+      <a href="/sign-in-or-create?redirectPost=true" class="govuk-link" id="sign-in-link">{{ 'pages.signInOrCreate.signInText' | translate }}</a>.
     </p>
 
   </form>


### PR DESCRIPTION
## What?

Removes newline between closing`</span>` and the closing `</a>` that follows it

## Why?

The newline is being interpreted as a space and rendered as a blank space at the end of the link.
