### PR TITLE
AUT-921: Update support pages to include GOV.UK ID Check app options

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -93,6 +93,10 @@ locals {
         value = var.support_password_reset_required
       },
       {
+        name  = "SUPPORT_ID_CHECK_APP_FORMS"
+        value = var.support_id_check_app_forms
+      },
+      {
         name  = "ZENDESK_API_TOKEN"
         value = var.zendesk_api_token
       },

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -5,7 +5,8 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
-support_language_cy = "1"
+support_language_cy        = "1"
+support_id_check_app_forms = "1"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -61,6 +61,11 @@ variable "support_password_reset_required" {
   type = string
 }
 
+variable "support_id_check_app_forms" {
+  type    = string
+  default = "0"
+}
+
 variable "zone_id" {
   default = null
 }

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -134,6 +134,7 @@ export const ZENDESK_THEMES = {
   ID_CHECK_APP: "id_check_app",
   LINKING_PROBLEM: "linking_problem",
   TAKING_PHOTO_OF_ID_PROBLEM: "taking_photo_of_id_problem",
+  FACE_SCANNING_PROBLEM: "face_scanning_problem",
 };
 
 export enum NOTIFICATION_TYPE {

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -136,6 +136,7 @@ export const ZENDESK_THEMES = {
   TAKING_PHOTO_OF_ID_PROBLEM: "taking_photo_of_id_problem",
   FACE_SCANNING_PROBLEM: "face_scanning_problem",
   ID_CHECK_APP_TECHNICAL_ERROR: "id_check_app_technical_problem",
+  ID_CHECK_APP_SOMETHING_ELSE: "id_check_app_something_else",
 };
 
 export enum NOTIFICATION_TYPE {

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -131,6 +131,8 @@ export const ZENDESK_THEMES = {
   NO_PHONE_NUMBER_ACCESS: "no_phone_number_access",
   PROVING_IDENTITY: "proving_identity",
   AUTHENTICATOR_APP_PROBLEM: "authenticator_app_problem",
+  ID_CHECK_APP: "id_check_app",
+  LINKING_PROBLEM: "linking_problem",
 };
 
 export enum NOTIFICATION_TYPE {

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -135,6 +135,7 @@ export const ZENDESK_THEMES = {
   LINKING_PROBLEM: "linking_problem",
   TAKING_PHOTO_OF_ID_PROBLEM: "taking_photo_of_id_problem",
   FACE_SCANNING_PROBLEM: "face_scanning_problem",
+  ID_CHECK_APP_TECHNICAL_ERROR: "id_check_app_technical_problem",
 };
 
 export enum NOTIFICATION_TYPE {

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -133,6 +133,7 @@ export const ZENDESK_THEMES = {
   AUTHENTICATOR_APP_PROBLEM: "authenticator_app_problem",
   ID_CHECK_APP: "id_check_app",
   LINKING_PROBLEM: "linking_problem",
+  TAKING_PHOTO_OF_ID_PROBLEM: "taking_photo_of_id_problem",
 };
 
 export enum NOTIFICATION_TYPE {

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -392,6 +392,12 @@ export function getQuestionFromThemes(
     face_scanning_problem: req.t(
       "pages.contactUsFurtherInformation.idCheckApp.section1.faceScanningProblem"
     ),
+    id_check_app_technical_problem: req.t(
+      "pages.contactUsFurtherInformation.idCheckApp.section1.technicalError"
+    ),
+    id_check_app_something_else: req.t(
+      "pages.contactUsFurtherInformation.idCheckApp.section1.somethingElse"
+    ),
   };
 
   const themeQuestion = themesToQuestions[theme];

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -33,6 +33,8 @@ const themeToPageTitle = {
     "pages.contactUsQuestions.authenticatorApp.title",
   [ZENDESK_THEMES.LINKING_PROBLEM]:
     "pages.contactUsQuestions.linkingProblem.title",
+  [ZENDESK_THEMES.TAKING_PHOTO_OF_ID_PROBLEM]:
+    "pages.contactUsQuestions.takingPhotoOfIdProblem.title",
 };
 
 const somethingElseSubThemeToPageTitle = {

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -5,6 +5,7 @@ import { ContactUsServiceInterface, Questions, ThemeQuestions } from "./types";
 import { ExpressRouteFunc } from "../../types";
 import crypto from "crypto";
 import { logger } from "../../utils/logger";
+import { supportIdCheckAppForms } from "../../config";
 
 const themeToPageTitle = {
   [ZENDESK_THEMES.ACCOUNT_NOT_FOUND]:
@@ -70,6 +71,7 @@ export function contactUsGet(req: Request, res: Response): void {
 
   return res.render("contact-us/index-public-contact-us.njk", {
     referer: referer,
+    showIdCheckAppFormOption: supportIdCheckAppForms(),
   });
 }
 

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -37,12 +37,16 @@ const themeToPageTitle = {
     "pages.contactUsQuestions.takingPhotoOfIdProblem.title",
   [ZENDESK_THEMES.FACE_SCANNING_PROBLEM]:
     "pages.contactUsQuestions.faceScanningProblem.title",
+  [ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR]:
+    "pages.contactUsQuestions.idCheckAppTechnicalProblem.title",
 };
 
 const somethingElseSubThemeToPageTitle = {
   [ZENDESK_THEMES.ACCOUNT_CREATION]:
     "pages.contactUsQuestions.accountCreation.title",
   [ZENDESK_THEMES.SIGNING_IN]: "pages.contactUsQuestions.signingIn.title",
+  [ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR]:
+    "pages.contactUsQuestions.idCheckAppTechnicalError.title",
 };
 
 export function contactUsGet(req: Request, res: Response): void {
@@ -281,6 +285,17 @@ export function getQuestionsFromFormType(
       issueDescription: `${req.t(
         "pages.contactUsQuestions.whatHappened.header"
       )} ${req.t("pages.contactUsQuestions.whatHappened.paragraph1")}`,
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header"
+      ),
+    },
+    idCheckAppTechnicalProblem: {
+      issueDescription: req.t(
+        "pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.header"
+      ),
+      additionalDescription: req.t(
+        "pages.contactUsQuestions.whatHappened.header"
+      ),
       serviceTryingToUse: req.t(
         "pages.contactUsQuestions.serviceTryingToUse.header"
       ),

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -39,6 +39,8 @@ const themeToPageTitle = {
     "pages.contactUsQuestions.faceScanningProblem.title",
   [ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR]:
     "pages.contactUsQuestions.idCheckAppTechnicalProblem.title",
+  [ZENDESK_THEMES.ID_CHECK_APP_SOMETHING_ELSE]:
+    "pages.contactUsQuestions.idCheckAppSomethingElse.title",
 };
 
 const somethingElseSubThemeToPageTitle = {
@@ -47,6 +49,8 @@ const somethingElseSubThemeToPageTitle = {
   [ZENDESK_THEMES.SIGNING_IN]: "pages.contactUsQuestions.signingIn.title",
   [ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR]:
     "pages.contactUsQuestions.idCheckAppTechnicalError.title",
+  [ZENDESK_THEMES.ID_CHECK_APP_SOMETHING_ELSE]:
+    "pages.contactUsQuestions.idCheckAppSomethingElse.title",
 };
 
 export function contactUsGet(req: Request, res: Response): void {
@@ -292,6 +296,17 @@ export function getQuestionsFromFormType(
     idCheckAppTechnicalProblem: {
       issueDescription: req.t(
         "pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.header"
+      ),
+      additionalDescription: req.t(
+        "pages.contactUsQuestions.whatHappened.header"
+      ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header"
+      ),
+    },
+    idCheckAppSomethingElse: {
+      issueDescription: req.t(
+        "pages.contactUsQuestions.idCheckAppSomethingElse.section1.header"
       ),
       additionalDescription: req.t(
         "pages.contactUsQuestions.whatHappened.header"

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -278,7 +278,9 @@ export function getQuestionsFromFormType(
       ),
     },
     idCheckApp: {
-      issueDescription: req.t("pages.contactUsQuestions.linkingProblem.header"),
+      issueDescription: `${req.t(
+        "pages.contactUsQuestions.whatHappened.header"
+      )} ${req.t("pages.contactUsQuestions.whatHappened.paragraph1")}`,
       serviceTryingToUse: req.t(
         "pages.contactUsQuestions.serviceTryingToUse.header"
       ),
@@ -353,6 +355,12 @@ export function getQuestionFromThemes(
   const idCheckAppSubthemeToQuestions: { [key: string]: any } = {
     linking_problem: req.t(
       "pages.contactUsFurtherInformation.idCheckApp.section1.linkingProblem"
+    ),
+    taking_photo_of_id_problem: req.t(
+      "pages.contactUsFurtherInformation.idCheckApp.section1.photoProblem"
+    ),
+    face_scanning_problem: req.t(
+      "pages.contactUsFurtherInformation.idCheckApp.section1.faceScanningProblem"
     ),
   };
 

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -279,12 +279,12 @@ export function getQuestionFromThemes(
   subtheme?: string
 ): ThemeQuestions {
   const themesToQuestions: { [key: string]: any } = {
-    account_creation: req.t("pages.contactUsPublic.section3.radio1"),
-    signing_in: req.t("pages.contactUsPublic.section3.radio2"),
-    proving_identity: req.t("pages.contactUsPublic.section3.radio3"),
-    something_else: req.t("pages.contactUsPublic.section3.radio4"),
-    email_subscriptions: req.t("pages.contactUsPublic.section3.radio5"),
-    suggestions_feedback: req.t("pages.contactUsPublic.section3.radio6"),
+    account_creation: req.t("pages.contactUsPublic.section3.accountCreation"),
+    signing_in: req.t("pages.contactUsPublic.section3.signingIn"),
+    proving_identity: req.t("pages.contactUsPublic.section3.provingIdentity"),
+    something_else: req.t("pages.contactUsPublic.section3.somethingElse"),
+    email_subscriptions: req.t("pages.contactUsPublic.section3.emailSubscriptions"),
+    suggestions_feedback: req.t("pages.contactUsPublic.section3.suggestionsFeedback"),
   };
   const signinSubthemeToQuestions: { [key: string]: any } = {
     no_security_code: req.t(

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -31,6 +31,8 @@ const themeToPageTitle = {
     "pages.contactUsQuestions.provingIdentity.title",
   [ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM]:
     "pages.contactUsQuestions.authenticatorApp.title",
+  [ZENDESK_THEMES.LINKING_PROBLEM]:
+    "pages.contactUsQuestions.linkingProblem.title",
 };
 
 const somethingElseSubThemeToPageTitle = {
@@ -66,9 +68,11 @@ export function contactUsFormPost(req: Request, res: Response): void {
     referer: req.body.referer,
   }).toString();
   if (
-    [ZENDESK_THEMES.ACCOUNT_CREATION, ZENDESK_THEMES.SIGNING_IN].includes(
-      req.body.theme
-    )
+    [
+      ZENDESK_THEMES.ACCOUNT_CREATION,
+      ZENDESK_THEMES.SIGNING_IN,
+      ZENDESK_THEMES.ID_CHECK_APP,
+    ].includes(req.body.theme)
   ) {
     url = PATH_NAMES.CONTACT_US_FURTHER_INFORMATION;
   }
@@ -136,6 +140,7 @@ export function contactUsQuestionsFormPost(
         additionalDescription: req.body.additionalDescription,
         optionalDescription: req.body.optionalDescription,
         moreDetailDescription: req.body.moreDetailDescription,
+        serviceTryingToUse: req.body.serviceTryingToUse,
       },
       themes: { theme: req.body.theme, subtheme: req.body.subtheme },
       subject: "GOV.UK Accounts Feedback",
@@ -268,6 +273,12 @@ export function getQuestionsFromFormType(
         "pages.contactUsQuestions.provingIdentity.section2.header"
       ),
     },
+    idCheckApp: {
+      issueDescription: req.t("pages.contactUsQuestions.linkingProblem.header"),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header"
+      ),
+    },
   };
 
   return formTypeToQuestions[formType];
@@ -283,8 +294,13 @@ export function getQuestionFromThemes(
     signing_in: req.t("pages.contactUsPublic.section3.signingIn"),
     proving_identity: req.t("pages.contactUsPublic.section3.provingIdentity"),
     something_else: req.t("pages.contactUsPublic.section3.somethingElse"),
-    email_subscriptions: req.t("pages.contactUsPublic.section3.emailSubscriptions"),
-    suggestions_feedback: req.t("pages.contactUsPublic.section3.suggestionsFeedback"),
+    email_subscriptions: req.t(
+      "pages.contactUsPublic.section3.emailSubscriptions"
+    ),
+    suggestions_feedback: req.t(
+      "pages.contactUsPublic.section3.suggestionsFeedback"
+    ),
+    id_check_app: req.t("pages.contactUsPublic.section3.idCheckApp"),
   };
   const signinSubthemeToQuestions: { [key: string]: any } = {
     no_security_code: req.t(
@@ -329,6 +345,13 @@ export function getQuestionFromThemes(
       "pages.contactUsFurtherInformation.accountCreation.section1.radio6"
     ),
   };
+
+  const idCheckAppSubthemeToQuestions: { [key: string]: any } = {
+    linking_problem: req.t(
+      "pages.contactUsFurtherInformation.idCheckApp.section1.linkingProblem"
+    ),
+  };
+
   const themeQuestion = themesToQuestions[theme];
   let subthemeQuestion;
   if (subtheme) {
@@ -337,6 +360,9 @@ export function getQuestionFromThemes(
     }
     if (theme == ZENDESK_THEMES.SIGNING_IN) {
       subthemeQuestion = signinSubthemeToQuestions[subtheme];
+    }
+    if (theme == ZENDESK_THEMES.ID_CHECK_APP) {
+      subthemeQuestion = idCheckAppSubthemeToQuestions[subtheme];
     }
   }
   return {

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -35,6 +35,8 @@ const themeToPageTitle = {
     "pages.contactUsQuestions.linkingProblem.title",
   [ZENDESK_THEMES.TAKING_PHOTO_OF_ID_PROBLEM]:
     "pages.contactUsQuestions.takingPhotoOfIdProblem.title",
+  [ZENDESK_THEMES.FACE_SCANNING_PROBLEM]:
+    "pages.contactUsQuestions.faceScanningProblem.title",
 };
 
 const somethingElseSubThemeToPageTitle = {

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -129,7 +129,7 @@ export function getErrorMessageForIssueDescription(
     theme === ZENDESK_THEMES.ID_CHECK_APP &&
     subtheme === ZENDESK_THEMES.LINKING_PROBLEM
   ) {
-    return "pages.contactUsQuestions.linkingProblem.section1.errorMessage";
+    return "pages.contactUsQuestions.whatHappened.errorMessage";
   }
 }
 

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -110,6 +110,12 @@ export function getErrorMessageForIssueDescription(
   ) {
     return "pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.errorMessage";
   }
+  if (
+    theme === ZENDESK_THEMES.ID_CHECK_APP &&
+    subtheme === ZENDESK_THEMES.ID_CHECK_APP_SOMETHING_ELSE
+  ) {
+    return "pages.contactUsQuestions.idCheckAppSomethingElse.section1.errorMessage";
+  }
   if (theme === ZENDESK_THEMES.ID_CHECK_APP) {
     return "pages.contactUsQuestions.whatHappened.errorMessage";
   }
@@ -156,6 +162,9 @@ export function getErrorMessageForAdditionalDescription(
     return "pages.contactUsQuestions.authenticatorApp.section2.errorMessage";
   }
   if (subtheme === ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR) {
+    return "pages.contactUsQuestions.idCheckAppTechnicalProblem.section2.errorMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.ID_CHECK_APP_SOMETHING_ELSE) {
     return "pages.contactUsQuestions.idCheckAppTechnicalProblem.section2.errorMessage";
   }
 }

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -30,15 +30,6 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
           { value }
         );
       }),
-    body("serviceTryingToUse")
-      .optional()
-      .notEmpty()
-      .withMessage((value, { req }) => {
-        return req.t(
-          "pages.contactUsQuestions.serviceTryingToUse.errorMessage",
-          { value }
-        );
-      }),
     body("additionalDescription")
       .optional()
       .notEmpty()
@@ -57,6 +48,15 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           "pages.contactUsQuestions.optionalDescriptionErrorMessage.message",
+          { value }
+        );
+      }),
+    body("serviceTryingToUse")
+      .optional()
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.serviceTryingToUse.errorMessage",
           { value }
         );
       }),
@@ -104,6 +104,12 @@ export function getErrorMessageForIssueDescription(
   if (theme === ZENDESK_THEMES.PROVING_IDENTITY) {
     return "pages.contactUsQuestions.provingIdentity.section1.errorMessage";
   }
+  if (
+    theme === ZENDESK_THEMES.ID_CHECK_APP &&
+    subtheme === ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR
+  ) {
+    return "pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.errorMessage";
+  }
   if (theme === ZENDESK_THEMES.ID_CHECK_APP) {
     return "pages.contactUsQuestions.whatHappened.errorMessage";
   }
@@ -148,5 +154,8 @@ export function getErrorMessageForAdditionalDescription(
   }
   if (subtheme === ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM) {
     return "pages.contactUsQuestions.authenticatorApp.section2.errorMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR) {
+    return "pages.contactUsQuestions.idCheckAppTechnicalProblem.section2.errorMessage";
   }
 }

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -30,6 +30,15 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
           { value }
         );
       }),
+    body("serviceTryingToUse")
+      .optional()
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.serviceTryingToUse.errorMessage",
+          { value }
+        );
+      }),
     body("additionalDescription")
       .optional()
       .notEmpty()
