### PR TITLE
ACI-122: Update govuk-frontend to latest version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2151,9 +2151,9 @@ globby@^11.0.3:
     slash "^3.0.0"
 
 govuk-frontend@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.3.1.tgz#d9c581aca3d23bbfe9bd27c25fee65322b276393"
-  integrity sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.4.0.tgz#36531ae3b12798267e5a72409c7e4b3b10565102"
+  integrity sha512-3Hg4GePCdlynd7F6a3YPOEJx0lDPPP6iBv1S893tv3+efYGWLGvsSFdCG0uob8Xc1O7ckL19dSsFpFhBWUkTNA==
 
 graceful-fs@^4.1.15:
   version "4.2.8"


### PR DESCRIPTION
## What?

Updates `govuk-frontend` to latest version `4.4.0`

* Updates via `yarn upgrade govuk-frontend` to 4.4.0 (updated `yarn.lock`)
* Ran `yarn build`. This had the effect of also minifying/uglifying the client-side JavaScript but I've reverted this because our JavaScript currently has references to the global objects (and I'm not certain the uglification might break references and introduce side-effects). The JavaScript needs a broader look as a dedicated task. 

### Pages manually tested locally

To ensure there were no visual regressions (that might not have been picked up by tests) I've also manually tested the following pages and states. 

* `/sign-in-or-create` (small screen and wide)
* `/enter-email-create` including errors (small screen and wide)
* `/check-your-email` including errors (small screen and wide)
* `/resend-email-code` (small screen and wide)
* `/create-password` including errors (small screen and wide) - also tested in Welsh because we'd previously had problems with word length in buttons here. 
* `/get-security-codes` including errors (small screen and wide)
* `/get-security-codes` including errors (small screen and wide)
* `/enter-phone-number` including errors (small screen and wide)
* `/check-your-phone` including errors (small screen and wide)
* `/account-created` (small screen and wide)
* `/setup-authenticator-app` including errors (small screen and wide)
* `/enter-email` including errors (small screen and wide)
* `/enter-password` including errors (small screen and wide)
* `/enter-authenticator-app-code` including errors (small screen and wide)
* `/signed-out?error_code=invalid_request` (small screen and wide)
* `/accessibility-statement` (small screen and wide)
* `/contact-us` including errors (small screen and wide)
* `/contact-us-further-information` including errors (small screen and wide)

## Why?

To keep repository depedencies up to date and benefit from the latest features.

