### PR TITLE
ACI-138 - Show the correct screen when user exceeds auth app code attempts and clicks try again

### DIFF
--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -1,7 +1,7 @@
 import { PATH_NAMES } from "../../app.constants";
 import { getNextState } from "./state-machine/state-machine";
 
-const SECURITY_CODE_ERROR = "actionType";
+export const SECURITY_CODE_ERROR = "actionType";
 
 export enum SecurityCodeErrorType {
   MfaMaxCodesSent = "mfaMaxCodesSent",
@@ -120,11 +120,11 @@ export function getErrorPathByCode(errorCode: number): string | undefined {
   return nextPath;
 }
 
-function pathWithQueryParam(
+export function pathWithQueryParam(
   path: string,
   queryParam?: string,
   value?: string | SecurityCodeErrorType
-) {
+): string {
   if (queryParam && value) {
     const queryParams = new URLSearchParams({
       [queryParam]: value,

--- a/src/components/security-code-error/index-security-code-entered-exceeded.njk
+++ b/src/components/security-code-error/index-security-code-entered-exceeded.njk
@@ -1,16 +1,29 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitleName = 'pages.securityCodeEnteredExceeded.title' | translate %}
+{% if isAuthApp %}
+    {% set pageTitleName = 'pages.securityCodeAuthAppEnteredExceeded.title' | translate %}
+{% else %}
+    {% set pageTitleName = 'pages.securityCodeEnteredExceeded.title' | translate %}
+{% endif %}
 
 {% block content %}
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeEnteredExceeded.header' | translate }}</h1>
-
-    <p class="govuk-body">{{'pages.securityCodeEnteredExceeded.info.paragraph1' | translate}}</p>
-    <p class="govuk-body">
-        {{'pages.securityCodeEnteredExceeded.info.paragraph2Start' | translate}}
-        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeEnteredExceeded.info.link' | translate}}</a>
-        {{'pages.securityCodeEnteredExceeded.info.paragraph2End' | translate}}
-    </p>
+    {% if isAuthApp %}
+        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeAuthAppEnteredExceeded.header' | translate }}</h1>
+        <p class="govuk-body">{{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph1' | translate}}</p>
+        <p class="govuk-body">
+            {{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph2Start' | translate}}
+            <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeAuthAppEnteredExceeded.info.link' | translate}}</a>
+            {{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph2End' | translate}}
+        </p>
+    {% else %}
+        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeEnteredExceeded.header' | translate }}</h1>
+        <p class="govuk-body">{{'pages.securityCodeEnteredExceeded.info.paragraph1' | translate}}</p>
+        <p class="govuk-body">
+            {{'pages.securityCodeEnteredExceeded.info.paragraph2Start' | translate}}
+            <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeEnteredExceeded.info.link' | translate}}</a>
+            {{'pages.securityCodeEnteredExceeded.info.paragraph2End' | translate}}
+        </p>
+    {% endif %}
 
 {% endblock %}

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -1,10 +1,18 @@
 import { Request, Response } from "express";
-import { SecurityCodeErrorType } from "../common/constants";
+import {
+  SecurityCodeErrorType,
+  pathWithQueryParam,
+  SECURITY_CODE_ERROR,
+} from "../common/constants";
 import { PATH_NAMES } from "../../app.constants";
 
 export function securityCodeInvalidGet(req: Request, res: Response): void {
   res.render("security-code-error/index.njk", {
-    newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
+    newCodeLink: pathWithQueryParam(
+      getNewCodePath(req.query.actionType as SecurityCodeErrorType),
+      SECURITY_CODE_ERROR,
+      req.query.actionType as SecurityCodeErrorType
+    ),
     isAuthApp: isAuthApp(req.query.actionType as SecurityCodeErrorType),
     isBlocked: req.query.actionType !== SecurityCodeErrorType.EmailMaxRetries,
   });
@@ -15,7 +23,6 @@ export function securityCodeTriesExceededGet(
   res: Response
 ): void {
   res.cookie("re", "true", { maxAge: 15 * 60 * 1000, httpOnly: true });
-
   return res.render("security-code-error/index-too-many-requests.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
     isResendCodeRequest: req.query.isResendCodeRequest,
@@ -36,7 +43,10 @@ export function securityCodeEnteredExceededGet(
   res: Response
 ): void {
   res.render("security-code-error/index-security-code-entered-exceeded.njk", {
-    newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
+    newCodeLink: isAuthApp(req.query.actionType as SecurityCodeErrorType)
+      ? PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE
+      : PATH_NAMES.ENTER_MFA,
+    isAuthApp: isAuthApp(req.query.actionType as SecurityCodeErrorType),
   });
 }
 
@@ -46,6 +56,7 @@ function getNewCodePath(actionType: SecurityCodeErrorType) {
     case SecurityCodeErrorType.MfaBlocked:
       return PATH_NAMES.RESEND_MFA_CODE;
     case SecurityCodeErrorType.MfaMaxRetries:
+    case SecurityCodeErrorType.AuthAppMfaMaxRetries:
       return PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED;
     case SecurityCodeErrorType.OtpMaxCodesSent:
     case SecurityCodeErrorType.OtpBlocked:
@@ -56,8 +67,6 @@ function getNewCodePath(actionType: SecurityCodeErrorType) {
       return PATH_NAMES.SECURITY_CODE_CHECK_TIME_LIMIT;
     case SecurityCodeErrorType.EmailMaxRetries:
       return PATH_NAMES.RESEND_EMAIL_CODE + "?requestNewCode=true";
-    case SecurityCodeErrorType.AuthAppMfaMaxRetries:
-      return PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE;
   }
 }
 

--- a/src/components/security-code-error/security-code-error-routes.ts
+++ b/src/components/security-code-error/security-code-error-routes.ts
@@ -1,6 +1,6 @@
 import { PATH_NAMES } from "../../app.constants";
 
-import * as express from "express";
+import express from "express";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import {
   securityCodeCannotRequestCodeGet,

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -66,13 +66,25 @@ describe("security code  controller", () => {
   });
 
   describe("securityCodeEnteredExceededGet", () => {
-    it("should render security code invalid request view", () => {
+    it("should render security code invalid request view when SMS code has been used max number of times", () => {
       req.query.actionType = SecurityCodeErrorType.MfaMaxRetries;
 
       securityCodeEnteredExceededGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
-        "security-code-error/index-security-code-entered-exceeded.njk"
+        "security-code-error/index-security-code-entered-exceeded.njk",
+        { newCodeLink: "/enter-code", isAuthApp: false }
+      );
+    });
+
+    it("should render security code invalid request view when Auth App code has been used max number of times", () => {
+      req.query.actionType = SecurityCodeErrorType.AuthAppMfaMaxRetries;
+
+      securityCodeEnteredExceededGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "security-code-error/index-security-code-entered-exceeded.njk",
+        { newCodeLink: "/enter-authenticator-app-code", isAuthApp: true }
       );
     });
   });

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1647,6 +1647,16 @@
         "paragraph2End": " ar ôl 15 munud."
       }
     },
+    "securityCodeAuthAppEnteredExceeded": {
+      "title": "Ni allwch roi cod diogelwch ar hyn o bryd ",
+      "header": "Ni allwch roi cod diogelwch ar hyn o bryd ",
+      "info": {
+        "paragraph1": "Mae hyn oherwydd eich bod wedi rhoi y cod diogelwch gormod o weithau.",
+        "paragraph2Start": "Gallwch ",
+        "link": "roi cynnig arall",
+        "paragraph2End": " ar ôl 15 munud."
+      }
+    },
     "signInRetryBlocked": {
       "title": "Mae eich cyfrif wedi’i gloi",
       "header": "Mae eich cyfrif wedi’i gloi",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1659,6 +1659,16 @@
         "paragraph2End": " after 15 minutes."
       }
     },
+    "securityCodeAuthAppEnteredExceeded": {
+      "title": "You cannot enter a security code at the moment ",
+      "header": "You cannot enter a security code at the moment ",
+      "info": {
+        "paragraph1": "This is because you entered the wrong security code too many times.",
+        "paragraph2Start": "You can ",
+        "link": "try again",
+        "paragraph2End": " after 15 minutes."
+      }
+    },
     "signInRetryBlocked": {
       "title": "Your account is locked",
       "header": "Your account is locked",


### PR DESCRIPTION
## What?

 - Correct error scenario for auth app incorrect code

## Why?

- When a user enters 6 invalid codes on the auth app enter otp they are taken to the 'You entered the wrong security code too many times', when they select try again they are taken to the Enter the 6 digit security code shown in your authenticator app' Fix that so the try again link takes them to the 'You cannot enter a security code at the moment' screen

