### PR TITLE
ACI-124: Change content on create password screen

### DIFF
--- a/src/components/common/show-password/macro.njk
+++ b/src/components/common/show-password/macro.njk
@@ -19,6 +19,28 @@
     </div>
 {% endmacro %}
 
+{% macro govukInputWithHintAndShowPassword(label, id, errors, showSettings, autocomplete, hintText) %}
+    <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="{{ showSettings.show }}" data-hide-text="{{ showSettings.hide }}" data-show-full-text="{{ showSettings.showFullText }}" data-hide-full-text="{{ showSettings.hideFullText }}" data-announce-show="{{ showSettings.announceShown }}" data-announce-hide="{{ showSettings.announceHidden }}">
+        {{ govukInput({
+            label: {
+                text: label
+            },
+            hint: {
+                text: hintText
+            },
+            classes: "govuk-!-width-two-thirds govuk-password-input",
+            id: id,
+            name: id,
+            type: "password",
+            autocomplete: autocomplete,
+            spellcheck: false,
+            errorMessage: {
+                text: errors[id].text
+            } if (errors[id])})
+        }}
+    </div>
+{% endmacro %}
+
 {% macro govukInputWithShowPasswordWithLabelAsPageHeading(label, id, errors, showSettings, autocomplete) %}
     <div class="govuk-show-password" data-module="show-password" data-disable-form-submit-check="false" data-show-text="{{ showSettings.show }}" data-hide-text="{{ showSettings.hide }}" data-show-full-text="{{ showSettings.showFullText }}" data-hide-full-text="{{ showSettings.hideFullText }}" data-announce-show="{{ showSettings.announceShown }}" data-announce-hide="{{ showSettings.announceHidden }}">
         {{ govukInput({

--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -2,7 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
-{% from "common/show-password/macro.njk" import govukInputWithShowPassword %}
+{% from "common/show-password/macro.njk" import govukInputWithShowPassword, govukInputWithHintAndShowPassword %}
 
 {% set pageTitleName = 'pages.createPassword.title' | translate %}
 
@@ -16,15 +16,7 @@
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
-    <p class="govuk-body">{{'pages.createPassword.password.paragraph1' | translate}}</p>
-    <ul class="govuk-list govuk-list--bullet">
-     <li>{{ 'pages.createPassword.password.bulletPoint1' | translate}}</li>
-     <li>{{ 'pages.createPassword.password.bulletPoint2' | translate}}</li>
-    </ul>
-
-     <p class="govuk-body">{{'pages.createPassword.password.paragraph2' | translate}}</p>
-
-    {{ govukInputWithShowPassword(
+    {{ govukInputWithHintAndShowPassword(
         'pages.createPassword.password.label'  | translate,
         "password",
         errors,
@@ -36,7 +28,8 @@
             announceShown: 'general.showPassword.announceShown' | translate,
             announceHidden: 'general.showPassword.announceHidden' | translate
         },
-        'new-password'
+        'new-password',
+        'pages.createPassword.password.hintText' | translate
     ) }}
 
     {{ govukInputWithShowPassword(

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -314,10 +314,7 @@
       "header": "Creu eich cyfrinair",
       "password": {
         "label": "Rhowch gyfrinair",
-        "paragraph1": "Mae’n rhaid i’ch cyfrinair:",
-        "bulletPoint1": "fod yn o leiaf 8 nod o hyd",
-        "bulletPoint2": "cynnwys llythrennau a rhifau",
-        "paragraph2": "Peidiwch defnyddio cyfrinair cyffredin iawn, fel ’password’ neu ddilyniant o rifau.",
+        "hintText": "Mae'n rhaid iddo fod yn o leiaf 8 nod o hyd a rhaid cynnwys llythrennau a rhifau. Peidiwch defnyddio cyfrinair cyffredin iawn, fel ’password’ neu ddilyniant o rifau.",
         "validationError": {
           "required": "Rhowch eich cyfrinair",
           "maxLength": "Mae’n rhaid i’ch cyfrinair fod yn llai na 256 nod",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -314,10 +314,7 @@
       "header": "Create your password",
       "password": {
         "label": "Enter a password",
-        "paragraph1": "Your password must:",
-        "bulletPoint1": "be at least 8 characters long",
-        "bulletPoint2": "include letters and numbers",
-        "paragraph2": "Do not use a very common password, such as ‘password’ or a sequence of numbers.",
+        "hintText": "It must be at least 8 characters and must include letters and numbers. Do not use a very common password, such as 'password' or a sequence of numbers.",
         "validationError": {
           "required": "Enter your password",
           "maxLength": "Your password must be less than 256 characters",


### PR DESCRIPTION
## What?

Updates content to extract messaging that was previously within bullet points to new hint text for one of the password fields.

## Why?

The change in content and presentation is intended to help users avoid issues. The impact of this change will be monitored to determine next steps.