### PR TITLE
BAU: Suppress non-LTS node.js versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     - dependabot
     ignore:
       - dependency-name: "node"
-        versions: ["17.x","18.x"]
+        versions: ["17.x","19.x","20.x"]
     commit-message:
       prefix: BAU
   - package-ecosystem: docker


### PR DESCRIPTION
## What?

Suppress non-LTS node.js versions.

## Why?

Would only like recommendations to patch our current version or move to the LTS.

