### PR TITLE
ACI-19: Set a default value for the SUPPORT_PASSWORD_RESET_REQUIRED variable in the pipeline

### DIFF
--- a/ci/tasks/deploy-frontend.yml
+++ b/ci/tasks/deploy-frontend.yml
@@ -27,6 +27,7 @@ params:
   BASIC_AUTH_BYPASS_CIDR_BLOCKS: '[]'
   SUPPORT_MFA_OPTIONS: "0"
   SUPPORT_LANGUAGE_CY: "0"
+  SUPPORT_PASSWORD_RESET_REQUIRED: "0"
 inputs:
   - name: frontend-src
   - name: frontend-image


### PR DESCRIPTION
## What?

Set a default value for the SUPPORT_PASSWORD_RESET_REQUIRED variable in the pipeline.

## Why?

Deploy frontend build is failing as this is unset.

## Related PRs

#848 