@@ -115,6 +124,12 @@ export function getErrorMessageForIssueDescription(
   }
   if (subtheme === ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM) {
     return "pages.contactUsQuestions.authenticatorApp.section1.errorMessage";
+  }
+  if (
+    theme === ZENDESK_THEMES.ID_CHECK_APP &&
+    subtheme === ZENDESK_THEMES.LINKING_PROBLEM
+  ) {
+    return "pages.contactUsQuestions.linkingProblem.section1.errorMessage";
   }
 }
 

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -104,6 +104,9 @@ export function getErrorMessageForIssueDescription(
   if (theme === ZENDESK_THEMES.PROVING_IDENTITY) {
     return "pages.contactUsQuestions.provingIdentity.section1.errorMessage";
   }
+  if (theme === ZENDESK_THEMES.ID_CHECK_APP) {
+    return "pages.contactUsQuestions.whatHappened.errorMessage";
+  }
   if (subtheme === ZENDESK_THEMES.ACCOUNT_NOT_FOUND) {
     return "pages.contactUsQuestions.accountNotFound.section1.errorMessage";
   }
@@ -124,12 +127,6 @@ export function getErrorMessageForIssueDescription(
   }
   if (subtheme === ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM) {
     return "pages.contactUsQuestions.authenticatorApp.section1.errorMessage";
-  }
-  if (
-    theme === ZENDESK_THEMES.ID_CHECK_APP &&
-    subtheme === ZENDESK_THEMES.LINKING_PROBLEM
-  ) {
-    return "pages.contactUsQuestions.whatHappened.errorMessage";
   }
 }
 

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -100,6 +100,11 @@ export function contactUsService(
       htmlBody.push(`<p>${descriptions.moreDetailDescription}</p>`);
     }
 
