### PR TITLE
ACI-18: Introduce non-service scenario and implement the content on T&Cs reje…

### DIFF
--- a/src/components/updated-terms-conditions/index-rejected.njk
+++ b/src/components/updated-terms-conditions/index-rejected.njk
@@ -1,0 +1,63 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set pageTitleName = 'pages.updatedTermsAndCondsRejected.title' | translate %}
+{% set rowClasses = 'interrupt-screen' %}
+{% block content %}
+
+<h1 class="govuk-white-text govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.updatedTermsAndCondsRejected.header' | translate}}</h1>
+
+<p class="govuk-body govuk-white-text">
+     {{ 'pages.updatedTermsAndCondsRejected.info.text' | translate }}
+        <a class="govuk-white-text"
+           href="/terms-and-conditions">{{ 'pages.updatedTermsAndCondsRejected.info.termsAndConditionsText' | translate }}</a>,
+        <a class="govuk-white-text"
+           href="/privacy-notice">{{ 'pages.updatedTermsAndCondsRejected.info.privacyNoticeText' | translate }}</a>
+        {{ 'pages.updatedTermsAndCondsRejected.info.and' | translate }}
+        <a class="govuk-white-text"
+           href="https://www.gov.uk/help/cookies">{{ 'pages.updatedTermsAndCondsRejected.info.cookiesPolicyText' | translate }}</a>
+           {{ 'pages.updatedTermsAndCondsRejected.info.end' | translate }}
+</p>
+
+<form id="form-tracking"  action="/updated-terms-and-conditions" method="post" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+    {{ govukButton({
+        "text": 'pages.updatedTermsAndCondsRejected.agreeAndContinue' | translate,
+        "type": "Submit",
+        "preventDoubleClick": true,
+        classes: 'govuk-blue-text govuk-white-button inverted-button',
+        "name": "termsAndConditionsResult",
+        "value": "accept"
+    }) }}
+
+    <br />
+
+    <p class="govuk-body govuk-white-text">
+        {{ 'pages.updatedTermsAndCondsRejected.section2.paragraph1' | translate }}
+        {{ govukButton({
+            "text": 'pages.updatedTermsAndCondsRejected.section2.govUkHomePageText' | translate,
+            "type": "Submit",
+            "preventDoubleClick": true,
+            classes: 'govuk-btn-link',
+            "name": "termsAndConditionsResult",
+            "value": "govUk"
+        }) }}
+    </p>
+
+    <p class="govuk-body govuk-white-text">
+        {{ 'pages.updatedTermsAndCondsRejected.section2.paragraph2' | translate }}
+        {{ govukButton({
+            "text": 'pages.updatedTermsAndCondsRejected.section2.contactUsText' | translate,
+            "type": "Submit",
+            "preventDoubleClick": true,
+            classes: 'govuk-btn-link',
+            "name": "termsAndConditionsResult",
+            "value": "contactUs"
+        }) }}
+    </p>
+
+</form>
+{% endblock %}
+

--- a/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
+++ b/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
@@ -15,10 +15,14 @@ export function updatedTermsConditionsGet(req: Request, res: Response): void {
 }
 
 export function updatedTermsRejectedGet(req: Request, res: Response): void {
-  const view =
-    req.session.client.serviceType === SERVICE_TYPE.OPTIONAL
-      ? "index-optional.njk"
-      : "index-mandatory.njk";
+  let view: string;
+  if (req.session.client.serviceType === SERVICE_TYPE.OPTIONAL) {
+    view = "index-optional.njk";
+  } else if (req.session.client.serviceType === SERVICE_TYPE.MANDATORY) {
+    view = "index-mandatory.njk";
+  } else {
+    view = "index-rejected.njk";
+  }
 
   return res.render("updated-terms-conditions/" + view, {
     clientName: req.session.client.name,

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -564,6 +564,26 @@
       "agreeAndContinue": "Cytuno a pharhau",
       "goBackToService": "Cwblhewch eich "
     },
+    "updatedTermsAndCondsRejected": {
+      "title": "Cytuno i’r telerau defnydd wedi’u diweddaru i fynd yn eich blaen",
+      "header": "Cytuno i’r telerau defnydd wedi’u diweddaru i fynd yn eich blaen",
+      "info": {
+        "text": "Mae angen i chi gytuno i’n",
+        "and": "a",
+        "termsAndConditionsText": "telerau ac amodau",
+        "privacyNoticeText": "hysbysiad preifatrwydd",
+        "cookiesPolicyText": "polisi cwcis",
+        "end": "wedi’u diweddaru i barhau i ddefnyddio eich cyfrif."
+      },
+      "section2": {
+        "paragraph1": "Os nad ydych yn cytuno i’r telerau newydd, ni allwch ddefnyddio eich cyfrif GOV.UK.",
+        "govUkHomePageText": "Ewch i hafan GOV.UK.",
+        "paragraph2": "Os nad ydych angen eich cyfrif mwyach, neu os ydych am ddileu gwybodaeth sydd wedi’i arbed yn eich cyfrif, gallwch ",
+        "contactUsText": "gysylltu â ni."
+      },
+      "agreeAndContinue": "Cytuno a pharhau",
+      "goBackToService": "Ewch yn ôl i "
+    },
     "cookiePolicy": {
       "title": "Polisi cwcis cyfrifon GOV.UK",
       "header": "Polisi cwcis cyfrifon GOV.UK",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -564,6 +564,26 @@
       "agreeAndContinue": "Agree and continue",
       "goBackToService": "Complete your "
     },
+    "updatedTermsAndCondsRejected": {
+      "title": "Agree to the updated terms of use to continue",
+      "header": "Agree to the updated terms of use to continue",
+      "info": {
+        "text": "You need to agree to our updated",
+        "and": "and",
+        "termsAndConditionsText": "terms and conditions",
+        "privacyNoticeText": "privacy notice",
+        "cookiesPolicyText": "cookies policy",
+        "end": "to keep using your account."
+      },
+      "section2": {
+        "paragraph1": "If you do not agree to the new terms, you cannot use your GOV.UK account.",
+        "govUkHomePageText": "Go to the GOV.UK homepage.",
+        "paragraph2": "If you no longer need your account, or want to delete information saved in your account, you can ",
+        "contactUsText": "contact us."
+      },
+      "agreeAndContinue": "Agree and continue",
+      "goBackToService": "Go back to "
+    },
     "cookiePolicy": {
       "title": "GOV.UK accounts cookies policy",
       "header": "GOV.UK accounts cookies policy",


### PR DESCRIPTION
## What?

- Introduce non-service scenario and implement the content on T&Cs rejection
- Created a new entry in translation file `updatedTermsAndCondsRejected` which is a direct copy of `updatedTermsAndCondsMandatory` which also has been modified in another PR
- Created a new page `index-rejected.njk` for non service scenarios
- Non service scenarios is determined when neither service type is optional or mandatory

## Why?

This scenario has not been implemented in the frontend, but exists on our [Figma board](https://www.figma.com/file/aVqNC4pKaebZchIU691f31/DI-Authentication?node-id=14739%3A60383&t=bESgCgN3gCalQOdA-0)

## Related PRs

[ACI-15](https://github.com/alphagov/di-authentication-frontend/pull/882)
[ACI-16](https://github.com/alphagov/di-authentication-frontend/pull/883)
