### PR TITLE
ACI-68: Simplify use of govukButton

### DIFF
--- a/src/components/account-created/index.njk
+++ b/src/components/account-created/index.njk
@@ -15,7 +15,7 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
     {{ govukButton({
-        "text": button_text|default('pages.accountCreated.continue' | translate, true),
+        "text": "pages.accountCreated.continue" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}
@@ -24,7 +24,7 @@
     <h1 class="govuk-body govuk-bold">{{'pages.accountCreated.progressSaved' | translate}}</h1>
 
     {{ govukButton({
-        "text": button_text|default('pages.accountCreated.continue' | translate, true),
+        "text": "pages.accountCreated.continue" | translate,
         "preventDoubleClick": true
     }) }}
 

--- a/src/components/account-not-found/index-mandatory.njk
+++ b/src/components/account-not-found/index-mandatory.njk
@@ -33,7 +33,7 @@
 </p>
 
 {{ govukButton({
-    "text": button_text|default('pages.accountNotFoundMandatory.createAccountButtonText' | translate, true),
+    "text": "pages.accountNotFoundOneLogin.signInToServiceButtonText" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/account-not-found/index-one-login.njk
+++ b/src/components/account-not-found/index-one-login.njk
@@ -33,7 +33,7 @@
 </p>
 
 {{ govukButton({
-    "text": button_text|default('pages.accountNotFoundOneLogin.signInToServiceButtonText' | translate, true),
+    "text": "pages.accountNotFoundOneLogin.signInToServiceButtonText" | translate,
     "value": "sign-in-to-a-service",
     "name": "optionSelected",
     "preventDoubleClick": true

--- a/src/components/account-not-found/index-optional.njk
+++ b/src/components/account-not-found/index-optional.njk
@@ -29,7 +29,7 @@
   }) }}
 
 {{ govukButton({
-    "text": button_text|default('pages.accountNotFoundOptional.createAccountButtonText' | translate, true),
+    "text": "pages.accountNotFoundOptional.createAccountButtonText" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -55,7 +55,7 @@
 }) }}
 
     {{ govukButton({
-    "text": button_text|default("general.continue.label" | translate, true),
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -65,7 +65,7 @@
     }) }}
 
     {{ govukButton({
-  "text": button_text|default('general.continue.label' | translate, true),
+  "text": "general.continue.label" | translate,
   "type": "Submit",
   "preventDoubleClick": true
   }) }}

--- a/src/components/common/errors/404.njk
+++ b/src/components/common/errors/404.njk
@@ -10,9 +10,9 @@
     <p class="govuk-body">{{'error.error404.content.paragraph2' | translate }}</p>
 
     {{ govukButton({
-    "text": button_text|default('error.error404.content.govUKHomepageButtonText' | translate, true),
+    "text": "error.error404.content.govUKHomepageButtonText" | translate,
     "type": "Submit",
-    "href": 'error.error404.content.govUKHomepageButtonHref' | translate
+    "href": "error.error404.content.govUKHomepageButtonHref" | translate
     }) }}
   </div>
 </div>

--- a/src/components/common/errors/session-expired.njk
+++ b/src/components/common/errors/session-expired.njk
@@ -10,9 +10,9 @@
 <p class="govuk-body">{{ 'error.timeoutError.content.paragraph2' | translate }}</p>
 
 {{ govukButton({
-"text": button_text|default('error.timeoutError.content.govUKHomepageButtonText' | translate, true),
+"text": "error.timeoutError.content.govUKHomepageButtonText" | translate,
 "type": "Submit",
-"href": 'error.timeoutError.content.govUKHomepageButtonHref' | translate
+"href": "error.timeoutError.content.govUKHomepageButtonHref" | translate
 }) }}
 
 {% endblock %}

--- a/src/components/contact-us/further-information/_account-creation-further-information.njk
+++ b/src/components/contact-us/further-information/_account-creation-further-information.njk
@@ -53,7 +53,7 @@
 
 
 {{ govukButton({
-    "text": button_text|default('general.continue.label' | translate, true),
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/further-information/_signing-in-further-information.njk
+++ b/src/components/contact-us/further-information/_signing-in-further-information.njk
@@ -54,11 +54,9 @@
 
 
 {{ govukButton({
-    "text": button_text|default('general.continue.label' | translate, true),
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}
 
 </form>
-
-

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -78,7 +78,7 @@
 
 
 {{ govukButton({
-    "text": button_text|default('general.continue.label' | translate, true),
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -35,7 +35,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -51,7 +51,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -48,7 +48,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_authenticator-app-problem.njk
+++ b/src/components/contact-us/questions/_authenticator-app-problem.njk
@@ -48,7 +48,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_email-subscriptions-questions.njk
+++ b/src/components/contact-us/questions/_email-subscriptions-questions.njk
@@ -48,7 +48,7 @@
 
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -35,7 +35,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -38,7 +38,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -38,7 +38,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -38,7 +38,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_no-uk-mobile-questions.njk
+++ b/src/components/contact-us/questions/_no-uk-mobile-questions.njk
@@ -35,7 +35,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_proving-identity-problem-questions.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-questions.njk
@@ -47,7 +47,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_signing-in-problem-questions.njk
+++ b/src/components/contact-us/questions/_signing-in-problem-questions.njk
@@ -35,7 +35,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_suggestion-feedback-questions.njk
+++ b/src/components/contact-us/questions/_suggestion-feedback-questions.njk
@@ -31,7 +31,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -61,7 +61,7 @@
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 
 {{ govukButton({
-    "text": button_text|default("general.sendMessage" | translate, true),
+    "text": "general.sendMessage" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -68,7 +68,7 @@
   </ul>
 
 {{ govukButton({
-    "text": button_text|default("general.continue.label" | translate, true),
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -30,7 +30,7 @@
   }}
 
     {{ govukButton({
-    "text": button_text|default('general.continue.label' | translate, true),
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
   }) }}

--- a/src/components/enter-email/index-create-account.njk
+++ b/src/components/enter-email/index-create-account.njk
@@ -33,7 +33,7 @@
 }}
 
 {{ govukButton({
-    "text": button_text|default("general.continue.label" | translate, true),
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/enter-email/index-existing-account.njk
+++ b/src/components/enter-email/index-existing-account.njk
@@ -33,7 +33,7 @@
 }}
 
 {{ govukButton({
-    "text": button_text|default("general.continue.label" | translate, true),
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/enter-email/index.njk
+++ b/src/components/enter-email/index.njk
@@ -52,7 +52,7 @@
 }}
 
 {{ govukButton({
-    "text": button_text|default("Continue", true),
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -47,7 +47,7 @@
     }) }}
 
     {{ govukButton({
-  "text": button_text|default('general.continue.label' | translate, true),
+  "text": "general.continue.label" | translate,
   "type": "Submit",
   "preventDoubleClick": true
   }) }}

--- a/src/components/enter-password/index-account-exists.njk
+++ b/src/components/enter-password/index-account-exists.njk
@@ -43,7 +43,7 @@
 </p>
 
 {{ govukButton({
-    "text": button_text|default('general.continue.label' | translate, true),
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -35,7 +35,7 @@
 </p>
 
 {{ govukButton({
-    "text": button_text|default('general.continue.label' | translate, true),
+    "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}

--- a/src/components/enter-phone-number/index.njk
+++ b/src/components/enter-phone-number/index.njk
@@ -82,7 +82,7 @@
     {% endif %}
 
     {{ govukButton({
-  "text": button_text|default('general.continue.label' | translate, true),
+  "text": "general.continue.label" | translate,
   "type": "Submit",
   "preventDoubleClick": true
   }) }}

--- a/src/components/photo-id/index-no-photo-id.njk
+++ b/src/components/photo-id/index-no-photo-id.njk
@@ -26,7 +26,7 @@
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
         {{ govukButton({
-            "text": button_text|default('general.continue.label' | translate, true),
+            "text": "general.continue.label" | translate,
             "type": "Submit",
             "preventDoubleClick": true
         }) }}

--- a/src/components/photo-id/index.njk
+++ b/src/components/photo-id/index.njk
@@ -55,7 +55,7 @@
         }) }}
 
         {{ govukButton({
-            "text": button_text|default('general.continue.label' | translate, true),
+            "text": "general.continue.label" | translate,
             "type": "Submit",
             "preventDoubleClick": true
         }) }}

--- a/src/components/prove-identity-welcome/index-existing-session.njk
+++ b/src/components/prove-identity-welcome/index-existing-session.njk
@@ -77,7 +77,7 @@
         }) }}
 
         {{ govukButton({
-        "text": button_text|default('general.continue.label' | translate, true),
+        "text": "general.continue.label" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/prove-identity-welcome/index.njk
+++ b/src/components/prove-identity-welcome/index.njk
@@ -86,7 +86,7 @@
         }) }}
 
         {{ govukButton({
-        "text": button_text|default('general.continue.label' | translate, true),
+        "text": "general.continue.label" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/resend-mfa-code/index.njk
+++ b/src/components/resend-mfa-code/index.njk
@@ -25,7 +25,7 @@
 
         <p class="govuk-body">{{'pages.resendMfaCode.message' | translate}}</p>
         {{ govukButton({
-        "text": button_text|default('pages.resendMfaCode.continue' | translate, true),
+        "text": "pages.resendMfaCode.continue" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/reset-password/index.njk
+++ b/src/components/reset-password/index.njk
@@ -58,7 +58,7 @@
     }) }}
 
     {{ govukButton({
-        "text": button_text|default("general.continue.label" | translate, true),
+        "text": "general.continue.label" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}

--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -62,7 +62,7 @@
   }}
 
     {{ govukButton({
-  "text": button_text|default('general.continue.label' | translate, true),
+  "text": "general.continue.label" | translate,
   "type": "Submit",
   "preventDoubleClick": true
   }) }}


### PR DESCRIPTION
## What?

Removes use of `button_text` and fallback to `default()`, and use consistent quotes within function. Has been applied to all instances within the application.

I've manually checked how every changed file renders within the app to ensure it hasn't broken anything. 

## Why?

The `button_text` variable does not exist and the use of `default()` is unnecessary.