### PR TITLE
BAU: Fix quotes for account created page

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -345,8 +345,8 @@
       }
     },
     "accountCreated": {
-      "title": "You’ve created your GOV.UK account",
-      "header": "You’ve created your GOV.UK account",
+      "title": "You've created your GOV.UK account",
+      "header": "You've created your GOV.UK account",
       "text": "Now continue to use the service.",
       "inset": "Your progress on ",
       "insetContinued": " has been saved.",


### PR DESCRIPTION

## What?

Fix quotes for account created page.

## Why?

Stop acc tests from failing

## Related PRs

#875 
