### PR TITLE
GUA-574: Update account blurb on sign-in-or-create

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -15,6 +15,12 @@
 
 {% set moreAboutTextHtml %}
 <p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph1' | translate}}</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>{{'pages.signInOrCreate.moreAbout.listItem1' | translate}}</li>
+  <li>{{'pages.signInOrCreate.moreAbout.listItem2' | translate}}</li>
+  <li>{{'pages.signInOrCreate.moreAbout.listItem3' | translate}}</li>
+  <li>{{'pages.signInOrCreate.moreAbout.listItem4' | translate}}</li>
+</ul>
 <p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph2' | translate}}</p>
 <p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph3' | translate}}</p>
 {% endset %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -152,9 +152,13 @@
       "signInText": "fewngofnodi",
       "moreAbout": {
         "header": "Am gyfrifon GOV.UK",
-        "paragraph1": "Mae cyfrifon GOV.UK yn newydd. Ar hyn o bryd gallwch ond defnyddio eich cyfrif GOV.UK gydag ychydig o wasanaethau.",
-        "paragraph2": "Ar hyn o bryd mae cyfrifon GOV.UK ar wahân i gyfrifon eraill y llywodraeth (er enghraifft Porth y Llywodraeth neu Gredyd Cynhwysol).",
-        "paragraph3": "Yn y dyfodol, byddwch yn gallu defnyddio eich cyfrif GOV.UK i fewngofnodi i’r rhan fwyaf o wasanaethau ar GOV.UK."
+        "paragraph1": "Mae cyfrifon GOV.UK yn newydd. Ar hyn o bryd gallwch ond defnyddio eich cyfrif GOV.UK gyda:",
+        "listItem1": "Gwneud cais am drwydded gweithredwr cerbyd",
+        "listItem2": "Tanysgrifiadau e-byst GOV.UK",
+        "listItem3": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
+        "listItem4": "Gwneud cais am wiriad DBS sylfaenol",
+        "paragraph2": "Nid yw cyfrifon GOV.UK yn gweithio gyda phob cyfrif neu wasanaeth y llywodraeth hyd yma (er enghraifft Porth y Llywodraeth neu Gredyd Cynhwysol).",
+        "paragraph3": "Yn y dyfodol, byddwch yn gallu defnyddio eich cyfrif GOV.UK i gael mynediad i holl wasanaethau ar GOV.UK."
       },
       "createButtonText": "Creu cyfrif GOV.UK"
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -152,9 +152,13 @@
       "signInText": "sign in",
       "moreAbout": {
         "header": "About GOV.UK accounts",
-        "paragraph1": "GOV.UK accounts are new. At the moment you can only use your GOV.UK account with a few services.",
-        "paragraph2": "GOV.UK accounts are currently separate from other government accounts (for example Government Gateway or Universal Credit).",
-        "paragraph3": "In the future, you’ll be able to use your GOV.UK account to sign in to most services on GOV.UK."
+        "paragraph1": "GOV.UK accounts are new. At the moment you can only use your GOV.UK account with:",
+        "listItem1": "Apply for a vehicle operator licence",
+        "listItem2": "GOV.UK email subscriptions ",
+        "listItem3": "LITE (Licensing for International Trade and Enterprise)",
+        "listItem4": "Request a basic DBS check",
+        "paragraph2": "GOV.UK accounts do not work with all government accounts and services yet (for example Government Gateway or Universal Credit).",
+        "paragraph3": "In the future, you'll be able to use your GOV.UK account to access all services on GOV.UK."
       },
       "createButtonText": "Create a GOV.UK account"
     },


### PR DESCRIPTION
~**DO NOT MERGE** for now as  this has to go out roughly at the same time as the equivalent changes on `di-authentication-account-management` land.~ Have now been cleared to merge this in.


-------

The accounts team are going live with some updates to the account management area including a content update on the account blurb which now lists the services the account can currently be used with.

Implement the same update on the authentication frontend side so that the entire journey is congruent.

### Before
<img width="1328" alt="Screenshot 2022-12-13 at 12 36 16" src="https://user-images.githubusercontent.com/7116819/207371833-352c74ba-e96e-4ca9-bb1d-dc3694951f57.png">

### After (English)
<img width="1125" alt="Screenshot 2022-12-13 at 13 10 58" src="https://user-images.githubusercontent.com/7116819/207371842-32153973-aa91-4296-a747-a5cf1ca40a06.png">

### After (Welsh)
<img width="1133" alt="Screenshot 2022-12-13 at 13 17 53" src="https://user-images.githubusercontent.com/7116819/207371849-e7df3e6e-4c0d-441e-af4a-b397589fbcf9.png">


## Related PRs

The equivalent content update on the account management side of things lives on [this branch](https://github.com/alphagov/di-authentication-account-management/pull/668).
