### PR TITLE
ACI-123 - Upgrade GH actions to not use Node.js 12

### DIFF
--- a/.github/workflows/analyse-on-merge.yml
+++ b/.github/workflows/analyse-on-merge.yml
@@ -20,9 +20,9 @@ jobs:
           - 6389:6379
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18.12.1
       - name: Install dependencies

--- a/.github/workflows/pre-merge-checks-terraform.yml
+++ b/.github/workflows/pre-merge-checks-terraform.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get Terraform version
         id: getterraformversion

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -23,9 +23,9 @@ jobs:
           - 6389:6379
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18.12.1
       - name: Install dependencies


### PR DESCRIPTION
## What?

- Upgrade GH actions to not use Node.js 12

## Why?

- We are currently seeing deprecation warnings. For example - https://github.com/alphagov/di-authentication-frontend/actions/runs/3649503508
- Node12 is out of support and any github versions running on Node will need to be upgrade - https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

