### PR TITLE
aci-12: Revert changes to display service name on account created page

### DIFF
--- a/src/components/account-created/index.njk
+++ b/src/components/account-created/index.njk
@@ -8,7 +8,7 @@
     
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.accountCreated.header' | translate}}</h1>
 
-<p class="govuk-body">{{'pages.accountCreated.text' | translate}} {{name}} {{'pages.accountCreated.textEnd' | translate}}</p>
+<p class="govuk-body">{{'pages.accountCreated.text' | translate}}</p>
 
 <form id="form-tracking" action="/account-created" method="post" novalidate>
 <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -347,8 +347,7 @@
     "accountCreated": {
       "title": "Rydych wedi creu eich cyfrif GOV.UK",
       "header": "Rydych wedi creu eich cyfrif GOV.UK",
-      "text": "Nawr ewch yn eich blaen i ddefnyddio’r ",
-      "textEnd": " gwasanaeth.",
+      "text": "Nawr ewch yn eich blaen i ddefnyddio’r gwasanaeth.",
       "inset": "Mae eich cynnydd ar ",
       "insetContinued": " wedi cael ei arbed.",
       "continue": "Parhau",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -345,10 +345,9 @@
       }
     },
     "accountCreated": {
-      "title": "You've created your GOV.UK account",
-      "header": "You've created your GOV.UK account",
-      "text": "Now continue to use the ",
-      "textEnd": " service.",
+      "title": "You’ve created your GOV.UK account",
+      "header": "You’ve created your GOV.UK account",
+      "text": "Now continue to use the service.",
       "inset": "Your progress on ",
       "insetContinued": " has been saved.",
       "continue": "Continue",


### PR DESCRIPTION

## What?

Revert changes to display service name 

## Why?

Service name returned does not appear user-friendly. i.e. for account management, it returns:

![image](https://user-images.githubusercontent.com/110528805/207627655-39934c12-4310-4bcb-abf6-c9c0f5a2d410.png)


## Related PRs

[ACI-12](https://github.com/alphagov/di-authentication-frontend/pull/846)
