### PR TITLE
PYIC-2203 Update wording on photo-id page

### DIFF
--- a/src/components/photo-id/index.njk
+++ b/src/components/photo-id/index.njk
@@ -15,15 +15,18 @@
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.photoId.header' | translate}}</h1>
 
+    <p class="govuk-body">{{'pages.photoId.introParagraph' | translate}}</p>
+
+
+    <h2 class="govuk-heading-m govuk-!-padding-top-10 govuk-!-margin-bottom-1">{{'pages.photoId.section1.subHeading' | translate}}</h2>
     <p class="govuk-body">{{'pages.photoId.section1.paragraph1' | translate}}</p>
 
-    <ul class="govuk-list govuk-list--bullet">
-        <li>{{'pages.photoId.section1.listItem1' | translate}}</li>
-        <li>{{'pages.photoId.section1.listItem2' | translate}}</li>
-    </ul>
+    <h2 class="govuk-heading-m govuk-!-padding-top-10 govuk-!-margin-bottom-1">{{'pages.photoId.section2.subHeading' | translate}}</h2>
+    <p class="govuk-body">{{'pages.photoId.section2.paragraph1' | translate}}</p>
+
 
     {{ govukInsetText({
-        html: 'pages.photoId.section1.insetPassportExpiry' | translate
+        html: 'pages.photoId.section2.expiredNote' | translate
     }) }}
 
     <form id="form-tracking" action="/photo-id" method="post" novalidate="novalidate">
@@ -34,7 +37,7 @@
             name:"havePhotoId",
             fieldset: {
                 legend: {
-                    text: 'pages.photoId.section2.subHeading' | translate,
+                    text: 'pages.photoId.section3.subHeading' | translate,
                     isPageHeading: false,
                     classes: "govuk-fieldset__legend--m"
                 }
@@ -42,11 +45,11 @@
             items: [
                 {
                     value: "true",
-                    text: 'pages.photoId.section2.radioOption1' | translate
+                    text: 'pages.photoId.section3.radioOption1' | translate
                 },
                 {
                     value: "false",
-                    text: 'pages.photoId.section2.radioOption2' | translate
+                    text: 'pages.photoId.section3.radioOption2' | translate
                 }
             ],
             errorMessage: {

--- a/src/components/photo-id/photo-id-validation.ts
+++ b/src/components/photo-id/photo-id-validation.ts
@@ -8,7 +8,7 @@ export function validatePhotoIdRequest(): ValidationChainFunc {
       .if(check("auth").isEmpty())
       .notEmpty()
       .withMessage((value, { req }) => {
-        return req.t("pages.photoId.section2.errorMessage", {
+        return req.t("pages.photoId.section3.errorMessage", {
           value,
         });
       }),

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1626,10 +1626,10 @@
       "step4": "4. Rhowch y cod diogelwch.",
       "code": {
         "label": "Cod diogelwch",
-        "hintText": "Dyma'r rhif 6-digid a ddangosir yn eich ap dilysydd",
+        "hintText": "Dyma’r rhif 6-digid a ddangosir yn eich ap dilysydd",
         "validationError": {
           "required": "Rhowch y cod diogelwch a ddangosir yn eich ap dilysydd",
-          "invalidCode": "Nid yw'r cod diogelwch rydych wedi'i roi yn gywir, ceisiwch ei roi i mewn eto neu aros i'ch ap dilysydd roi cod newydd i chi",
+          "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi yn gywir, ceisiwch ei roi i mewn eto neu aros i’ch ap dilysydd roi cod newydd i chi",
           "length": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig"
         }
       },
@@ -1668,14 +1668,14 @@
       }
     },
     "noPhotoId": {
-      "title": "Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi",
-      "header": "Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi",
+      "title": "Mae’n ddrwg gennym, ni allwn brofi pwy ydych chi",
+      "header": "Mae’n ddrwg gennym, ni allwn brofi pwy ydych chi",
       "section1": {
-        "paragraph1": "Ar hyn o bryd gallwch ond profi pwy ydych chi gyda'ch cyfrif GOV.UK os oes gennych ID gyda llun."
+        "paragraph1": "Ar hyn o bryd gallwch ond profi pwy ydych chi gyda’ch cyfrif GOV.UK os oes gennych ID gyda llun."
       },
       "section2": {
         "subHeading": "Beth allwch chi ei wneud",
-        "paragraph1": "Parhau i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi."
+        "paragraph1": "Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi."
       }
     },
     "securityCodeEnteredExceeded": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1221,7 +1221,7 @@
       "header": "Rydych wedi ceisio ailosod eich cyfrinair ormod o weithiau",
       "paragraph1": "Mae angen i chi aros am 15 munud.",
       "paragraph2": "Yna gallwch ",
-     "resetPasswordLinkText": "ailosod eich cyfrinair",
+      "resetPasswordLinkText": "ailosod eich cyfrinair",
       "paragraph3": " a cheisio mewngofnodi eto."
     },
     "resetPasswordAttemptBlocked": {
@@ -1229,7 +1229,7 @@
       "header": "Ni allwch ailosod eich cyfrinair ar hyn o bryd",
       "paragraph1": "Mae hyn oherwydd i chi geisio ailosod eich cyfrinair ormod o weithiau y tro diwethaf i chi geisio mewngofnodi.",
       "paragraph2": "Gallwch ",
-     "resetPasswordLinkText": "ailosod eich cyfrinair",
+      "resetPasswordLinkText": "ailosod eich cyfrinair",
       "paragraph3": " ar ôl i 15 munud fynd heibio."
     },
     "accountLocked": {
@@ -1448,7 +1448,6 @@
           "header": "How did you expect to get the security code?",
           "errorMessage": "Select whether you expected to get the code by email, text message or authenticator app",
           "errorMessageSignIn": "Select whether you expected to get the code by text message or authenticator app"
-
         },
         "section2": {
           "header": "Anything else you want to tell us",
@@ -1628,8 +1627,8 @@
       "code": {
         "label": "Cod diogelwch",
         "hintText": "Dyma'r rhif 6-digid a ddangosir yn eich ap dilysydd",
-        "validationError":{
-         "required": "Rhowch y cod diogelwch a ddangosir yn eich ap dilysydd",
+        "validationError": {
+          "required": "Rhowch y cod diogelwch a ddangosir yn eich ap dilysydd",
           "invalidCode": "Nid yw'r cod diogelwch rydych wedi'i roi yn gywir, ceisiwch ei roi i mewn eto neu aros i'ch ap dilysydd roi cod newydd i chi",
           "length": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig"
         }
@@ -1648,31 +1647,35 @@
         }
       }
     },
-    "photoId" : {
-      "title": "Mae'n rhaid i chi gael ID gyda llun i brofi pwy ydych chi yn y ffordd yma",
-      "header": "Mae'n rhaid i chi gael ID gyda llun i brofi pwy ydych chi yn y ffordd yma",
+    "photoId": {
+      "title": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych gyda chyfrif GOV.UK",
+      "header": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych gyda chyfrif GOV.UK",
+      "introParagraph": "Gallwch ond brofi pwy ydych chi gyda chyfrif GOV.UK os oes gennych un o’r mathau canlynol o ID llun.",
       "section1": {
-        "paragraph1" : "Gallwch ond profi pwy ydych chi gyda'ch cyfrif GOV.UK os oes gennych un o'r canlynol:",
-        "listItem1": "trwydded yrru'r DU",
-        "listItem2": "pasbort y DU",
-        "insetPassportExpiry" : "Os yw eich pasbort wedi dod i ben, gallwch barhau i'w ddefnyddio i brofi pwy ydych chi hyd at 18 mis ar ôl y dyddiad dod i ben."
+        "subHeading": "Trwydded yrru y DU gyda llun",
+        "paragraph1": "Byddwch angen trwydded yrru lawn neu dros dro dilys gyda’ch llun arno."
       },
       "section2": {
-        "subHeading" : "Oes gennych chi ID gyda llun?",
-        "radioOption1" : "Oes",
-        "radioOption2" : "Na",
+        "subHeading": "Pasbort biometrig y DU neu ddim o’r DU",
+        "paragraph1": "Mae gan basbortau biometrig (neu ‘ePassports’) symbol hirsgwar bach ar y clawr blaen. Gallwch eu defnyddio i fynd trwy eGiatiau mewn meysydd awyr a gorsafoedd trên.",
+        "expiredNote": "Os oes gennych basbort biometrig y DU sydd wedi dod i ben, gallwch barhau i’w ddefnyddio i brofi pwy ydych chi am hyd at 18 mis ar ôl y dyddiad dod i ben."
+      },
+      "section3": {
+        "subHeading": "Oes gennych chi un o’r mathau hyn o ID llun?",
+        "radioOption1": "Oes",
+        "radioOption2": "Na",
         "errorMessage": "Dewiswch opsiwn"
       }
     },
-    "noPhotoId" : {
+    "noPhotoId": {
       "title": "Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi",
       "header": "Mae'n ddrwg gennym, ni allwn brofi pwy ydych chi",
       "section1": {
-        "paragraph1" : "Ar hyn o bryd gallwch ond profi pwy ydych chi gyda'ch cyfrif GOV.UK os oes gennych ID gyda llun."
+        "paragraph1": "Ar hyn o bryd gallwch ond profi pwy ydych chi gyda'ch cyfrif GOV.UK os oes gennych ID gyda llun."
       },
       "section2": {
-        "subHeading" : "Beth allwch chi ei wneud",
-        "paragraph1" : "Parhau i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi."
+        "subHeading": "Beth allwch chi ei wneud",
+        "paragraph1": "Parhau i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi."
       }
     },
     "securityCodeEnteredExceeded": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1449,7 +1449,6 @@
           "header": "How did you expect to get the security code?",
           "errorMessage": "Select whether you expected to get the code by email, text message or authenticator app",
           "errorMessageSignIn": "Select whether you expected to get the code by text message or authenticator app"
-
         },
         "section2": {
           "header": "Anything else you want to tell us",
@@ -1629,8 +1628,8 @@
       "code": {
         "label": "Security code",
         "hintText": "This is the 6-digit number shown in your authenticator app",
-        "validationError":{
-         "required": "Enter the security code shown in your authenticator app",
+        "validationError": {
+          "required": "Enter the security code shown in your authenticator app",
           "invalidCode": "The security code you entered is not correct, try entering it again or wait for for your authenticator app to give you a new code",
           "length": "Enter the security code using only 6 digits"
         }
@@ -1649,31 +1648,35 @@
         }
       }
     },
-    "photoId" : {
-      "title": "You must have a photo ID to prove your identity this way",
-      "header": "You must have a photo ID to prove your identity this way",
+    "photoId": {
+      "title": "You must have a photo ID to prove your identity with a GOV.UK account",
+      "header": "You must have a photo ID to prove your identity with a GOV.UK account",
+      "introParagraph": "You can only prove your identity with a GOV.UK account if you have one of the following types of photo ID.",
       "section1": {
-        "paragraph1" : "You can only prove your identity with your GOV.UK account if you have one of the following:",
-        "listItem1": "a UK driving licence",
-        "listItem2": "a UK passport",
-        "insetPassportExpiry" : "If your passport has expired, you can still use it to prove your identity up until 18 months after the expiry date."
+        "subHeading": "UK photocard driving licence",
+        "paragraph1": "You’ll need a valid full or provisional driving licence with your photo on it."
       },
       "section2": {
-        "subHeading" : "Do you have a photo ID?",
-        "radioOption1" : "Yes",
-        "radioOption2" : "No",
+        "subHeading": "UK or non-UK biometric passport",
+        "paragraph1": "Biometric passports (or ‘ePassports’) have a small rectangular symbol on the front cover. You can use them to go through eGates at airports and train stations.",
+        "expiredNote": "If you have an expired UK biometric passport, you can still use it to prove your identity up to 18 months after the expiry date."
+      },
+      "section3": {
+        "subHeading": "Do you have one of these types of photo ID?",
+        "radioOption1": "Yes",
+        "radioOption2": "No",
         "errorMessage": "Select an option"
       }
     },
-    "noPhotoId" : {
+    "noPhotoId": {
       "title": "No photo id",
       "header": "Sorry, we cannot prove your identity",
       "section1": {
-        "paragraph1" : "You can currently only prove your identity with your GOV.UK account if you have a photo ID."
+        "paragraph1": "You can currently only prove your identity with your GOV.UK account if you have a photo ID."
       },
       "section2": {
-        "subHeading" : "What you can do",
-        "paragraph1" : "Continue to the service you were trying to use and look for other ways to prove your identity."
+        "subHeading": "What you can do",
+        "paragraph1": "Continue to the service you were trying to use and look for other ways to prove your identity."
       }
     },
     "securityCodeEnteredExceeded": {


### PR DESCRIPTION
## What?

This PR changes the content on the `photo-id` page to inform users chipped passports can be used to prove their identity.

## Why?

The app journey supports this form of identity proofing.

## Related tickets

* [PYIC-2203](https://govukverify.atlassian.net/browse/PYIC-2203)
