### PR TITLE
FIREBREAK: Enable frontend of A/B Testing proof of concept

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -87,6 +87,23 @@ var cookies = function (trackingId, analyticsCookieDomain) {
     return cookieConsent ? cookieConsent.analytics : false;
   }
 
+  function pushABTestVariantToDataLayer() {
+    var path = window.location.pathname;
+
+    if(path === '/create-password') {
+      var matchedElement = document.querySelector('[data-ab-test]');
+
+      if(matchedElement && matchedElement.dataset.abTest) {
+          window.dataLayer = window.dataLayer || [];
+          window.dataLayer.push({
+            event: "abTestEvent",
+            variant: matchedElement.dataset.abTest,
+            page: path
+          });
+      }
+    }
+  }
+
   function initAnalytics() {
     loadGtmScript();
     initGtm();
@@ -150,6 +167,7 @@ var cookies = function (trackingId, analyticsCookieDomain) {
     }
 
     pushLanguageToDataLayer();
+    pushABTestVariantToDataLayer();
     gtag({ "gtm.start": new Date().getTime(), event: "gtm.js" });
   }
 

--- a/src/components/create-password/ab-tests/index-variant.njk
+++ b/src/components/create-password/ab-tests/index-variant.njk
@@ -1,0 +1,82 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "common/show-password/macro.njk" import govukInputWithShowPassword %}
+
+{% set pageTitleName = 'abTestPages.createPassword.title' | translate %}
+
+{% block content %}
+
+    {% include "common/errors/errorSummary.njk" %}
+
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'abTestPages.createPassword.header' | translate}}</h1>
+
+    <form action="/create-password" method="post" novalidate>
+
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+        <p class="govuk-body">{{'abTestPages.createPassword.password.paragraph1' | translate}}</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>{{ 'abTestPages.createPassword.password.bulletPoint1' | translate}}</li>
+            <li>{{ 'abTestPages.createPassword.password.bulletPoint2' | translate}}</li>
+        </ul>
+
+        <p class="govuk-body">{{'abTestPages.createPassword.password.paragraph2' | translate}}</p>
+
+        {{ govukInputWithShowPassword(
+            'abTestPages.createPassword.password.label'  | translate,
+            "password",
+            errors,
+            {
+                show: 'general.showPassword.show' | translate,
+                hide: 'general.showPassword.hide' | translate,
+                showFullText: 'general.showPassword.showFullText' | translate,
+                hideFullText: 'general.showPassword.hideFullText' | translate,
+                announceShown: 'general.showPassword.announceShown' | translate,
+                announceHidden: 'general.showPassword.announceHidden' | translate
+            },
+            'new-password'
+        ) }}
+
+        {{ govukInputWithShowPassword(
+            'abTestPages.createPassword.confirmPassword.label' | translate,
+            "confirm-password",
+            errors,
+            {
+                show: 'general.showPassword.show' | translate,
+                hide: 'general.showPassword.hide' | translate,
+                showFullText: 'general.showPassword.showFullText' | translate,
+                hideFullText: 'general.showPassword.hideFullText' | translate,
+                announceShown: 'general.showPassword.announceShown' | translate,
+                announceHidden: 'general.showPassword.announceHidden' | translate
+            },
+            'new-password'
+        ) }}
+
+        {{ govukDetails({
+            summaryText: 'abTestPages.createPassword.securePasswordDetails.summary' | translate,
+            text: 'abTestPages.createPassword.securePasswordDetails.text' | translate
+        }) }}
+
+        <h2 class="govuk-heading-s">{{'abTestPages.createPassword.termsOfUse.heading' | translate}}</h2>
+
+        <p class="govuk-body">{{'abTestPages.createPassword.termsOfUse.paragraph1' | translate}}</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li><a href="{{'abTestPages.createPassword.termsOfUse.bullet1LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'abTestPages.createPassword.termsOfUse.bullet1LinkText'| translate}}</a>{{'abTestPages.createPassword.termsOfUse.bullet1Text'| translate}}</li>
+            <li><a href="{{'abTestPages.createPassword.termsOfUse.bullet2LinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener" target="_blank">{{'abTestPages.createPassword.termsOfUse.bullet2LinkText'| translate}}</a></li>
+        </ul>
+
+        {{ govukButton({
+            "text": button_text|default("general.continue.label" | translate, true),
+            "type": "Submit",
+            "preventDoubleClick": true
+        }) }}
+
+    </form>
+
+{% endblock %}
+
+{% block scripts %}
+    <script type="text/javascript" src="/public/scripts/showPassword.js"></script>
+{% endblock %}

--- a/src/components/create-password/ab-tests/index-variant.njk
+++ b/src/components/create-password/ab-tests/index-variant.njk
@@ -12,7 +12,7 @@
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'abTestPages.createPassword.header' | translate}}</h1>
 
-    <form action="/create-password" method="post" novalidate>
+    <form action="/create-password" data-ab-test="variant-b" method="post" novalidate>
 
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -11,7 +11,10 @@ import {
 } from "../../utils/validation";
 
 export function createPasswordGet(req: Request, res: Response): void {
-  if(req.session.user.featureFlags && req.session.user.featureFlags.updatePasswordHintTextVersion === '2') {
+  if (
+    req.session.user.featureFlags &&
+    req.session.user.featureFlags.updatePasswordHintTextVersion === "2"
+  ) {
     return res.render("create-password/ab-tests/index-variant.njk");
   }
   res.render("create-password/index.njk");

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -11,6 +11,9 @@ import {
 } from "../../utils/validation";
 
 export function createPasswordGet(req: Request, res: Response): void {
+  if(req.session.user.abTest) {
+    return res.render("create-password/ab-tests/index-variant.njk");
+  }
   res.render("create-password/index.njk");
 }
 

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -11,10 +11,7 @@ import {
 } from "../../utils/validation";
 
 export function createPasswordGet(req: Request, res: Response): void {
-  if (
-    req.session.user.featureFlags &&
-    req.session.user.featureFlags.updatePasswordHintTextVersion === "2"
-  ) {
+  if (req.session.user.featureFlags?.updatePasswordHintTextVersion === "2") {
     return res.render("create-password/ab-tests/index-variant.njk");
   }
   res.render("create-password/index.njk");

--- a/src/components/create-password/create-password-controller.ts
+++ b/src/components/create-password/create-password-controller.ts
@@ -11,7 +11,7 @@ import {
 } from "../../utils/validation";
 
 export function createPasswordGet(req: Request, res: Response): void {
-  if(req.session.user.abTest) {
+  if(req.session.user.featureFlags && req.session.user.featureFlags.updatePasswordHintTextVersion === '2') {
     return res.render("create-password/ab-tests/index-variant.njk");
   }
   res.render("create-password/index.njk");

--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -12,7 +12,7 @@
 
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.createPassword.header' | translate}}</h1>
 
-<form action="/create-password" method="post" novalidate>
+<form action="/create-password" data-ab-test="variant-a" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 

--- a/src/components/create-password/tests/create-password-controller.test.ts
+++ b/src/components/create-password/tests/create-password-controller.test.ts
@@ -23,7 +23,7 @@ describe("create-password controller", () => {
   beforeEach(() => {
     req = mockRequest({
       path: PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD,
-      session: { client: {}, user: {} },
+      session: { client: {}, user: { featureFlags: {} } },
       log: { info: sinon.fake() },
     });
     res = mockResponse();
@@ -33,21 +33,30 @@ describe("create-password controller", () => {
     sinon.restore();
   });
 
-  describe("createPasswordGet", () => {
-    it("should render create password view", () => {
+  describe("createPasswordGet no feature flags", () => {
+    it("should render create password view when no feature flags", () => {
       createPasswordGet(req as Request, res as Response);
 
+      req.session.user.featureFlags = null;
       expect(res.render).to.have.calledWith("create-password/index.njk");
     });
   });
 
+  describe("createPasswordGet with feature flag existing version", () => {
+    it("should render create password view with feature flags", () => {
+      createPasswordGet(req as Request, res as Response);
+
+      req.session.user.featureFlags.updatePasswordHintTextVersion = '1';
+      expect(res.render).to.have.calledWith("create-password/index.njk");
+    });
+
   describe("createPasswordGetABScenario", () => {
     it("should render create password view", () => {
 
-      req.session.user.abTest = true;
+      req.session.user.featureFlags.updatePasswordHintTextVersion = '2';
       createPasswordGet(req as Request, res as Response);
 
-      expect(res.render).to.have.calledWith("create-password/index-variant.njk");
+      expect(res.render).to.have.calledWith("create-password/ab-tests/index-variant.njk");
     });
   });
 

--- a/src/components/create-password/tests/create-password-controller.test.ts
+++ b/src/components/create-password/tests/create-password-controller.test.ts
@@ -41,6 +41,16 @@ describe("create-password controller", () => {
     });
   });
 
+  describe("createPasswordGetABScenario", () => {
+    it("should render create password view", () => {
+
+      req.session.user.abTest = true;
+      createPasswordGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("create-password/index-variant.njk");
+    });
+  });
+
   describe("createPasswordPost", () => {
     it("should redirect to get security codes when 2 factor is required", async () => {
       const fakeService: CreatePasswordServiceInterface = {

--- a/src/components/create-password/tests/create-password-controller.test.ts
+++ b/src/components/create-password/tests/create-password-controller.test.ts
@@ -46,88 +46,90 @@ describe("create-password controller", () => {
     it("should render create password view with feature flags", () => {
       createPasswordGet(req as Request, res as Response);
 
-      req.session.user.featureFlags.updatePasswordHintTextVersion = '1';
+      req.session.user.featureFlags.updatePasswordHintTextVersion = "1";
       expect(res.render).to.have.calledWith("create-password/index.njk");
     });
 
-  describe("createPasswordGetABScenario", () => {
-    it("should render create password view", () => {
+    describe("createPasswordGetABScenario", () => {
+      it("should render create password view", () => {
+        req.session.user.featureFlags.updatePasswordHintTextVersion = "2";
+        createPasswordGet(req as Request, res as Response);
 
-      req.session.user.featureFlags.updatePasswordHintTextVersion = '2';
-      createPasswordGet(req as Request, res as Response);
-
-      expect(res.render).to.have.calledWith("create-password/ab-tests/index-variant.njk");
-    });
-  });
-
-  describe("createPasswordPost", () => {
-    it("should redirect to get security codes when 2 factor is required", async () => {
-      const fakeService: CreatePasswordServiceInterface = {
-        signUpUser: sinon.fake.returns({
-          data: {
-            consentRequired: false,
-          },
-          success: true,
-        }),
-      };
-
-      req.body.password = "password1";
-      req.session.user.email = "joe.bloggs@test.com";
-      res.locals.sessionId = "34234dsf";
-
-      await createPasswordPost(fakeService)(req as Request, res as Response);
-
-      expect(res.redirect).to.have.calledWith(PATH_NAMES.GET_SECURITY_CODES);
-      expect(fakeService.signUpUser).to.have.been.calledOnce;
+        expect(res.render).to.have.calledWith(
+          "create-password/ab-tests/index-variant.njk"
+        );
+      });
     });
 
-    it("should throw error when session is not populated", async () => {
-      const fakeService: CreatePasswordServiceInterface = {
-        signUpUser: sinon.fake(),
-      };
+    describe("createPasswordPost", () => {
+      it("should redirect to get security codes when 2 factor is required", async () => {
+        const fakeService: CreatePasswordServiceInterface = {
+          signUpUser: sinon.fake.returns({
+            data: {
+              consentRequired: false,
+            },
+            success: true,
+          }),
+        };
 
-      req.body.password = "password1";
-      req.session.user = undefined;
+        req.body.password = "password1";
+        req.session.user.email = "joe.bloggs@test.com";
+        res.locals.sessionId = "34234dsf";
 
-      await expect(
-        createPasswordPost(fakeService)(req as Request, res as Response)
-      ).to.be.rejectedWith(
-        TypeError,
-        "Cannot read properties of undefined (reading 'email')"
-      );
-      expect(fakeService.signUpUser).to.have.not.been.called;
-    });
+        await createPasswordPost(fakeService)(req as Request, res as Response);
 
-    it("should throw error when password field is not in body", async () => {
-      const fakeService: CreatePasswordServiceInterface = {
-        signUpUser: sinon.fake(),
-      };
+        expect(res.redirect).to.have.calledWith(PATH_NAMES.GET_SECURITY_CODES);
+        expect(fakeService.signUpUser).to.have.been.calledOnce;
+      });
 
-      req.body = undefined;
-      req.session.user.email = "joe.bloggs@test.com";
+      it("should throw error when session is not populated", async () => {
+        const fakeService: CreatePasswordServiceInterface = {
+          signUpUser: sinon.fake(),
+        };
 
-      await expect(
-        createPasswordPost(fakeService)(req as Request, res as Response)
-      ).to.be.rejectedWith(
-        TypeError,
-        "Cannot read properties of undefined (reading 'password')"
-      );
-      expect(fakeService.signUpUser).to.have.not.been.called;
-    });
+        req.body.password = "password1";
+        req.session.user = undefined;
 
-    it("should throw error when API call returns error", async () => {
-      const error = new Error("Internal server error");
-      const fakeService: CreatePasswordServiceInterface = {
-        signUpUser: sinon.fake.throws(error),
-      };
+        await expect(
+          createPasswordPost(fakeService)(req as Request, res as Response)
+        ).to.be.rejectedWith(
+          TypeError,
+          "Cannot read properties of undefined (reading 'email')"
+        );
+        expect(fakeService.signUpUser).to.have.not.been.called;
+      });
 
-      req.body.password = "password1";
-      req.session.user.email = "joe.bloggs@test.com";
+      it("should throw error when password field is not in body", async () => {
+        const fakeService: CreatePasswordServiceInterface = {
+          signUpUser: sinon.fake(),
+        };
 
-      await expect(
-        createPasswordPost(fakeService)(req as Request, res as Response)
-      ).to.be.rejectedWith(Error, "Internal server error");
-      expect(fakeService.signUpUser).to.have.been.called;
+        req.body = undefined;
+        req.session.user.email = "joe.bloggs@test.com";
+
+        await expect(
+          createPasswordPost(fakeService)(req as Request, res as Response)
+        ).to.be.rejectedWith(
+          TypeError,
+          "Cannot read properties of undefined (reading 'password')"
+        );
+        expect(fakeService.signUpUser).to.have.not.been.called;
+      });
+
+      it("should throw error when API call returns error", async () => {
+        const error = new Error("Internal server error");
+        const fakeService: CreatePasswordServiceInterface = {
+          signUpUser: sinon.fake.throws(error),
+        };
+
+        req.body.password = "password1";
+        req.session.user.email = "joe.bloggs@test.com";
+
+        await expect(
+          createPasswordPost(fakeService)(req as Request, res as Response)
+        ).to.be.rejectedWith(Error, "Internal server error");
+        expect(fakeService.signUpUser).to.have.been.called;
+      });
     });
   });
 });

--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -82,6 +82,8 @@ export function landingGet(
     req.session.user.docCheckingAppUser =
       startAuthResponse.data.user.docCheckingAppUser;
 
+    req.session.user.abTest = true;
+
     const nextState = req.session.user.isAuthenticated
       ? USER_JOURNEY_EVENTS.EXISTING_SESSION
       : USER_JOURNEY_EVENTS.LANDING;

--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -82,7 +82,9 @@ export function landingGet(
     req.session.user.docCheckingAppUser =
       startAuthResponse.data.user.docCheckingAppUser;
 
-    req.session.user.abTest = true;
+    if (startAuthResponse.data.featureFlags) {
+      req.session.user.featureFlags = startAuthResponse.data.featureFlags;
+    }
 
     const nextState = req.session.user.isAuthenticated
       ? USER_JOURNEY_EVENTS.EXISTING_SESSION

--- a/src/components/landing/types.ts
+++ b/src/components/landing/types.ts
@@ -3,6 +3,7 @@ import { ApiResponseResult, DefaultApiResponse } from "../../types";
 export interface StartAuthResponse extends DefaultApiResponse {
   client: ClientInfo;
   user: UserSessionInfo;
+  featureFlags?: {};
 }
 
 export interface ClientInfo {

--- a/src/components/landing/types.ts
+++ b/src/components/landing/types.ts
@@ -3,7 +3,7 @@ import { ApiResponseResult, DefaultApiResponse } from "../../types";
 export interface StartAuthResponse extends DefaultApiResponse {
   client: ClientInfo;
   user: UserSessionInfo;
-  featureFlags?: {};
+  featureFlags?: Record<string, unknown>;
 }
 
 export interface ClientInfo {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1661,5 +1661,44 @@
         "paragraph2End": "."
       }
     }
+  },
+  "abTestPages": {
+    "createPassword": {
+      "title": "Creu eich cyfrinair",
+      "header": "Creu eich cyfrinair",
+      "password": {
+        "label": "Rhowch gyfrinair",
+        "paragraph1": "Mae'n rhaid i'ch cyfrinair:",
+        "bulletPoint1": "fod yn o leiaf 8 nod o hyd",
+        "bulletPoint2": "cynnwys llythrennau a rhifau",
+        "paragraph2": "Peidiwch defnyddio cyfrinair cyffredin iawn, fel 'password' neu ddilyniant o rifau.",
+        "validationError": {
+          "required": "Rhowch eich cyfrinair",
+          "maxLength": "Mae'n rhaid i'ch cyfrinair fod yn llai na 256 nod",
+          "commonPassword": "Rhowch gyfrinair cryfach. Peidiwch defnyddio cyfrineiriau cyffredin iawn, fel 'password' neu ddilyniant o rifau.",
+          "alphaNumeric": "Mae'n rhaid i'ch cyfrinair fod yn o leiaf 8 nod o hyd a rhaid iddo gynnwys llythrennau a rhifau"
+        }
+      },
+      "confirmPassword": {
+        "label": "Ail deipiwch y cyfrinair",
+        "validationError": {
+          "required": "Ail deipiwch eich cyfrinair",
+          "matches": "Rhowch yr un cyfrinair yn y ddau faes"
+        }
+      },
+      "securePasswordDetails": {
+        "summary": "Sut i greu cyfrinair diogel",
+        "text": "Ffordd dda o greu cyfrinair diogel a chofiadwy yw defnyddio 3 gair ar hap. Gallwch ddefnyddio rhifau, symbolau a gofodau."
+      },
+      "termsOfUse": {
+        "heading": "Cytuno i'n telerau defnyddio",
+        "paragraph1": "Drwy barhau, rydych yn cadarnhau eich bod yn cytuno i'n:",
+        "bullet1LinkText": "hysbysiad preifatrwydd (agor mewn tab newydd)",
+        "bullet1Text": ", sy'n egluro sut rydym yn defnyddio eich gwybodaeth bersonol",
+        "bullet1LinkHref": "/privacy-notice",
+        "bullet2LinkText": "telerau ac amodau (agor mewn tab newydd)",
+        "bullet2LinkHref": "/terms-and-conditions"
+      }
+    }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1673,5 +1673,44 @@
         "paragraph2End": "."
       }
     }
+  },
+  "abTestPages": {
+    "createPassword": {
+      "title": "Create your password",
+      "header": "Create your password",
+      "password": {
+        "label": "Enter a password",
+        "paragraph1": "Your password must:",
+        "bulletPoint1": "be at least 8 characters long",
+        "bulletPoint2": "include letters and numbers",
+        "paragraph2": "Do not use a very common password, such as ‘password’ or a sequence of numbers.",
+        "validationError": {
+          "required": "Enter your password",
+          "maxLength": "Your password must be less than 256 characters",
+          "commonPassword": "Enter a stronger password. Do not use very common passwords, such as ‘password’ or a sequence of numbers.",
+          "alphaNumeric": "Your password must be at least 8 characters long and must include letters and numbers"
+        }
+      },
+      "confirmPassword": {
+        "label": "Re-type password",
+        "validationError": {
+          "required": "Re-type your password",
+          "matches": "Enter the same password in both fields"
+        }
+      },
+      "securePasswordDetails": {
+        "summary": "How to create a secure password",
+        "text": "A good way to create a secure and memorable password is to use 3 random words. You can use numbers, symbols and spaces."
+      },
+      "termsOfUse": {
+        "heading": "Agree to our terms of use",
+        "paragraph1": "By continuing, you confirm that you agree to our:",
+        "bullet1LinkText": "privacy notice (opens in a new tab)",
+        "bullet1Text": ", which explains how we use your personal information",
+        "bullet1LinkHref": "/privacy-notice",
+        "bullet2LinkText": "terms and conditions (opens in a new tab)",
+        "bullet2LinkHref": "/terms-and-conditions"
+      }
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,6 @@ export interface Error {
 }
 
 export interface UserSession {
-  abTest?: boolean;
   isAuthenticated?: boolean;
   email?: string;
   phoneNumber?: string;
@@ -48,6 +47,7 @@ export interface UserSession {
   authAppSecret?: string;
   authAppQrCodeUrl?: string;
   isPasswordChangeRequired?: boolean;
+  featureFlags?: any;
 }
 
 export interface UserSessionClient {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface Error {
 }
 
 export interface UserSession {
+  abTest?: boolean;
   isAuthenticated?: boolean;
   email?: string;
   phoneNumber?: string;


### PR DESCRIPTION
## What?

Enables front-end aspects of an A/B testing proof of concept that works as follows: 

1. Where `landing-controller.ts` encounters `startAuthResponse.data.featureFlags` they are added to the session
2. The presence or absence of these `featureFlags` on the session will determine which template is rendered by `create-password-controller.ts`
3. Each template is rendered with a `data-ab-test` attribute that has a value of either "variant-a" or "variant-b"
4. A new section is added to `translation.json` files for content that is included in A/B tests (the intention here is to allow it to be identified quickly and removed when no longer needed)
5. Where the user has consented to analytics cookies a JavaScript function will run that captures the `path` and variant information and pushes this to `dataLayer`

## Why?

Firebreak proof of concept to explore potential for A/B testing.

## Related PRs

A [corresponding PR](https://github.com/alphagov/di-authentication-api/pull/2610) has been raised for related API changes.
