### PR TITLE
ACI-121: Add cannot scan QR code to auth app page

### DIFF
--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -12,10 +12,19 @@
 
   {% include "common/errors/errorSummary.njk" %}
 
-  {% set insetTextHtml %}
+  {% set noAuthAppInsetTextHtml %}
   <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph1' | translate}}</p>
   <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph2' | translate}}</p>
   <p class="govuk-body">{{'pages.setupAuthenticatorApp.noAuthAppDetails.paragraph3' | translate}}</p>
+  {% endset %}
+
+  {% set cannotScanInsetTextHtml %}
+  <p class="govuk-body">{{'pages.setupAuthenticatorApp.cannotScanDetails.paragraph1' | translate}}</p>
+  <p class="govuk-body">
+    {{'pages.setupAuthenticatorApp.cannotScanDetails.paragraph2' | translate}}
+    <span id="secret-key" class="govuk-body govuk-!-font-weight-bold govuk-!-display-block permit-reflow">{{secretKey}}</span>
+  </p>
+  <p class="govuk-body">{{'pages.setupAuthenticatorApp.cannotScanDetails.paragraph3' | translate}}</p>
   {% endset %}
 
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.setupAuthenticatorApp.header' | translate }}</h1>
@@ -23,18 +32,19 @@
   <p class="govuk-body">{{'pages.setupAuthenticatorApp.step1' | translate }}</p>
   {{ govukDetails({
         summaryText: 'pages.setupAuthenticatorApp.noAuthAppDetails.summaryText' | translate,
-        html: insetTextHtml
-    }) }}
+        html: noAuthAppInsetTextHtml
+  }) }}
   <p class="govuk-body">{{'pages.setupAuthenticatorApp.step2' | translate }}</p>
 
   <p class="govuk-body">
     <img id="qr-code" src="{{qrCode}}" alt="QR Code Image">
   </p>
 
-  <p class="govuk-body">
-    {{ 'pages.setupAuthenticatorApp.secretKeyLabelText' | translate }}
-    <span id="secret-key" class="govuk-body govuk-!-font-weight-bold permit-reflow">{{secretKey}}</span>
-  </p>
+  {{ govukDetails({
+    summaryText: 'pages.setupAuthenticatorApp.cannotScanDetails.summaryText' | translate,
+    html: cannotScanInsetTextHtml
+  }) }}
+
   <p class="govuk-body">{{'pages.setupAuthenticatorApp.step3' | translate }}</p>
   <p class="govuk-body">{{'pages.setupAuthenticatorApp.step4' | translate }}</p>
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1618,8 +1618,13 @@
         "paragraph2": "Os nad oes gennych ffôn clyfar neu lechen, chwiliwch ar-lein am ap dilysydd ar gyfer eich cyfrifiadur.",
         "paragraph3": "Gallwch ddefnyddio unrhyw ap dilysydd."
       },
-      "step2": "2. Defnyddiwch eich ap dilysydd i sganio’r cod QR neu teipiwch yr allwedd gyfrinachol i’ch ap dilysydd.  Mae rhai apiau dilysydd yn galw’r allwedd gyfrinachol yn ’cod’.",
-      "secretKeyLabelText": "Allwedd gyfrinachol: ",
+      "step2": "2. Defnyddiwch eich ap dilysydd i sganio'r cod QR.",
+      "cannotScanDetails": {
+        "summaryText": "Ni allaf sganio'r cod QR",
+        "paragraph1": "Gallwch roi yr allwedd gyfrinachol i'ch ap dilysydd yn lle hynny.",
+        "paragraph2": "Allwedd gyfrinachol: ",
+        "paragraph3": "Mae rhai apiau dilysydd yn galw'r allwedd gyfrinachol yn 'cod'."
+      },
       "step3": "3. Bydd yr ap dilysydd yn dangos cod diogelwch.",
       "step4": "4. Rhowch y cod diogelwch.",
       "code": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1619,8 +1619,13 @@
         "paragraph2": "If you don’t have a smartphone or tablet, search online for an authenticator app for your computer.",
         "paragraph3": "You can use any authenticator app."
       },
-      "step2": "2. Use your authenticator app to scan the QR code or type the secret key into your authenticator app.  Some authenticator apps call the secret key a ’code’.",
-      "secretKeyLabelText": "Secret key: ",
+      "step2": "2. Use your authenticator app to scan the QR code.",
+      "cannotScanDetails": {
+        "summaryText": "I cannot scan the QR code",
+        "paragraph1": "You can enter the secret key into your authenticator app instead.",
+        "paragraph2": "Secret key: ",
+        "paragraph3": "Some authenticator apps call the secret key a 'code'."
+      },
       "step3": "3. The authenticator app will show a security code.",
       "step4": "4. Enter the security code.",
       "code": {


### PR DESCRIPTION
## What?

Content and design change to the ‘Set up an authenticator app’ page advising users they can enter the secret key manually in to their authenticator app rather than scan the QR code.

## Why?

Change is to help users avoid issues relating to the interplay of the secret key and QR code.