### PR TITLE
ACI-120: Update accessibility statement

### DIFF
--- a/src/components/common/footer/accessibility-statement.njk
+++ b/src/components/common/footer/accessibility-statement.njk
@@ -41,6 +41,7 @@
 <ul class="govuk-list govuk-list--bullet">
   <li>{{'pages.accessibilityStatement.section2.bulletPoint1' | translate}}</li>
   <li>{{'pages.accessibilityStatement.section2.bulletPoint2' | translate}}</li>
+  <li>{{'pages.accessibilityStatement.section2.bulletPoint3' | translate}}</li>
 </ul>
 <p class="govuk-body">{{'pages.accessibilityStatement.section2.paragraph2' | translate}}</p>
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -768,6 +768,7 @@
         "paragraph1": "The following parts of GOV.UK accounts are not fully accessible:",
         "bulletPoint1": "it’s not possible to stop or change the length of the time-out when you use, sign in to or create an account",
         "bulletPoint2": "it’s not possible for a screen reader to know when the emails we send are in a language other than English",
+        "bulletPoint3": "one page reloads automatically after a set time limit, and it’s not possible to stop or delay this",
         "paragraph2": "We’ll update this page when issues are fixed or with information about when we plan to fix them."
       },
       "section3": {


### PR DESCRIPTION
## What?

Adds issue arising from use of `meta refresh` to the Accessibility Statement.

## Why?

As a WCAG non-compliance this should be listed in the Accessibility Statement under the Public Sector Bodies Accessibility Regulations.
