### PR TITLE
AUT-929: Fix wording on 'wrong security code entered too many times'

### DIFF
--- a/src/components/security-code-error/index-security-code-entered-exceeded.njk
+++ b/src/components/security-code-error/index-security-code-entered-exceeded.njk
@@ -8,7 +8,7 @@
 
     <p class="govuk-body">{{'pages.securityCodeEnteredExceeded.info.paragraph1' | translate}}</p>
     <p class="govuk-body">
-        {{'pages.securityRequestsExceededExpired.info.paragraph2Start' | translate}}
+        {{'pages.securityCodeEnteredExceeded.info.paragraph2Start' | translate}}
         <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeEnteredExceeded.info.link' | translate}}</a>
         {{'pages.securityCodeEnteredExceeded.info.paragraph2End' | translate}}
     </p>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1654,7 +1654,7 @@
       "title": "You cannot get a new security code at the moment ",
       "header": "You cannot get a new security code at the moment ",
       "info": {
-        "paragraph1": "This is because you entered the security code too many times.",
+        "paragraph1": "This is because you entered the wrong security code too many times.",
         "paragraph2Start": "You can ",
         "link": "get a new code",
         "paragraph2End": " after 15 minutes."


### PR DESCRIPTION
## What?

- Clarify that the issue is the *wrong* code being submitted
- Remove the word 'then' from one of the sentences (this was in fact a bug where the view was referencing the wrong part of the translation JSON)

Before:
<img width="620" alt="image" src="https://user-images.githubusercontent.com/106964077/207587529-32da5971-ee63-47cd-801d-d6949dc119f8.png">


After:
<img width="971" alt="image" src="https://user-images.githubusercontent.com/106964077/207587380-642b9ce3-d4fd-4e72-8547-98a5321d9e33.png">


## Why?

- At request of content designer - locally-run screenshot has been checked and approved by her