+    if (descriptions.serviceTryingToUse) {
+      htmlBody.push(`<span>[${questions.serviceTryingToUse}]</span>`);
+      htmlBody.push(`<p>${descriptions.serviceTryingToUse}</p>`);
+    }
+
     htmlBody.push(`<span>[Ticket Identifier]</span>`);
     if (optionalData.ticketIdentifier) {
       htmlBody.push(`<p>${optionalData.ticketIdentifier}</p>`);

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -59,7 +59,7 @@ export function contactUsService(
     htmlBody.push(`<p>${themeQuestions.themeQuestion}</p>`);
 
     if (themeQuestions.subthemeQuestion) {
-      htmlBody.push(`<span>[Tell us what happened?]</span>`);
+      htmlBody.push(`<span>[Subtheme]</span>`);
       htmlBody.push(`<p>${themeQuestions.subthemeQuestion}</p>`);
     }
 

--- a/src/components/contact-us/contact-us-validation.ts
+++ b/src/components/contact-us/contact-us-validation.ts
@@ -17,6 +17,9 @@ export function validateContactUsRequest(
         } else if (req.body.theme === "account_creation") {
           errorMessage =
             "pages.contactUsFurtherInformation.accountCreation.section1.errorMessage";
+        } else if (req.body.theme === "id_check_app") {
+          errorMessage =
+            "pages.contactUsFurtherInformation.idCheckApp.section1.errorMessage";
         }
 
         return req.t(errorMessage, {

--- a/src/components/contact-us/further-information/_id-check-app-further-information.njk
+++ b/src/components/contact-us/further-information/_id-check-app-further-information.njk
@@ -26,7 +26,7 @@
                     text: 'pages.contactUsFurtherInformation.idCheckApp.section1.technicalError' | translate
                 },
                 {
-                    value: "something_else",
+                    value: "id_check_app_something_else",
                     text: 'pages.contactUsFurtherInformation.idCheckApp.section1.somethingElse' | translate
                 }
             ]

--- a/src/components/contact-us/further-information/_id-check-app-further-information.njk
+++ b/src/components/contact-us/further-information/_id-check-app-further-information.njk
@@ -22,7 +22,7 @@
                     text: 'pages.contactUsFurtherInformation.idCheckApp.section1.faceScanningProblem' | translate
                 },
                 {
-                    value: "technical_error",
+                    value: "id_check_app_technical_problem",
                     text: 'pages.contactUsFurtherInformation.idCheckApp.section1.technicalError' | translate
                 },
                 {

--- a/src/components/contact-us/further-information/_id-check-app-further-information.njk
+++ b/src/components/contact-us/further-information/_id-check-app-further-information.njk
@@ -14,7 +14,7 @@
                     text: 'pages.contactUsFurtherInformation.idCheckApp.section1.linkingProblem' | translate
                 },
                 {
-                    value: "photo_problem",
+                    value: "taking_photo_of_id_problem",
                     text: 'pages.contactUsFurtherInformation.idCheckApp.section1.photoProblem' | translate
                 },
                 {

--- a/src/components/contact-us/further-information/_id-check-app-further-information.njk
+++ b/src/components/contact-us/further-information/_id-check-app-further-information.njk
@@ -1,0 +1,57 @@
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+  {{ 'pages.contactUsFurtherInformation.idCheckApp.header' | translate }}
+</h1>
+
+<form action="/contact-us-further-information" method="post" novalidate>
+
+<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+<input type="hidden" name="theme" value="{{theme}}"/>
+<input type="hidden" name="referer" value="{{referer}}"/>
+
+        {% set items = [
+                {
+                    value: "linking_problem",
+                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.linkingProblem' | translate
+                },
+                {
+                    value: "photo_problem",
+                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.photoProblem' | translate
+                },
+                {
+                    value: "face_scanning_problem",
+                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.faceScanningProblem' | translate
+                },
+                {
+                    value: "technical_error",
+                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.technicalError' | translate
+                },
+                {
+                    value: "something_else",
+                    text: 'pages.contactUsFurtherInformation.idCheckApp.section1.somethingElse' | translate
+                }
+            ]
+        %}
+
+    {{ govukRadios({
+        name: "subtheme",
+        fieldset: {
+            legend: {
+                text: 'pages.contactUsFurtherInformation.idCheckApp.section1.header' | translate,
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: items,
+      errorMessage: {
+      text: errors['subtheme'].text
+      } if (errors['subtheme'])
+    }) }}
+
+
+{{ govukButton({
+    "text": "general.continue.label" | translate,
+    "type": "Submit",
+    "preventDoubleClick": true
+}) }}
+
+</form>

--- a/src/components/contact-us/further-information/index.njk
+++ b/src/components/contact-us/further-information/index.njk
@@ -17,6 +17,10 @@
     {% set pageTitleName = 'pages.contactUsFurtherInformation.accountCreation.title' | translate %}
 {% endif %}
 
+{% if theme == 'id_check_app' %}
+    {% set pageTitleName = 'pages.contactUsFurtherInformation.idCheckApp.title' | translate %}
+{% endif %}
+
 {% block content %}
 {% include "common/errors/errorSummary.njk" %}
 
@@ -28,7 +32,8 @@
         {% include 'contact-us/further-information/_account-creation-further-information.njk' %}
     {% endif %}
 
+    {% if theme == 'id_check_app' %}
+        {% include 'contact-us/further-information/_id-check-app-further-information.njk' %}
+    {% endif %}
+
 {% endblock %}
-
-
-

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -55,12 +55,16 @@
                 text: 'pages.contactUsPublic.section3.radio2' | translate
             },
             {
-                value: "proving_identity",
-                text: 'pages.contactUsPublic.section3.radio3' | translate
-            },
-            {
                 value: "something_else",
                 text: 'pages.contactUsPublic.section3.radio4' | translate
+            },
+            {
+                value: "id_check_app",
+                text: 'pages.contactUsPublic.section3.idCheckApp' | translate
+            },
+            {
+                value: "proving_identity",
+                text: 'pages.contactUsPublic.section3.radio3' | translate
             },
             {
                 value: "email_subscriptions",

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -48,15 +48,15 @@
         items: [
             {
                 value: "account_creation",
-                text: 'pages.contactUsPublic.section3.radio1' | translate
+                text: 'pages.contactUsPublic.section3.accountCreation' | translate
             },
             {
                 value: "signing_in",
-                text: 'pages.contactUsPublic.section3.radio2' | translate
+                text: 'pages.contactUsPublic.section3.signingIn' | translate
             },
             {
                 value: "something_else",
-                text: 'pages.contactUsPublic.section3.radio4' | translate
+                text: 'pages.contactUsPublic.section3.somethingElse' | translate
             },
             {
                 value: "id_check_app",
@@ -64,15 +64,15 @@
             },
             {
                 value: "proving_identity",
-                text: 'pages.contactUsPublic.section3.radio3' | translate
+                text: 'pages.contactUsPublic.section3.provingIdentity' | translate
             },
             {
                 value: "email_subscriptions",
-                text: 'pages.contactUsPublic.section3.radio5' | translate
+                text: 'pages.contactUsPublic.section3.emailSubscriptions' | translate
             },
             {
                 value: "suggestions_feedback",
-                text: 'pages.contactUsPublic.section3.radio6' | translate
+                text: 'pages.contactUsPublic.section3.suggestionsFeedback' | translate
             }
         ],
           errorMessage: {

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -36,16 +36,8 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-    {{ govukRadios({
-        name: "theme",
-        fieldset: {
-            legend: {
-                text: 'pages.contactUsPublic.section3.header' | translate,
-                isPageHeading: false,
-                classes: "govuk-fieldset__legend--m"
-            }
-        },
-        items: [
+    {% if showIdCheckAppFormOption === true %}
+        {% set items = [
             {
                 value: "account_creation",
                 text: 'pages.contactUsPublic.section3.accountCreation' | translate
@@ -74,7 +66,46 @@
                 value: "suggestions_feedback",
                 text: 'pages.contactUsPublic.section3.suggestionsFeedback' | translate
             }
-        ],
+        ] %}
+    {% else %}
+        {% set items = [
+            {
+                value: "account_creation",
+                text: 'pages.contactUsPublic.section3.accountCreation' | translate
+            },
+            {
+                value: "signing_in",
+                text: 'pages.contactUsPublic.section3.signingIn' | translate
+            },
+            {
+                value: "something_else",
+                text: 'pages.contactUsPublic.section3.somethingElse' | translate
+            },
+            {
+                value: "proving_identity",
+                text: 'pages.contactUsPublic.section3.provingIdentity' | translate
+            },
+            {
+                value: "email_subscriptions",
+                text: 'pages.contactUsPublic.section3.emailSubscriptions' | translate
+            },
+            {
+                value: "suggestions_feedback",
+                text: 'pages.contactUsPublic.section3.suggestionsFeedback' | translate
+            }
+        ] %}
+    {% endif %}
+
+    {{ govukRadios({
+        name: "theme",
+        fieldset: {
+            legend: {
+                text: 'pages.contactUsPublic.section3.header' | translate,
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: items,
           errorMessage: {
           text: errors['theme'].text
           } if (errors['theme'])

--- a/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
@@ -11,21 +11,7 @@
     <input type="hidden" name="formType" value="idCheckApp"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
 
-    {{ govukTextarea({
-        label: {
-            text: 'pages.contactUsQuestions.faceScanningProblem.section1.header' | translate,
-            classes: "govuk-label--s"
-        },
-        hint: {
-            text: 'pages.contactUsQuestions.faceScanningProblem.section1.paragraph1' | translate
-        },
-        id: "issueDescription",
-        name: "issueDescription",
-        value: issueDescription,
-        errorMessage: {
-            text: errors['issueDescription'].text
-        } if (errors['issueDescription'])
-    }) }}
+    {% include 'contact-us/questions/_what_happened.njk' %}
 
     {{ govukWarningText({
         text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,

--- a/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
@@ -1,0 +1,45 @@
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+    {{ 'pages.contactUsQuestions.faceScanningProblem.header' | translate }}
+</h1>
+
+<form action="/contact-us-questions" method="post" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="theme" value="{{theme}}"/>
+    <input type="hidden" name="subtheme" value="{{subtheme}}"/>
+    <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="formType" value="idCheckApp"/>
+    <input type="hidden" name="referer" value="{{referer}}"/>
+
+    {{ govukTextarea({
+        label: {
+            text: 'pages.contactUsQuestions.faceScanningProblem.section1.header' | translate,
+            classes: "govuk-label--s"
+        },
+        hint: {
+            text: 'pages.contactUsQuestions.faceScanningProblem.section1.paragraph1' | translate
+        },
+        id: "issueDescription",
+        name: "issueDescription",
+        value: issueDescription,
+        errorMessage: {
+            text: errors['issueDescription'].text
+        } if (errors['issueDescription'])
+    }) }}
+
+    {{ govukWarningText({
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+        iconFallbackText: "Warning"
+    }) }}
+
+    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
+
+    {% include 'contact-us/questions/_reply_by_email.njk' %}
+
+    {{ govukButton({
+        "text": "general.sendMessage" | translate,
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
+
+</form>

--- a/src/components/contact-us/questions/_id-check-app-linking-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-linking-problem.njk
@@ -11,21 +11,7 @@
 <input type="hidden" name="formType" value="idCheckApp"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
-    label: {
-      text: 'pages.contactUsQuestions.linkingProblem.section1.header' | translate,
-      classes: "govuk-label--s"
-    },
-    hint: {
-        text: 'pages.contactUsQuestions.linkingProblem.section1.paragraph1' | translate
-      },
-    id: "issueDescription",
-    name: "issueDescription",
-    value: issueDescription,
-    errorMessage: {
-        text: errors['issueDescription'].text
-    } if (errors['issueDescription'])
-}) }}
+{% include 'contact-us/questions/_what_happened.njk' %}
 
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,

--- a/src/components/contact-us/questions/_id-check-app-linking-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-linking-problem.njk
@@ -1,0 +1,45 @@
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+  {{ 'pages.contactUsQuestions.linkingProblem.header' | translate }}
+</h1>
+
+<form action="/contact-us-questions" method="post" novalidate>
+
+<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+<input type="hidden" name="theme" value="{{theme}}"/>
+<input type="hidden" name="subtheme" value="{{subtheme}}"/>
+<input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="formType" value="idCheckApp"/>
+<input type="hidden" name="referer" value="{{referer}}"/>
+
+{{ govukTextarea({
+    label: {
+      text: 'pages.contactUsQuestions.linkingProblem.section1.header' | translate,
+      classes: "govuk-label--s"
+    },
+    hint: {
+        text: 'pages.contactUsQuestions.linkingProblem.section1.paragraph1' | translate
+      },
+    id: "issueDescription",
+    name: "issueDescription",
+    value: issueDescription,
+    errorMessage: {
+        text: errors['issueDescription'].text
+    } if (errors['issueDescription'])
+}) }}
+
+{{ govukWarningText({
+    text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+    iconFallbackText: "Warning"
+}) }}
+
+{% include 'contact-us/questions/_service_trying_to_use.njk' %}
+
+{% include 'contact-us/questions/_reply_by_email.njk' %}
+
+{{ govukButton({
+    "text": "general.sendMessage" | translate,
+    "type": "Submit",
+    "preventDoubleClick": true
+}) }}
+
+</form>

--- a/src/components/contact-us/questions/_id-check-app-something-else.njk
+++ b/src/components/contact-us/questions/_id-check-app-something-else.njk
@@ -1,0 +1,58 @@
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+    {{ 'pages.contactUsQuestions.idCheckAppSomethingElse.section1.title' | translate }}
+</h1>
+
+<form action="/contact-us-questions" method="post" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="theme" value="{{theme}}"/>
+    <input type="hidden" name="subtheme" value="{{subtheme}}"/>
+    <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="formType" value="idCheckAppSomethingElse"/>
+    <input type="hidden" name="referer" value="{{referer}}"/>
+
+    {{ govukTextarea({
+        label: {
+            text: 'pages.contactUsQuestions.idCheckAppSomethingElse.section1.header' | translate,
+            classes: "govuk-label--s"
+        },
+        id: "issueDescription",
+        name: "issueDescription",
+        value: issueDescription,
+        errorMessage: {
+            text: errors['issueDescription'].text
+        } if (errors['issueDescription'])
+    }) }}
+
+    {{ govukTextarea({
+        label: {
+            text: 'pages.contactUsQuestions.idCheckAppSomethingElse.section2.header' | translate,
+            classes: "govuk-label--s"
+        },
+        hint: {
+            text: 'pages.contactUsQuestions.idCheckAppSomethingElse.section2.paragraph1' | translate
+        },
+        id: "additionalDescription",
+        name: "additionalDescription",
+        value: additionalDescription,
+        errorMessage: {
+            text: errors['additionalDescription'].text
+        } if (errors['additionalDescription'])
+    }) }}
+
+    {{ govukWarningText({
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+        iconFallbackText: "Warning"
+    }) }}
+
+    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
+
+    {% include 'contact-us/questions/_reply_by_email.njk' %}
+
+    {{ govukButton({
+        "text": "general.sendMessage" | translate,
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
+
+</form>

--- a/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
@@ -11,21 +11,7 @@
     <input type="hidden" name="formType" value="idCheckApp"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
 
-    {{ govukTextarea({
-        label: {
-            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.section1.header' | translate,
-            classes: "govuk-label--s"
-        },
-        hint: {
-            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.section1.paragraph1' | translate
-        },
-        id: "issueDescription",
-        name: "issueDescription",
-        value: issueDescription,
-        errorMessage: {
-            text: errors['issueDescription'].text
-        } if (errors['issueDescription'])
-    }) }}
+    {% include 'contact-us/questions/_what_happened.njk' %}
 
     {{ govukWarningText({
         text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,

--- a/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
@@ -1,0 +1,45 @@
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+    {{ 'pages.contactUsQuestions.takingPhotoOfIdProblem.header' | translate }}
+</h1>
+
+<form action="/contact-us-questions" method="post" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="theme" value="{{theme}}"/>
+    <input type="hidden" name="subtheme" value="{{subtheme}}"/>
+    <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="formType" value="idCheckApp"/>
+    <input type="hidden" name="referer" value="{{referer}}"/>
+
+    {{ govukTextarea({
+        label: {
+            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.section1.header' | translate,
+            classes: "govuk-label--s"
+        },
+        hint: {
+            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.section1.paragraph1' | translate
+        },
+        id: "issueDescription",
+        name: "issueDescription",
+        value: issueDescription,
+        errorMessage: {
+            text: errors['issueDescription'].text
+        } if (errors['issueDescription'])
+    }) }}
+
+    {{ govukWarningText({
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+        iconFallbackText: "Warning"
+    }) }}
+
+    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
+
+    {% include 'contact-us/questions/_reply_by_email.njk' %}
+
+    {{ govukButton({
+        "text": "general.sendMessage" | translate,
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
+
+</form>

--- a/src/components/contact-us/questions/_id-check-app-technical-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-technical-problem.njk
@@ -1,0 +1,58 @@
+<h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+    {{ 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.title' | translate }}
+</h1>
+
+<form action="/contact-us-questions" method="post" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="theme" value="{{theme}}"/>
+    <input type="hidden" name="subtheme" value="{{subtheme}}"/>
+    <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="formType" value="idCheckAppTechnicalProblem"/>
+    <input type="hidden" name="referer" value="{{referer}}"/>
+
+    {{ govukTextarea({
+        label: {
+            text: 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.header' | translate,
+            classes: "govuk-label--s"
+        },
+        id: "issueDescription",
+        name: "issueDescription",
+        value: issueDescription,
+        errorMessage: {
+            text: errors['issueDescription'].text
+        } if (errors['issueDescription'])
+    }) }}
+
+    {{ govukTextarea({
+        label: {
+            text: 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section2.header' | translate,
+            classes: "govuk-label--s"
+        },
+        hint: {
+            text: 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section2.paragraph1' | translate
+        },
+        id: "additionalDescription",
+        name: "additionalDescription",
+        value: additionalDescription,
+        errorMessage: {
+            text: errors['additionalDescription'].text
+        } if (errors['additionalDescription'])
+    }) }}
+
+    {{ govukWarningText({
+        text:'pages.contactUsQuestions.personalInformation.paragraph1' | translate,
+        iconFallbackText: "Warning"
+    }) }}
+
+    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
+
+    {% include 'contact-us/questions/_reply_by_email.njk' %}
+
+    {{ govukButton({
+        "text": "general.sendMessage" | translate,
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
+
+</form>

--- a/src/components/contact-us/questions/_service_trying_to_use.njk
+++ b/src/components/contact-us/questions/_service_trying_to_use.njk
@@ -1,0 +1,15 @@
+{{ govukInput({
+    label: {
+        text: 'pages.contactUsQuestions.serviceTryingToUse.header' | translate,
+        classes: "govuk-label--s"
+    },
+    id: "serviceTryingToUse",
+    name: "serviceTryingToUse",
+    value: serviceTryingToUse,
+    hint: {
+        text: 'pages.contactUsQuestions.serviceTryingToUse.hint' | translate
+    },
+    errorMessage: {
+        text: errors['serviceTryingToUse'].text
+    } if (errors['serviceTryingToUse'])
+}) }}

--- a/src/components/contact-us/questions/_what_happened.njk
+++ b/src/components/contact-us/questions/_what_happened.njk
@@ -1,0 +1,15 @@
+{{ govukTextarea({
+    label: {
+        text: 'pages.contactUsQuestions.whatHappened.header' | translate,
+        classes: "govuk-label--s"
+    },
+    hint: {
+        text: 'pages.contactUsQuestions.whatHappened.paragraph1' | translate
+    },
+    id: "issueDescription",
+    name: "issueDescription",
+    value: issueDescription,
+    errorMessage: {
+        text: errors['issueDescription'].text
+    } if (errors['issueDescription'])
+}) }}

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -78,4 +78,8 @@
         {% include 'contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk' %}
     {% endif %}
 
+    {% if (theme == 'id_check_app') and (subtheme == 'face_scanning_problem') %}
+        {% include 'contact-us/questions/_id-check-app-face-scanning-problem.njk' %}
+    {% endif %}
+
 {% endblock %}

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -74,4 +74,8 @@
         {% include 'contact-us/questions/_id-check-app-linking-problem.njk' %}
     {% endif %}
 
+    {% if (theme == 'id_check_app') and (subtheme == 'taking_photo_of_id_problem') %}
+        {% include 'contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk' %}
+    {% endif %}
+
 {% endblock %}

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -86,4 +86,8 @@
         {% include 'contact-us/questions/_id-check-app-technical-problem.njk' %}
     {% endif %}
 
+    {% if (theme == 'id_check_app') and (subtheme == 'id_check_app_something_else') %}
+        {% include 'contact-us/questions/_id-check-app-something-else.njk' %}
+    {% endif %}
+
 {% endblock %}

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -70,4 +70,8 @@
         {% include 'contact-us/questions/_proving-identity-problem-questions.njk' %}
     {% endif %}
 
+    {% if (theme == 'id_check_app') and (subtheme == 'linking_problem') %}
+        {% include 'contact-us/questions/_id-check-app-linking-problem.njk' %}
+    {% endif %}
+
 {% endblock %}

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -82,4 +82,8 @@
         {% include 'contact-us/questions/_id-check-app-face-scanning-problem.njk' %}
     {% endif %}
 
+    {% if (theme == 'id_check_app') and (subtheme == 'id_check_app_technical_problem') %}
+        {% include 'contact-us/questions/_id-check-app-technical-problem.njk' %}
+    {% endif %}
+
 {% endblock %}

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -23,6 +23,7 @@ export interface Questions {
   optionalDescription?: string;
   moreDetailDescription?: string;
   radioButtons?: string;
+  serviceTryingToUse?: string;
 }
 
 export interface ThemeQuestions {
@@ -35,6 +36,7 @@ export interface Descriptions {
   additionalDescription?: string;
   optionalDescription?: string;
   moreDetailDescription?: string;
+  serviceTryingToUse?: string;
 }
 
 export interface Themes {

--- a/src/config.ts
+++ b/src/config.ts
@@ -62,6 +62,10 @@ export function supportPasswordResetRequired(): boolean {
   return process.env.SUPPORT_PASSWORD_RESET_REQUIRED === "1";
 }
 
+export function supportIdCheckAppForms(): boolean {
+  return process.env.SUPPORT_ID_CHECK_APP_FORMS === "1";
+}
+
 export async function getRedisConfig(appEnv: string): Promise<RedisConfig> {
   const hostKey = `${appEnv}-${process.env.REDIS_KEY}-redis-master-host`;
   const portKey = `${appEnv}-${process.env.REDIS_KEY}-redis-port`;

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1403,8 +1403,8 @@
         }
       },
       "technicalError": {
-        "title": "There was a technical error",
-        "header": "There was a technical error",
+        "title": "There was a technical problem",
+        "header": "There was a technical problem",
         "section1": {
           "header": "What were you trying to do?",
           "errorMessage": "Enter what you were trying to do"

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1536,6 +1536,19 @@
       "faceScanningProblem": {
         "title": "You had a problem scanning your face using the GOV.UK ID Check app",
         "header": "You had a problem scanning your face using the GOV.UK ID Check app"
+      },
+      "idCheckAppTechnicalProblem": {
+        "title": "You had a technical problem",
+        "section1": {
+          "title": "You had a technical problem",
+          "header": "What were you trying to do?",
+          "errorMessage": "Tell us what you were trying to do"
+        },
+        "section2": {
+          "header": "What happened?",
+          "paragraph1": "Include details of the error",
+          "errorMessage": "Tell us what happened"
+        }
       }
     },
     "contactUsSubmitSuccess": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1278,6 +1278,7 @@
         "radio4": "Another problem using your GOV.UK account",
         "radio5": "GOV.UK email subscriptions",
         "radio6": "A suggestion or feedback about using your GOV.UK account",
+        "idCheckApp": "A problem proving your identity using the GOV.UK ID Check app",
         "errorMessage": "Select a reason for contacting us"
       },
       "submitButtonText": "Submit",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1528,6 +1528,15 @@
           "paragraph1": "For example, did you see any warning or error messages?",
           "errorMessage": "Enter what happened"
         }
+      },
+      "takingPhotoOfIdProblem": {
+        "title": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
+        "header": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
+        "section1":{
+          "header": "What happened?",
+          "paragraph1": "For example, did you see any warning or error messages?",
+          "errorMessage": "Enter what happened"
+        }
       }
     },
     "contactUsSubmitSuccess": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1411,7 +1411,7 @@
         },
         "section2": {
           "header": "What happened?",
-          "paragraph1": "Included details of the error",
+          "paragraph1": "Include details of the error",
           "errorMessage": "Enter what happened"
         },
         "section3": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1313,11 +1313,29 @@
           "radio6": "You had a problem with an authenticator app",
           "errorMessage": "Select the problem you had when creating an account"
         }
+      },
+      "idCheckApp": {
+        "title": "A problem proving your identity using the GOV.UK ID Check app",
+        "header": "A problem proving your identity using the GOV.UK ID Check app",
+        "section1": {
+          "header": "Tell us what happened",
+          "linkingProblem": "You had a problem linking the app to your web browser",
+          "photoProblem": "You had a problem taking a photo of your identity document (for example, passport of driving licence",
+          "faceScanningProblem": "You had a problem scanning your face",
+          "technicalError": "There was a technical problem (for example you saw an error message)",
+          "somethingElse": "Something else",
+          "errorMessage": "Select the problem you had when proving your identity using the GOV.UK ID Check app"
+        }
       }
     },
     "contactUsQuestions": {
       "personalInformation": {
-        "paragraph1": "Do not include personal or financial information, for example your National Insurance number or credit card details."
+        "paragraph1": "Do not include personal or financial information, for example your passport or credit card details."
+      },
+      "serviceTryingToUse": {
+        "header": "What service were you trying to use?",
+        "hint": "For example, get a DBS check",
+        "errorMessage": "Enter the name of the service"
       },
       "replyByEmail": {
         "validationError": {
@@ -1500,6 +1518,15 @@
         "section2": {
           "header": "Ydych chi eisiau dweud unrhyw beth arall wrthym",
           "paragraph1": "Er enghraifft, os ydych eisiau ychwanegu mwy o fanylion neu roi adborth i ni"
+        }
+      },
+      "linkingProblem": {
+        "title": "You had a problem linking the app to your web browser",
+        "header": "You had a problem linking the app to your web browser",
+        "section1":{
+          "header": "What happened?",
+          "paragraph1": "For example, did you see any warning or error messages?",
+          "errorMessage": "Enter what happened"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1537,6 +1537,15 @@
           "paragraph1": "For example, did you see any warning or error messages?",
           "errorMessage": "Enter what happened"
         }
+      },
+      "faceScanningProblem": {
+        "title": "You had a problem scanning your face using the GOV.UK ID Check app",
+        "header": "You had a problem scanning your face using the GOV.UK ID Check app",
+        "section1":{
+          "header": "What happened?",
+          "paragraph1": "For example, did you see any warning or error messages?",
+          "errorMessage": "Enter what happened"
+        }
       }
     },
     "contactUsSubmitSuccess": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1549,6 +1549,19 @@
           "paragraph1": "Include details of the error",
           "errorMessage": "Tell us what happened"
         }
+      },
+      "idCheckAppSomethingElse": {
+        "title": "Another problem with the GOV.UK ID Check app",
+        "section1": {
+          "title": "Another problem with the GOV.UK ID Check app",
+          "header": "What were you trying to do?",
+          "errorMessage": "Tell us what you were trying to do"
+        },
+        "section2": {
+          "header": "What happened?",
+          "paragraph1": "For example, was there a technical problem?",
+          "errorMessage": "Tell us what happened"
+        }
       }
     },
     "contactUsSubmitSuccess": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1320,7 +1320,7 @@
         "section1": {
           "header": "Tell us what happened",
           "linkingProblem": "You had a problem linking the app to your web browser",
-          "photoProblem": "You had a problem taking a photo of your identity document (for example, passport of driving licence",
+          "photoProblem": "You had a problem taking a photo of your identity document (for example, passport or driving licence)",
           "faceScanningProblem": "You had a problem scanning your face",
           "technicalError": "There was a technical problem (for example you saw an error message)",
           "somethingElse": "Something else",
@@ -1331,6 +1331,11 @@
     "contactUsQuestions": {
       "personalInformation": {
         "paragraph1": "Do not include personal or financial information, for example your passport or credit card details."
+      },
+      "whatHappened": {
+        "header": "What happened?",
+        "paragraph1": "For example, did you see any warning or error messages?",
+        "errorMessage": "Enter what happened"
       },
       "serviceTryingToUse": {
         "header": "What service were you trying to use?",
@@ -1522,30 +1527,15 @@
       },
       "linkingProblem": {
         "title": "You had a problem linking the app to your web browser",
-        "header": "You had a problem linking the app to your web browser",
-        "section1":{
-          "header": "What happened?",
-          "paragraph1": "For example, did you see any warning or error messages?",
-          "errorMessage": "Enter what happened"
-        }
+        "header": "You had a problem linking the app to your web browser"
       },
       "takingPhotoOfIdProblem": {
         "title": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
-        "header": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
-        "section1":{
-          "header": "What happened?",
-          "paragraph1": "For example, did you see any warning or error messages?",
-          "errorMessage": "Enter what happened"
-        }
+        "header": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app"
       },
       "faceScanningProblem": {
         "title": "You had a problem scanning your face using the GOV.UK ID Check app",
-        "header": "You had a problem scanning your face using the GOV.UK ID Check app",
-        "section1":{
-          "header": "What happened?",
-          "paragraph1": "For example, did you see any warning or error messages?",
-          "errorMessage": "Enter what happened"
-        }
+        "header": "You had a problem scanning your face using the GOV.UK ID Check app"
       }
     },
     "contactUsSubmitSuccess": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1272,12 +1272,12 @@
       },
       "section3": {
         "header": "What are you contacting us about?",
-        "radio1": "A problem creating a GOV.UK account",
-        "radio2": "A problem signing in to your GOV.UK account",
-        "radio3": "A problem proving your identity",
-        "radio4": "Another problem using your GOV.UK account",
-        "radio5": "GOV.UK email subscriptions",
-        "radio6": "A suggestion or feedback about using your GOV.UK account",
+        "accountCreation": "A problem creating a GOV.UK account",
+        "signingIn": "A problem signing in to your GOV.UK account",
+        "provingIdentity": "A problem proving your identity",
+        "somethingElse": "Another problem using your GOV.UK account",
+        "emailSubscriptions": "GOV.UK email subscriptions",
+        "suggestionsFeedback": "A suggestion or feedback about using your GOV.UK account",
         "idCheckApp": "A problem proving your identity using the GOV.UK ID Check app",
         "errorMessage": "Select a reason for contacting us"
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1314,11 +1314,29 @@
           "radio6": "You had a problem with an authenticator app",
           "errorMessage": "Select the problem you had when creating an account"
         }
+      },
+      "idCheckApp": {
+        "title": "A problem proving your identity using the GOV.UK ID Check app",
+        "header": "A problem proving your identity using the GOV.UK ID Check app",
+        "section1": {
+          "header": "Tell us what happened",
+          "linkingProblem": "You had a problem linking the app to your web browser",
+          "photoProblem": "You had a problem taking a photo of your identity document (for example, passport of driving licence",
+          "faceScanningProblem": "You had a problem scanning your face",
+          "technicalError": "There was a technical problem (for example you saw an error message)",
+          "somethingElse": "Something else",
+          "errorMessage": "Select the problem you had when proving your identity using the GOV.UK ID Check app"
+        }
       }
     },
     "contactUsQuestions": {
       "personalInformation": {
-        "paragraph1": "Do not include personal or financial information, for example your National Insurance number or credit card details."
+        "paragraph1": "Do not include personal or financial information, for example your passport or credit card details."
+      },
+      "serviceTryingToUse": {
+        "header": "What service were you trying to use?",
+        "hint": "For example, get a DBS check",
+        "errorMessage": "Enter the name of the service"
       },
       "replyByEmail": {
         "validationError": {
@@ -1502,6 +1520,15 @@
           "header": "Anything else you want to tell us",
           "paragraph1": "For example, if you want to add more detail or give us feedback"
         }
+      },
+      "linkingProblem": {
+          "title": "You had a problem linking the app to your web browser",
+          "header": "You had a problem linking the app to your web browser",
+          "section1":{
+            "header": "What happened?",
+            "paragraph1": "For example, did you see any warning or error messages?",
+            "errorMessage": "Enter what happened"
+          }
       }
     },
     "contactUsSubmitSuccess": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1538,6 +1538,15 @@
             "paragraph1": "For example, did you see any warning or error messages?",
             "errorMessage": "Enter what happened"
           }
+      },
+      "faceScanningProblem": {
+        "title": "You had a problem scanning your face using the GOV.UK ID Check app",
+        "header": "You had a problem scanning your face using the GOV.UK ID Check app",
+        "section1":{
+          "header": "What happened?",
+          "paragraph1": "For example, did you see any warning or error messages?",
+          "errorMessage": "Enter what happened"
+        }
       }
     },
     "contactUsSubmitSuccess": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1279,6 +1279,7 @@
         "radio4": "Another problem using your GOV.UK account",
         "radio5": "GOV.UK email subscriptions",
         "radio6": "A suggestion or feedback about using your GOV.UK account",
+        "idCheckApp": "A problem proving your identity using the GOV.UK ID Check app",
         "errorMessage": "Select a reason for contacting us"
       },
       "submitButtonText": "Submit",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1321,7 +1321,7 @@
         "section1": {
           "header": "Tell us what happened",
           "linkingProblem": "You had a problem linking the app to your web browser",
-          "photoProblem": "You had a problem taking a photo of your identity document (for example, passport of driving licence",
+          "photoProblem": "You had a problem taking a photo of your identity document (for example, passport or driving licence)",
           "faceScanningProblem": "You had a problem scanning your face",
           "technicalError": "There was a technical problem (for example you saw an error message)",
           "somethingElse": "Something else",
@@ -1332,6 +1332,11 @@
     "contactUsQuestions": {
       "personalInformation": {
         "paragraph1": "Do not include personal or financial information, for example your passport or credit card details."
+      },
+      "whatHappened": {
+        "header": "What happened?",
+        "paragraph1": "For example, did you see any warning or error messages?",
+        "errorMessage": "Enter what happened"
       },
       "serviceTryingToUse": {
         "header": "What service were you trying to use?",
@@ -1523,30 +1528,15 @@
       },
       "linkingProblem": {
           "title": "You had a problem linking the app to your web browser",
-          "header": "You had a problem linking the app to your web browser",
-          "section1":{
-            "header": "What happened?",
-            "paragraph1": "For example, did you see any warning or error messages?",
-            "errorMessage": "Enter what happened"
-          }
+          "header": "You had a problem linking the app to your web browser"
       },
       "takingPhotoOfIdProblem": {
           "title": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
-          "header": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
-          "section1":{
-            "header": "What happened?",
-            "paragraph1": "For example, did you see any warning or error messages?",
-            "errorMessage": "Enter what happened"
-          }
+          "header": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app"
       },
       "faceScanningProblem": {
         "title": "You had a problem scanning your face using the GOV.UK ID Check app",
-        "header": "You had a problem scanning your face using the GOV.UK ID Check app",
-        "section1":{
-          "header": "What happened?",
-          "paragraph1": "For example, did you see any warning or error messages?",
-          "errorMessage": "Enter what happened"
-        }
+        "header": "You had a problem scanning your face using the GOV.UK ID Check app"
       }
     },
     "contactUsSubmitSuccess": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1404,8 +1404,8 @@
         }
       },
       "technicalError": {
-        "title": "There was a technical error",
-        "header": "There was a technical error",
+        "title": "There was a technical problem",
+        "header": "There was a technical problem",
         "section1": {
           "header": "What were you trying to do?",
           "errorMessage": "Enter what you were trying to do"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1273,12 +1273,12 @@
       },
       "section3": {
         "header": "What are you contacting us about?",
-        "radio1": "A problem creating a GOV.UK account",
-        "radio2": "A problem signing in to your GOV.UK account",
-        "radio3": "A problem proving your identity",
-        "radio4": "Another problem using your GOV.UK account",
-        "radio5": "GOV.UK email subscriptions",
-        "radio6": "A suggestion or feedback about using your GOV.UK account",
+        "accountCreation": "A problem creating a GOV.UK account",
+        "signingIn": "A problem signing in to your GOV.UK account",
+        "provingIdentity": "A problem proving your identity",
+        "somethingElse": "Another problem using your GOV.UK account",
+        "emailSubscriptions": "GOV.UK email subscriptions",
+        "suggestionsFeedback": "A suggestion or feedback about using your GOV.UK account",
         "idCheckApp": "A problem proving your identity using the GOV.UK ID Check app",
         "errorMessage": "Select a reason for contacting us"
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1537,6 +1537,19 @@
       "faceScanningProblem": {
         "title": "You had a problem scanning your face using the GOV.UK ID Check app",
         "header": "You had a problem scanning your face using the GOV.UK ID Check app"
+      },
+      "idCheckAppTechnicalProblem": {
+        "title": "You had a technical problem",
+        "section1": {
+          "title": "You had a technical problem",
+          "header": "What were you trying to do?",
+          "errorMessage": "Tell us what you were trying to do"
+        },
+        "section2": {
+          "header": "What happened?",
+          "paragraph1": "Include details of the error",
+          "errorMessage": "Tell us what happened"
+        }
       }
     },
     "contactUsSubmitSuccess": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1412,7 +1412,7 @@
         },
         "section2": {
           "header": "What happened?",
-          "paragraph1": "Included details of the error",
+          "paragraph1": "Include details of the error",
           "errorMessage": "Enter what happened"
         },
         "section3": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1550,6 +1550,19 @@
           "paragraph1": "Include details of the error",
           "errorMessage": "Tell us what happened"
         }
+      },
+      "idCheckAppSomethingElse": {
+        "title": "Another problem with the GOV.UK ID Check app",
+        "section1": {
+          "title": "Another problem with the GOV.UK ID Check app",
+          "header": "What were you trying to do?",
+          "errorMessage": "Tell us what you were trying to do"
+        },
+        "section2": {
+          "header": "What happened?",
+          "paragraph1": "For example, was there a technical problem?",
+          "errorMessage": "Tell us what happened"
+        }
       }
     },
     "contactUsSubmitSuccess": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1529,6 +1529,15 @@
             "paragraph1": "For example, did you see any warning or error messages?",
             "errorMessage": "Enter what happened"
           }
+      },
+      "takingPhotoOfIdProblem": {
+          "title": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
+          "header": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
+          "section1":{
+            "header": "What happened?",
+            "paragraph1": "For example, did you see any warning or error messages?",
+            "errorMessage": "Enter what happened"
+          }
       }
     },
     "contactUsSubmitSuccess": {


### PR DESCRIPTION
## What?

Add GOV.UK ID Check app specific options to support pages. 

The initial option to access ID Check App forms will be displayed only where the `support_id_check_app_forms=1` environment variable is present. The feature flag was introduced in a secondary commit that can be reverted when the feature has been confirmed by user support as working as expected. I've also set this variable to default to "0" but have a value of "1" in `staging.tfvars`.

## Why?

So that users experiencing issues with the GOV.UK ID Check app are presented with suitable options on the support pages.

## How this was approached

In addition to adding the new entries in the Welsh and English`translation.json` files, the steps to achieve this were: 

### Adding a working ID App Check option to the support landing page
- [x] **Re-order** radio options in `index-public-contact-us.njk` and (because the naming convention no longer made sense) change from numeric names to descriptive names (i.e. `radio2` becomes `signingIn`) 
- [x] **Add** new radio option for `id_check_app` to `index-public-contact-us.njk`
- [x] **Add** new properties to the `ZENDESK_THEMES` constant. One for the `ID_CHECK_APP` "parent" and one for each subtheme (i.e.`LINKING_PROBLEM`) 

### Adding a page to show sub-theme options for ID Check app
- [x] **Update** `contactUsFormPost` so that where the theme is `ZENDESK_THEMES.ID_CHECK_APP` the user is directed to `PATH_NAMES.CONTACT_US_FURTHER_INFORMATION`
- [x] **Introduce** new `_id-check-app-further-information.njk` template to present sub-theme options for the ID Check App 
- [x] **Update** `/further-information/index.njk` template to show this where the `theme` is `id_check_app`
- [x] **Add** validation message for users who try to proceed without selecting an option

### Adding new forms for the ID Check App sub-themes
- [x] **Add** entry to `themeToPageTitle` object 
- [x] **Add** condition to `contact-us/questions/index.njk` **and** new templates in `contact-us/questions/` where `formType` is `idCheckApp`
    - [x] `_id-check-app-linking-problem.njk` **AUT-923**
    - [x] `_id-check-app-taking-photo-of-id-problem.njs` **AUT-925**
    - [x] `_id-check-app-face-scanning-problem.njk` **AUT-926**
    - [x] [`_id-check-app-technical-problem.njk`" **AUT-927**
    - [x] `_id-check-app-other-problem.njk` **AUT-928**
- [x] **Add** new `_service_trying_to_use.njk` template to hold field shared across forms

### Update validation
- [x] **Add** new rule to `contact-us-questions-validation.ts` to ensure `serviceTryingToUse` is `.notEmpty()`

### Permit processing of new forms
- [x] **Update** the `Descriptions` and `Questions` interfaces to include new `serviceTryingToUse?: string`
- [x] **Add** `serviceTryingToUse` to the `descriptions` object passed to `service.ContactUsSubmitForm`
- [x] **Add** `idCheckApp` object and references to the `getQuestionsFromFormType()` and `themesToQuestions()` functions
- [x] **Add** new `idCheckAppSubthemeToQuestions()` function which is called there `theme == ZENDESK_THEMES.ID_CHECK_APP`
- [x] **Update** `contact-us-service.ts` to push the text entered for `serviceTryingToUse` through as formatted HTML to Zendesk


[AUT-923]: https://govukverify.atlassian.net/browse/AUT-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