### PR TITLE
AUT 881: Update dataLayer push to reflect new requirements

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -91,7 +91,6 @@ var cookies = function (trackingId, analyticsCookieDomain) {
     loadGtmScript();
     initGtm();
     initLinkerHandlers();
-    pushLanguageToDataLayer();
   }
 
   function pushLanguageToDataLayer() {
@@ -142,6 +141,7 @@ var cookies = function (trackingId, analyticsCookieDomain) {
       gtag(sessionJourney);
     }
 
+    pushLanguageToDataLayer();
     gtag({ "gtm.start": new Date().getTime(), event: "gtm.js" });
   }
 

--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -94,14 +94,22 @@ var cookies = function (trackingId, analyticsCookieDomain) {
   }
 
   function pushLanguageToDataLayer() {
-    var language = document.querySelector('html') &&
+    var languageCode = document.querySelector('html') &&
         document.querySelector('html').getAttribute('lang');
 
-    if (language) {
+    var languageNames = {
+      'en':'english',
+      'cy':'welsh'
+    }
+
+    if (languageCode && languageNames[languageCode]) {
+
       window.dataLayer = window.dataLayer || [];
+
       window.dataLayer.push({
         event: "langEvent",
-        language: language
+        language: languageNames[languageCode],
+        languagecode: languageCode
       });
     }
   }


### PR DESCRIPTION
## What?

Change to structure of page language data pushed to Google Analytics and bring the push earlier in the lifecycle. 

## Why?

The analytics core team have requested a change to the timing and structure of data pushed to Google Analytics via `dataLayer`.

## Related PRs

The first implementation based on initial requirements was merged via #839  
