### PR TITLE
BAU - Set the default keep alive to be greater than that of the ALB

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ const port: number | string = process.env.PORT || 3000;
 
 (async () => {
   const app = await createApp();
-  app
+  const server = app
     .listen(port, () => {
       logger.info(`Server listening on port ${port}`);
       app.emit("appStarted");
@@ -13,6 +13,8 @@ const port: number | string = process.env.PORT || 3000;
     .on("error", (error: Error) => {
       logger.error(`Unable to start server because of ${error.message}`);
     });
+  server.keepAliveTimeout = 61 * 1000;
+  server.headersTimeout = 91 * 1000;
 })().catch((ex) => {
   logger.error(`Server failed to create app ${ex.message}`);
 });


### PR DESCRIPTION
## What?

- Set the default keep alive to be greater than that of the ALB

## Why?

- The default keep alive of an express app is 5seconds. The default keep alive of the Frontend ALB is 60 seconds. This can cause 5xx errors from the ALB, as the ALB will occasionally believe it has an open connection it can use however as the ECS keep alive timeout is only 5 seconds the socket has since closed and a 502 is sent back to the ALB.
- By keeping the keep alive timeout of the ECS container slightly longer than the ELB keep alive timeout, we can reduce these errors from happening.
