### PR TITLE
ACI-139: Add character limit to user support forms

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -139,6 +139,15 @@ export const ZENDESK_THEMES = {
   ID_CHECK_APP_SOMETHING_ELSE: "id_check_app_something_else",
 };
 
+export const ZENDESK_FIELD_MAX_LENGTH = 1200;
+
+export const PLACEHOLDER_REPLACEMENTS = [
+  {
+    search: "[maximumCharacters]",
+    replacement: ZENDESK_FIELD_MAX_LENGTH.toLocaleString(),
+  },
+];
+
 export enum NOTIFICATION_TYPE {
   VERIFY_EMAIL = "VERIFY_EMAIL",
   VERIFY_PHONE_NUMBER = "VERIFY_PHONE_NUMBER",

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -1,5 +1,10 @@
 import { Request, Response } from "express";
-import { PATH_NAMES, SUPPORT_TYPE, ZENDESK_THEMES } from "../../app.constants";
+import {
+  PATH_NAMES,
+  SUPPORT_TYPE,
+  ZENDESK_THEMES,
+  ZENDESK_FIELD_MAX_LENGTH,
+} from "../../app.constants";
 import { contactUsService } from "./contact-us-service";
 import { ContactUsServiceInterface, Questions, ThemeQuestions } from "./types";
 import { ExpressRouteFunc } from "../../types";
@@ -133,6 +138,7 @@ export function contactUsQuestionsGet(req: Request, res: Response): void {
     backurl: req.headers.referer,
     referer: req.query.referer,
     pageTitleHeading: pageTitle,
+    zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
   });
 }
 

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -221,6 +221,9 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   ) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.anythingElseTooLongMessage";
   }
+  if (theme === ZENDESK_THEMES.SOMETHING_ELSE) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -35,7 +35,10 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .isLength({ max: ZENDESK_FIELD_MAX_LENGTH })
       .withMessage((value, { req }) => {
         return req.t(
-          "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage",
+          getErrorMessageForIssueDescriptionWhereLengthExceeded(
+            req.body.theme,
+            req.body.subtheme
+          ),
           { value }
         );
       }),
@@ -166,6 +169,30 @@ export function getErrorMessageForIssueDescription(
   }
   if (subtheme === ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM) {
     return "pages.contactUsQuestions.authenticatorApp.section1.errorMessage";
+  }
+}
+
+export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
+  theme: string,
+  subtheme: string
+): string {
+  if (
+    theme === ZENDESK_THEMES.ACCOUNT_CREATION &&
+    subtheme === ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM
+  ) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
+  if (
+    theme === ZENDESK_THEMES.ACCOUNT_CREATION &&
+    subtheme === ZENDESK_THEMES.TECHNICAL_ERROR
+  ) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
+  if (
+    theme === ZENDESK_THEMES.ACCOUNT_CREATION &&
+    subtheme === ZENDESK_THEMES.SOMETHING_ELSE
+  ) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.anythingElseTooLongMessage";
   }
 }
 

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -30,6 +30,15 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
           { value }
         );
       }),
+    body("issueDescription")
+      .optional()
+      .isLength({ max: ZENDESK_FIELD_MAX_LENGTH })
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage",
+          { value }
+        );
+      }),
     body("additionalDescription")
       .optional()
       .notEmpty()
@@ -39,6 +48,15 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
             req.body.theme,
             req.body.subtheme
           ),
+          { value }
+        );
+      }),
+    body("additionalDescription")
+      .optional()
+      .isLength({ max: ZENDESK_FIELD_MAX_LENGTH })
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.additionalDescriptionErrorMessage.entryTooLongMessage",
           { value }
         );
       }),

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -248,6 +248,12 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   ) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
   }
+  if (
+    theme === ZENDESK_THEMES.ID_CHECK_APP &&
+    subtheme === ZENDESK_THEMES.ID_CHECK_APP_SOMETHING_ELSE
+  ) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -236,6 +236,12 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   ) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
   }
+  if (
+    theme === ZENDESK_THEMES.ID_CHECK_APP &&
+    subtheme === ZENDESK_THEMES.FACE_SCANNING_PROBLEM
+  ) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -63,6 +63,15 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
           { value }
         );
       }),
+    body("optionalDescription")
+      .optional()
+      .isLength({ max: ZENDESK_FIELD_MAX_LENGTH })
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.optionalDescriptionErrorMessage.entryTooLongMessage",
+          { value }
+        );
+      }),
     body("moreDetailDescription")
       .optional()
       .notEmpty()

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -254,6 +254,9 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   ) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
   }
+  if (theme === ZENDESK_THEMES.PROVING_IDENTITY) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -257,6 +257,9 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   if (theme === ZENDESK_THEMES.PROVING_IDENTITY) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
   }
+  if (theme === ZENDESK_THEMES.EMAIL_SUBSCRIPTIONS) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -203,6 +203,12 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   ) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.anythingElseTooLongMessage";
   }
+  if (
+    theme === ZENDESK_THEMES.SIGNING_IN &&
+    subtheme === ZENDESK_THEMES.ACCOUNT_NOT_FOUND
+  ) {
+    return "pages.contactUsQuestions.accountNotFound.section1.entryTooLongErrorMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -35,7 +35,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .isLength({ max: ZENDESK_FIELD_MAX_LENGTH })
       .withMessage((value, { req }) => {
         return req.t(
-          getErrorMessageForIssueDescriptionWhereLengthExceeded(
+          getLengthExceededErrorMessageForIssueDescription(
             req.body.theme,
             req.body.subtheme
           ),
@@ -130,7 +130,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
 export function getErrorMessageForIssueDescription(
   theme: string,
   subtheme: string
-): string {
+): string | undefined {
   if (theme === ZENDESK_THEMES.EMAIL_SUBSCRIPTIONS) {
     return "pages.contactUsQuestions.emailSubscriptions.section1.errorMessage";
   }
@@ -143,20 +143,8 @@ export function getErrorMessageForIssueDescription(
   if (theme === ZENDESK_THEMES.PROVING_IDENTITY) {
     return "pages.contactUsQuestions.provingIdentity.section1.errorMessage";
   }
-  if (
-    theme === ZENDESK_THEMES.ID_CHECK_APP &&
-    subtheme === ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR
-  ) {
-    return "pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.errorMessage";
-  }
-  if (
-    theme === ZENDESK_THEMES.ID_CHECK_APP &&
-    subtheme === ZENDESK_THEMES.ID_CHECK_APP_SOMETHING_ELSE
-  ) {
-    return "pages.contactUsQuestions.idCheckAppSomethingElse.section1.errorMessage";
-  }
   if (theme === ZENDESK_THEMES.ID_CHECK_APP) {
-    return "pages.contactUsQuestions.whatHappened.errorMessage";
+    return getErrorMessageForIdCheckAppIssueDescription(subtheme);
   }
   if (subtheme === ZENDESK_THEMES.ACCOUNT_NOT_FOUND) {
     return "pages.contactUsQuestions.accountNotFound.section1.errorMessage";
@@ -164,95 +152,73 @@ export function getErrorMessageForIssueDescription(
   if (subtheme === ZENDESK_THEMES.TECHNICAL_ERROR) {
     return "pages.contactUsQuestions.technicalError.section1.errorMessage";
   }
-  if (
-    theme === ZENDESK_THEMES.SIGNING_IN &&
-    subtheme === ZENDESK_THEMES.SOMETHING_ELSE
-  ) {
-    return "pages.contactUsQuestions.signignInProblem.section1.errorMessage";
+  if (theme === ZENDESK_THEMES.SIGNING_IN) {
+    return getErrorMessageForSigningInIssueDescription(subtheme);
   }
-  if (
-    theme === ZENDESK_THEMES.ACCOUNT_CREATION &&
-    subtheme === ZENDESK_THEMES.SOMETHING_ELSE
-  ) {
-    return "pages.contactUsQuestions.accountCreationProblem.section1.errorMessage";
+  if (theme === ZENDESK_THEMES.ACCOUNT_CREATION) {
+    return getErrorMessageForAccountCreationIssueDescription(subtheme);
   }
   if (subtheme === ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM) {
     return "pages.contactUsQuestions.authenticatorApp.section1.errorMessage";
   }
 }
 
-export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
+export function getErrorMessageForAccountCreationIssueDescription(
+  subtheme: string
+): string | undefined {
+  if (subtheme === ZENDESK_THEMES.SOMETHING_ELSE) {
+    return "pages.contactUsQuestions.accountCreationProblem.section1.errorMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM) {
+    return "pages.contactUsQuestions.anotherProblem.section1.errorMessage";
+  }
+}
+
+export function getErrorMessageForSigningInIssueDescription(
+  subtheme: string
+): string | undefined {
+  if (subtheme === ZENDESK_THEMES.SOMETHING_ELSE) {
+    return "pages.contactUsQuestions.signignInProblem.section1.errorMessage";
+  }
+}
+
+export function getErrorMessageForIdCheckAppIssueDescription(
+  subtheme: string
+): string | undefined {
+  if (subtheme === ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR) {
+    return "pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.errorMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.ID_CHECK_APP_SOMETHING_ELSE) {
+    return "pages.contactUsQuestions.idCheckAppSomethingElse.section1.errorMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.TAKING_PHOTO_OF_ID_PROBLEM) {
+    return "pages.contactUsQuestions.whatHappened.errorMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.LINKING_PROBLEM) {
+    return "pages.contactUsQuestions.whatHappened.errorMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.FACE_SCANNING_PROBLEM) {
+    return "pages.contactUsQuestions.whatHappened.errorMessage";
+  }
+}
+
+export function getLengthExceededErrorMessageForIssueDescription(
   theme: string,
   subtheme: string
-): string {
-  if (
-    theme === ZENDESK_THEMES.ACCOUNT_CREATION &&
-    subtheme === ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM
-  ) {
-    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+): string | undefined {
+  if (theme === ZENDESK_THEMES.ACCOUNT_CREATION) {
+    return getLengthExceededErrorMessageForAccountCreationIssueDescription(
+      subtheme
+    );
   }
-  if (
-    theme === ZENDESK_THEMES.ACCOUNT_CREATION &&
-    subtheme === ZENDESK_THEMES.TECHNICAL_ERROR
-  ) {
-    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
-  }
-  if (
-    theme === ZENDESK_THEMES.ACCOUNT_CREATION &&
-    subtheme === ZENDESK_THEMES.SOMETHING_ELSE
-  ) {
-    return "pages.contactUsQuestions.issueDescriptionErrorMessage.anythingElseTooLongMessage";
-  }
-  if (
-    theme === ZENDESK_THEMES.SIGNING_IN &&
-    subtheme === ZENDESK_THEMES.ACCOUNT_NOT_FOUND
-  ) {
-    return "pages.contactUsQuestions.accountNotFound.section1.entryTooLongErrorMessage";
-  }
-  if (
-    theme === ZENDESK_THEMES.SIGNING_IN &&
-    subtheme === ZENDESK_THEMES.TECHNICAL_ERROR
-  ) {
-    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
-  }
-  if (
-    theme === ZENDESK_THEMES.SIGNING_IN &&
-    subtheme === ZENDESK_THEMES.SOMETHING_ELSE
-  ) {
-    return "pages.contactUsQuestions.issueDescriptionErrorMessage.anythingElseTooLongMessage";
+  if (theme === ZENDESK_THEMES.SIGNING_IN) {
+    return getLengthExceededErrorMessageForSigningInIssueDescription(subtheme);
   }
   if (theme === ZENDESK_THEMES.SOMETHING_ELSE) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
   }
-  if (
-    theme === ZENDESK_THEMES.ID_CHECK_APP &&
-    subtheme === ZENDESK_THEMES.LINKING_PROBLEM
-  ) {
-    return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
-  }
-  if (
-    theme === ZENDESK_THEMES.ID_CHECK_APP &&
-    subtheme === ZENDESK_THEMES.TAKING_PHOTO_OF_ID_PROBLEM
-  ) {
-    return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
-  }
-  if (
-    theme === ZENDESK_THEMES.ID_CHECK_APP &&
-    subtheme === ZENDESK_THEMES.FACE_SCANNING_PROBLEM
-  ) {
-    return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
-  }
-  if (
-    theme === ZENDESK_THEMES.ID_CHECK_APP &&
-    subtheme === ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR
-  ) {
-    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
-  }
-  if (
-    theme === ZENDESK_THEMES.ID_CHECK_APP &&
-    subtheme === ZENDESK_THEMES.ID_CHECK_APP_SOMETHING_ELSE
-  ) {
-    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  if (theme === ZENDESK_THEMES.ID_CHECK_APP) {
+    return getLengthExceededErrorMessageForIdCheckAppIssueDescription(subtheme);
   }
   if (theme === ZENDESK_THEMES.PROVING_IDENTITY) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
@@ -265,10 +231,58 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   }
 }
 
+export function getLengthExceededErrorMessageForAccountCreationIssueDescription(
+  subtheme: string
+): string | undefined {
+  if (subtheme === ZENDESK_THEMES.AUTHENTICATOR_APP_PROBLEM) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.TECHNICAL_ERROR) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.SOMETHING_ELSE) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.anythingElseTooLongMessage";
+  }
+}
+
+export function getLengthExceededErrorMessageForIdCheckAppIssueDescription(
+  subtheme: string
+): string | undefined {
+  if (subtheme === ZENDESK_THEMES.LINKING_PROBLEM) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.TAKING_PHOTO_OF_ID_PROBLEM) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.FACE_SCANNING_PROBLEM) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.ID_CHECK_APP_SOMETHING_ELSE) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
+}
+
+export function getLengthExceededErrorMessageForSigningInIssueDescription(
+  subtheme: string
+): string | undefined {
+  if (subtheme === ZENDESK_THEMES.ACCOUNT_NOT_FOUND) {
+    return "pages.contactUsQuestions.accountNotFound.section1.entryTooLongErrorMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.TECHNICAL_ERROR) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
+  if (subtheme === ZENDESK_THEMES.SOMETHING_ELSE) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.anythingElseTooLongMessage";
+  }
+}
+
 export function getErrorMessageForAdditionalDescription(
   theme: string,
   subtheme: string
-): string {
+): string | undefined {
   if (theme === ZENDESK_THEMES.EMAIL_SUBSCRIPTIONS) {
     return "pages.contactUsQuestions.emailSubscriptions.section1.errorMessage";
   }

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -260,6 +260,9 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   if (theme === ZENDESK_THEMES.EMAIL_SUBSCRIPTIONS) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
   }
+  if (theme === ZENDESK_THEMES.SUGGESTIONS_FEEDBACK) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.suggestionFeedbackTooLongMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -242,6 +242,12 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   ) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
   }
+  if (
+    theme === ZENDESK_THEMES.ID_CHECK_APP &&
+    subtheme === ZENDESK_THEMES.ID_CHECK_APP_TECHNICAL_ERROR
+  ) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -224,6 +224,12 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   if (theme === ZENDESK_THEMES.SOMETHING_ELSE) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
   }
+  if (
+    theme === ZENDESK_THEMES.ID_CHECK_APP &&
+    subtheme === ZENDESK_THEMES.LINKING_PROBLEM
+  ) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -230,6 +230,12 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   ) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
   }
+  if (
+    theme === ZENDESK_THEMES.ID_CHECK_APP &&
+    subtheme === ZENDESK_THEMES.TAKING_PHOTO_OF_ID_PROBLEM
+  ) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.whatHappenedTooLongMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -1,7 +1,7 @@
 import { body, check } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
-import { ZENDESK_THEMES } from "../../app.constants";
+import { ZENDESK_FIELD_MAX_LENGTH, ZENDESK_THEMES } from "../../app.constants";
 
 export function validateContactUsQuestionsRequest(): ValidationChainFunc {
   return [
@@ -57,6 +57,15 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           "pages.contactUsQuestions.serviceTryingToUse.errorMessage",
+          { value }
+        );
+      }),
+    body("moreDetailDescription")
+      .optional()
+      .isLength({ max: ZENDESK_FIELD_MAX_LENGTH })
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.optionalDescriptionErrorMessage.entryTooLongMessage",
           { value }
         );
       }),

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -215,6 +215,12 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   ) {
     return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
   }
+  if (
+    theme === ZENDESK_THEMES.SIGNING_IN &&
+    subtheme === ZENDESK_THEMES.SOMETHING_ELSE
+  ) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.anythingElseTooLongMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -209,6 +209,12 @@ export function getErrorMessageForIssueDescriptionWhereLengthExceeded(
   ) {
     return "pages.contactUsQuestions.accountNotFound.section1.entryTooLongErrorMessage";
   }
+  if (
+    theme === ZENDESK_THEMES.SIGNING_IN &&
+    subtheme === ZENDESK_THEMES.TECHNICAL_ERROR
+  ) {
+    return "pages.contactUsQuestions.issueDescriptionErrorMessage.entryTooLongMessage";
+  }
 }
 
 export function getErrorMessageForAdditionalDescription(

--- a/src/components/contact-us/further-information/index.njk
+++ b/src/components/contact-us/further-information/index.njk
@@ -3,7 +3,6 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set showBack = true %}

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -3,7 +3,6 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set showBack = true %}

--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -24,7 +24,7 @@
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
-        text: errors['issueDescription'].text
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -11,7 +11,7 @@
 <input type="hidden" name="formType" value="accountCreationProblem"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.accountCreationProblem.section1.header' | translate,
       classes: "govuk-label--s"
@@ -21,6 +21,7 @@
       },
     id: "issueDescription",
     name: "issueDescription",
+    maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
         text: errors['issueDescription'].text

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -11,7 +11,7 @@
 <input type="hidden" name="formType" value="accountNotFound"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.accountNotFound.section1.header' | translate,
       classes: "govuk-label--s"
@@ -21,13 +21,14 @@
       },
     id: "issueDescription",
     name: "issueDescription",
+    maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
         text: errors['issueDescription'].text
     } if (errors['issueDescription'])
 }) }}
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.accountNotFound.section2.header' | translate,
       classes: "govuk-label--s"
@@ -37,6 +38,7 @@
       },
     id: "optionalDescription",
     name: "optionalDescription",
+    maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
     errorMessage: {
         text: errors['optionalDescription'].text

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -24,7 +24,7 @@
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
-        text: errors['issueDescription'].text
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
@@ -41,7 +41,7 @@
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
     errorMessage: {
-        text: errors['optionalDescription'].text
+        text: errors['optionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -21,7 +21,7 @@
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
-        text: errors['issueDescription'].text
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
@@ -38,7 +38,7 @@
     maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
     errorMessage: {
-        text: errors['additionalDescription'].text
+        text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -11,20 +11,21 @@
 <input type="hidden" name="formType" value="anotherProblem"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.anotherProblem.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
+    maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
         text: errors['issueDescription'].text
     } if (errors['issueDescription'])
 }) }}
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.anotherProblem.section2.header' | translate,
       classes: "govuk-label--s"
@@ -34,6 +35,7 @@
       },
     id: "additionalDescription",
     name: "additionalDescription",
+    maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
     errorMessage: {
         text: errors['additionalDescription'].text

--- a/src/components/contact-us/questions/_authenticator-app-problem.njk
+++ b/src/components/contact-us/questions/_authenticator-app-problem.njk
@@ -11,7 +11,7 @@
 <input type="hidden" name="formType" value="authenticatorApp"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.authenticatorApp.section1.header' | translate,
       classes: "govuk-label--s"
@@ -19,12 +19,13 @@
     id: "issueDescription",
     name: "issueDescription",
     value: issueDescription,
+    maxlength: zendeskFieldMaxLength,
     errorMessage: {
         text: errors['issueDescription'].text
     } if (errors['issueDescription'])
 }) }}
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.authenticatorApp.section2.header' | translate,
       classes: "govuk-label--s"
@@ -35,6 +36,7 @@
     id: "additionalDescription",
     name: "additionalDescription",
     value: additionalDescription,
+    maxlength: zendeskFieldMaxLength,
     errorMessage: {
         text: errors['additionalDescription'].text
     } if (errors['additionalDescription'])

--- a/src/components/contact-us/questions/_authenticator-app-problem.njk
+++ b/src/components/contact-us/questions/_authenticator-app-problem.njk
@@ -21,7 +21,7 @@
     value: issueDescription,
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
-        text: errors['issueDescription'].text
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
@@ -38,7 +38,7 @@
     value: additionalDescription,
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
-        text: errors['additionalDescription'].text
+        text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_email-subscriptions-questions.njk
+++ b/src/components/contact-us/questions/_email-subscriptions-questions.njk
@@ -20,7 +20,7 @@
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
-        text: errors['issueDescription'].text
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
@@ -37,7 +37,7 @@
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
     errorMessage: {
-        text: errors['optionalDescription'].text
+        text: errors['optionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_email-subscriptions-questions.njk
+++ b/src/components/contact-us/questions/_email-subscriptions-questions.njk
@@ -10,20 +10,21 @@
 <input type="hidden" name="formType" value="emailSubscription"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.emailSubscriptions.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
+    maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
         text: errors['issueDescription'].text
     } if (errors['issueDescription'])
 }) }}
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.emailSubscriptions.section2.header' | translate,
       classes: "govuk-label--s"
@@ -33,6 +34,7 @@
       },
     id: "optionalDescription",
     name: "optionalDescription",
+    maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
     errorMessage: {
         text: errors['optionalDescription'].text

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -24,7 +24,7 @@
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
     errorMessage: {
-        text: errors['optionalDescription'].text
+        text: errors['optionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -11,7 +11,7 @@
 <input type="hidden" name="formType" value="forgottenPassword"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.forgottenPassword.section1.header' | translate,
       classes: "govuk-label--s"
@@ -21,6 +21,7 @@
       },
     id: "optionalDescription",
     name: "optionalDescription",
+    maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
     errorMessage: {
         text: errors['optionalDescription'].text

--- a/src/components/contact-us/questions/_id-check-app-something-else.njk
+++ b/src/components/contact-us/questions/_id-check-app-something-else.njk
@@ -11,20 +11,21 @@
     <input type="hidden" name="formType" value="idCheckAppSomethingElse"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
 
-    {{ govukTextarea({
+    {{ govukCharacterCount({
         label: {
             text: 'pages.contactUsQuestions.idCheckAppSomethingElse.section1.header' | translate,
             classes: "govuk-label--s"
         },
         id: "issueDescription",
         name: "issueDescription",
+        maxlength: zendeskFieldMaxLength,
         value: issueDescription,
         errorMessage: {
             text: errors['issueDescription'].text
         } if (errors['issueDescription'])
     }) }}
 
-    {{ govukTextarea({
+    {{ govukCharacterCount({
         label: {
             text: 'pages.contactUsQuestions.idCheckAppSomethingElse.section2.header' | translate,
             classes: "govuk-label--s"
@@ -34,6 +35,7 @@
         },
         id: "additionalDescription",
         name: "additionalDescription",
+        maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
         errorMessage: {
             text: errors['additionalDescription'].text

--- a/src/components/contact-us/questions/_id-check-app-something-else.njk
+++ b/src/components/contact-us/questions/_id-check-app-something-else.njk
@@ -21,7 +21,7 @@
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
         errorMessage: {
-            text: errors['issueDescription'].text
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
     }) }}
 
@@ -38,7 +38,7 @@
         maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
         errorMessage: {
-            text: errors['additionalDescription'].text
+            text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['additionalDescription'])
     }) }}
 

--- a/src/components/contact-us/questions/_id-check-app-technical-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-technical-problem.njk
@@ -11,20 +11,21 @@
     <input type="hidden" name="formType" value="idCheckAppTechnicalProblem"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
 
-    {{ govukTextarea({
+    {{ govukCharacterCount({
         label: {
             text: 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.header' | translate,
             classes: "govuk-label--s"
         },
         id: "issueDescription",
         name: "issueDescription",
+        maxlength: zendeskFieldMaxLength,
         value: issueDescription,
         errorMessage: {
             text: errors['issueDescription'].text
         } if (errors['issueDescription'])
     }) }}
 
-    {{ govukTextarea({
+    {{ govukCharacterCount({
         label: {
             text: 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section2.header' | translate,
             classes: "govuk-label--s"
@@ -34,6 +35,7 @@
         },
         id: "additionalDescription",
         name: "additionalDescription",
+        maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
         errorMessage: {
             text: errors['additionalDescription'].text

--- a/src/components/contact-us/questions/_id-check-app-technical-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-technical-problem.njk
@@ -21,7 +21,7 @@
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
         errorMessage: {
-            text: errors['issueDescription'].text
+            text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
     }) }}
 
@@ -38,7 +38,7 @@
         maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
         errorMessage: {
-            text: errors['additionalDescription'].text
+            text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['additionalDescription'])
     }) }}
 

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -14,7 +14,7 @@
 {% set radioHeader = 'pages.contactUsQuestions.invalidSecurityCode.section1.header' | translate %}
 {% include "contact-us/questions/_security_send_method.njk" %}
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.invalidSecurityCode.section2.header' | translate,
       classes: "govuk-label--s"
@@ -25,6 +25,7 @@
     id: "moreDetailDescription",
     name: "moreDetailDescription",
     value: moreDetailDescription,
+    maxlength: zendeskFieldMaxLength,
     errorMessage: {
         text: errors['moreDetailDescription'].text
     } if (errors['moreDetailDescription'])

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -27,7 +27,7 @@
     value: moreDetailDescription,
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
-        text: errors['moreDetailDescription'].text
+        text: errors['moreDetailDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['moreDetailDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -14,7 +14,7 @@
 {% set radioHeader = 'pages.contactUsQuestions.noPhoneNumberAccess.section1.header' | translate %}
 {% include "contact-us/questions/_security_send_method.njk" %}
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.noPhoneNumberAccess.section2.header' | translate,
       classes: "govuk-label--s"
@@ -24,6 +24,7 @@
       },
     id: "optionalDescription",
     name: "optionalDescription",
+    maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
     errorMessage: {
         text: errors['optionalDescription'].text

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -27,7 +27,7 @@
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
     errorMessage: {
-        text: errors['optionalDescription'].text
+        text: errors['optionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -14,7 +14,7 @@
 {% set radioHeader = 'pages.contactUsQuestions.noSecurityCode.section1.header' | translate %}
 {% include "contact-us/questions/_security_send_method.njk" %}
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.noSecurityCode.section2.header' | translate,
       classes: "govuk-label--s"
@@ -25,6 +25,7 @@
     id: "moreDetailDescription",
     name: "moreDetailDescription",
     value: moreDetailDescription,
+    maxlength: zendeskFieldMaxLength,
     errorMessage: {
         text: errors['moreDetailDescription'].text
     } if (errors['moreDetailDescription'])

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -27,7 +27,7 @@
     value: moreDetailDescription,
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
-        text: errors['moreDetailDescription'].text
+        text: errors['moreDetailDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['moreDetailDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_no-uk-mobile-questions.njk
+++ b/src/components/contact-us/questions/_no-uk-mobile-questions.njk
@@ -11,7 +11,7 @@
 <input type="hidden" name="formType" value="noUKMobile"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.noUKMobile.section1.header' | translate,
       classes: "govuk-label--s"
@@ -21,6 +21,7 @@
       },
     id: "moreDetailDescription",
     name: "moreDetailDescription",
+    maxlength: zendeskFieldMaxLength,
     value: moreDetailDescription,
     errorMessage: {
         text: errors['moreDetailDescription'].text

--- a/src/components/contact-us/questions/_no-uk-mobile-questions.njk
+++ b/src/components/contact-us/questions/_no-uk-mobile-questions.njk
@@ -24,7 +24,7 @@
     maxlength: zendeskFieldMaxLength,
     value: moreDetailDescription,
     errorMessage: {
-        text: errors['moreDetailDescription'].text
+        text: errors['moreDetailDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['moreDetailDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_proving-identity-problem-questions.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-questions.njk
@@ -10,20 +10,21 @@
 <input type="hidden" name="formType" value="provingIdentity"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.provingIdentity.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
+    maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
         text: errors['issueDescription'].text
     } if (errors['issueDescription'])
 }) }}
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.provingIdentity.section2.header' | translate,
       classes: "govuk-label--s"
@@ -33,6 +34,7 @@
       },
     id: "additionalDescription",
     name: "additionalDescription",
+    maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
     errorMessage: {
         text: errors['additionalDescription'].text

--- a/src/components/contact-us/questions/_proving-identity-problem-questions.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-questions.njk
@@ -20,7 +20,7 @@
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
-        text: errors['issueDescription'].text
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
@@ -37,7 +37,7 @@
     maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
     errorMessage: {
-        text: errors['additionalDescription'].text
+        text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_signing-in-problem-questions.njk
+++ b/src/components/contact-us/questions/_signing-in-problem-questions.njk
@@ -11,7 +11,7 @@
 <input type="hidden" name="formType" value="signingInProblem"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.signignInProblem.section1.header' | translate,
       classes: "govuk-label--s"
@@ -21,6 +21,7 @@
       },
     id: "issueDescription",
     name: "issueDescription",
+    maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
         text: errors['issueDescription'].text

--- a/src/components/contact-us/questions/_signing-in-problem-questions.njk
+++ b/src/components/contact-us/questions/_signing-in-problem-questions.njk
@@ -24,7 +24,7 @@
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
-        text: errors['issueDescription'].text
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_suggestion-feedback-questions.njk
+++ b/src/components/contact-us/questions/_suggestion-feedback-questions.njk
@@ -20,7 +20,7 @@
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
-        text: errors['issueDescription'].text
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_suggestion-feedback-questions.njk
+++ b/src/components/contact-us/questions/_suggestion-feedback-questions.njk
@@ -10,13 +10,14 @@
 <input type="hidden" name="formType" value="suggestionFeedback"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.suggestionOrFeedback.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
+    maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
         text: errors['issueDescription'].text

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -21,7 +21,7 @@
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
-        text: errors['issueDescription'].text
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}
 
@@ -38,7 +38,7 @@
     maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
     errorMessage: {
-        text: errors['additionalDescription'].text
+        text: errors['additionalDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])
 }) }}
 

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -11,20 +11,21 @@
 <input type="hidden" name="formType" value="technicalError"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.technicalError.section1.header' | translate,
       classes: "govuk-label--s"
     },
     id: "issueDescription",
     name: "issueDescription",
+    maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
         text: errors['issueDescription'].text
     } if (errors['issueDescription'])
 }) }}
 
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
       text: 'pages.contactUsQuestions.technicalError.section2.header' | translate,
       classes: "govuk-label--s"
@@ -34,6 +35,7 @@
       },
     id: "additionalDescription",
     name: "additionalDescription",
+    maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
     errorMessage: {
         text: errors['additionalDescription'].text

--- a/src/components/contact-us/questions/_what_happened.njk
+++ b/src/components/contact-us/questions/_what_happened.njk
@@ -11,6 +11,6 @@
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
-        text: errors['issueDescription'].text
+        text: errors['issueDescription'].text | translate | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
 }) }}

--- a/src/components/contact-us/questions/_what_happened.njk
+++ b/src/components/contact-us/questions/_what_happened.njk
@@ -1,4 +1,4 @@
-{{ govukTextarea({
+{{ govukCharacterCount({
     label: {
         text: 'pages.contactUsQuestions.whatHappened.header' | translate,
         classes: "govuk-label--s"
@@ -8,6 +8,7 @@
     },
     id: "issueDescription",
     name: "issueDescription",
+    maxlength: zendeskFieldMaxLength,
     value: issueDescription,
     errorMessage: {
         text: errors['issueDescription'].text

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -5,6 +5,8 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+
 
 {% set showBack = true %}
 {% set hrefBack = backurl %}

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -3,7 +3,6 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
 

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -7,7 +7,10 @@ import {
   contactUsQuestionsFormPost,
   contactUsQuestionsGet,
 } from "../contact-us-controller";
-import { ZENDESK_THEMES } from "../../../app.constants";
+import {
+  ZENDESK_THEMES,
+  ZENDESK_FIELD_MAX_LENGTH,
+} from "../../../app.constants";
 import { ContactUsServiceInterface } from "../types";
 
 describe("contact us questions controller", () => {
@@ -46,6 +49,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'GOV.UK email subscriptions' radio option was chosen", () => {
@@ -60,6 +64,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.emailSubscriptions.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'A suggestion or feedback' radio option was chosen", () => {
@@ -74,6 +79,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.suggestionOrFeedback.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
 
@@ -89,6 +95,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us",
         pageTitleHeading: "pages.contactUsQuestions.provingIdentity.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
 
@@ -113,6 +120,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -128,6 +136,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'You do not have access to the phone number' radio option was chosen", () => {
@@ -143,6 +152,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noPhoneNumberAccess.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'You've forgotten your password' radio option was chosen", () => {
@@ -158,6 +168,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.forgottenPassword.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'Your account cannot be found' radio option was chosen", () => {
@@ -173,6 +184,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.accountNotFound.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -188,6 +200,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -203,6 +216,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
   });
@@ -221,6 +235,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -236,6 +251,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'You do not have a UK number' radio option was chosen", () => {
@@ -251,6 +267,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.noUKMobile.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -266,6 +283,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -281,6 +299,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.accountCreation.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
     it("should render contact-us-questions if a 'problem with authenticator app' radio option was chosen", () => {
@@ -296,6 +315,7 @@ describe("contact us questions controller", () => {
         backurl: "/contact-us-further-information",
         pageTitleHeading: "pages.contactUsQuestions.authenticatorApp.title",
         referer: REFERER,
+        zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
       });
     });
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1474,9 +1474,16 @@
           "paragraph1": "You can add more detail, such as what you were trying to do, or give us feedback"
         }
       },
+      "issueDescriptionErrorMessage": {
+        "entryTooLongMessage": "What were you trying to do must be [maximumCharacters] characters or less",
+        "anythingElseTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less"
+      },
+      "additionalDescriptionErrorMessage": {
+        "entryTooLongMessage": "What happened must be [maximumCharacters] characters or less"
+      },
       "optionalDescriptionErrorMessage": {
-        "message": "Rhowch fwy o fanylion",
-        "entryTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less",
+        "message": "Enter more detail",
+        "entryTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less"
       },
       "forgottenPassword": {
         "title": "Rydych wedi anghofio eich cyfrinair",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1529,7 +1529,8 @@
         "section1": {
           "header": "Pa wasanaeth oeddech chi’n ceisio ei ddefnyddio?",
           "paragraph1": "Er enghraifft, eich tanysgrifiadau e-bost GOV.UK, eich cyfrif treth personol neu Gredyd Cynhwysol",
-          "errorMessage": "Rhowch ba wasanaeth roeddech yn ceisio ei ddefnyddio"
+          "errorMessage": "Rhowch ba wasanaeth roeddech yn ceisio ei ddefnyddio",
+          "entryTooLongErrorMessage": "What service were you trying to use must be [maximumCharacters] characters or less"
         },
         "section2": {
           "header": "Ydych chi eisiau dweud unrhyw beth arall wrthym",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1476,7 +1476,8 @@
       },
       "issueDescriptionErrorMessage": {
         "entryTooLongMessage": "What were you trying to do must be [maximumCharacters] characters or less",
-        "anythingElseTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less"
+        "anythingElseTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less",
+        "whatHappenedTooLongMessage": "What happened must be [maximumCharacters] characters or less"
       },
       "additionalDescriptionErrorMessage": {
         "entryTooLongMessage": "What happened must be [maximumCharacters] characters or less"

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1475,7 +1475,8 @@
         }
       },
       "optionalDescriptionErrorMessage": {
-        "message": "Rhowch fwy o fanylion"
+        "message": "Rhowch fwy o fanylion",
+        "entryTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less",
       },
       "forgottenPassword": {
         "title": "Rydych wedi anghofio eich cyfrinair",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1477,7 +1477,8 @@
       "issueDescriptionErrorMessage": {
         "entryTooLongMessage": "What were you trying to do must be [maximumCharacters] characters or less",
         "anythingElseTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less",
-        "whatHappenedTooLongMessage": "What happened must be [maximumCharacters] characters or less"
+        "whatHappenedTooLongMessage": "What happened must be [maximumCharacters] characters or less",
+        "suggestionFeedbackTooLongMessage": "Your suggestion or feedback must be [maximumCharacters] characters or less"
       },
       "additionalDescriptionErrorMessage": {
         "entryTooLongMessage": "What happened must be [maximumCharacters] characters or less"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1475,6 +1475,12 @@
           "paragraph1": "You can add more detail, such as what you were trying to do, or give us feedback"
         }
       },
+      "issueDescriptionErrorMessage": {
+        "entryTooLongMessage": "What were you trying to do must be [maximumCharacters] characters or less"
+      },
+      "additionalDescriptionErrorMessage": {
+        "entryTooLongMessage": "What happened must be [maximumCharacters] characters or less"
+      },
       "optionalDescriptionErrorMessage": {
         "message": "Enter more detail",
         "entryTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1476,7 +1476,8 @@
         }
       },
       "optionalDescriptionErrorMessage": {
-        "message": "Enter more detail"
+        "message": "Enter more detail",
+        "entryTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less"
       },
       "forgottenPassword": {
         "title": "You’ve forgotten your password",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1478,7 +1478,8 @@
       "issueDescriptionErrorMessage": {
         "entryTooLongMessage": "What were you trying to do must be [maximumCharacters] characters or less",
         "anythingElseTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less",
-        "whatHappenedTooLongMessage": "What happened must be [maximumCharacters] characters or less"
+        "whatHappenedTooLongMessage": "What happened must be [maximumCharacters] characters or less",
+        "suggestionFeedbackTooLongMessage": "Your suggestion or feedback must be [maximumCharacters] characters or less"
       },
       "additionalDescriptionErrorMessage": {
         "entryTooLongMessage": "What happened must be [maximumCharacters] characters or less"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1530,7 +1530,8 @@
         "section1": {
           "header": "What service were you trying to use?",
           "paragraph1": "For example, your GOV.UK email subscriptions, your personal tax account or Universal Credit",
-          "errorMessage": "Enter what service you were trying to use"
+          "errorMessage": "Enter what service you were trying to use",
+          "entryTooLongErrorMessage": "What service were you trying to use must be [maximumCharacters] characters or less"
         },
         "section2": {
           "header": "Anything else you want to tell us",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1477,7 +1477,8 @@
       },
       "issueDescriptionErrorMessage": {
         "entryTooLongMessage": "What were you trying to do must be [maximumCharacters] characters or less",
-        "anythingElseTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less"
+        "anythingElseTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less",
+        "whatHappenedTooLongMessage": "What happened must be [maximumCharacters] characters or less"
       },
       "additionalDescriptionErrorMessage": {
         "entryTooLongMessage": "What happened must be [maximumCharacters] characters or less"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1476,7 +1476,8 @@
         }
       },
       "issueDescriptionErrorMessage": {
-        "entryTooLongMessage": "What were you trying to do must be [maximumCharacters] characters or less"
+        "entryTooLongMessage": "What were you trying to do must be [maximumCharacters] characters or less",
+        "anythingElseTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less"
       },
       "additionalDescriptionErrorMessage": {
         "entryTooLongMessage": "What happened must be [maximumCharacters] characters or less"

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,11 @@ export interface Error {
   href: string;
 }
 
+export interface PlaceholderReplacement {
+  search: string;
+  replacement: string;
+}
+
 export interface UserSession {
   isAuthenticated?: boolean;
   email?: string;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -22,7 +22,9 @@ export function formatValidationError(
   return error;
 }
 
-export function replaceErrorMessagePlaceholders(errors: { [k: string]: Error }): {
+export function replaceErrorMessagePlaceholders(errors: {
+  [k: string]: Error;
+}): {
   [p: string]: Error;
 } {
   for (const error in errors) {

--- a/test/unit/utils/validation.test.ts
+++ b/test/unit/utils/validation.test.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import {
+  replaceErrorMessagePlaceholders,
+  deDuplicateErrorList,
+} from "../../../src/utils/validation";
+import { PLACEHOLDER_REPLACEMENTS } from "../../../src/app.constants";
+
+describe("validation", () => {
+  describe("replaceErrorMessagePlaceholders", () => {
+    it("should make all replacements", () => {
+      const errorsWithPlaceholders = [
+        {
+          text: "What happened must be [maximumCharacters] characters or less",
+          href: "#issueDescription",
+        },
+      ];
+
+      const expected = [
+        {
+          text: "What happened must be 1,200 characters or less",
+          href: "#issueDescription",
+        },
+      ];
+
+      expect(
+        replaceErrorMessagePlaceholders(
+          errorsWithPlaceholders,
+          PLACEHOLDER_REPLACEMENTS
+        )
+      ).to.eql(expected);
+    });
+  });
+
+  describe("deDuplicateErrorList", () => {
+    it("should remove duplicates", () => {
+      const initialErrorList = {
+        serviceTryingToUse: {
+          text: "Enter the name of the service",
+          href: "#serviceTryingToUse",
+        },
+        serviceWhereIssueWasEncountered: {
+          text: "Enter the name of the service",
+          href: "#serviceTryingToUse",
+        },
+        contact: {
+          text: "Select yes if we can reply to you by email",
+          href: "#contact",
+        },
+      };
+
+      const expected = [
+        {
+          text: "Enter the name of the service",
+          href: "#serviceTryingToUse",
+        },
+        {
+          text: "Select yes if we can reply to you by email",
+          href: "#contact",
+        },
+      ];
+
+      expect(deDuplicateErrorList(initialErrorList)).to.eql(expected);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2159,9 +2159,9 @@ globby@^11.0.3:
     slash "^3.0.0"
 
 govuk-frontend@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz"
-  integrity sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.4.1.tgz#88857c4ad8508255a4e983030a3964d6e1674107"
+  integrity sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==
 
 graceful-fs@^4.1.15:
   version "4.2.8"


### PR DESCRIPTION
## What?

Introduces the `govukCharacterCount` to the following user support forms: 

- [x] (Account creation) You do not have a UK mobile phone number
- [x] (Account creation) You did not get a security code
- [x] (Account creation) The security code did not work
- [x] (Account creation) You had a problem with an authenticator app
- [x] (Account creation) There was a technical problem (for example, the service was unavailable)
- [x] (Account creation) Something else
- [x] (Signing in) You did not get a security code
- [x] (Signing in) The security code did not work
- [x] (Signing in) You’ve forgotten your password
- [x] (Signing in) You’ve changed your phone number or lost your phone
- [x] (Signing in) You’ve been told your account ‘cannot be found’
- [x] (Signing in) There was a technical problem (for example, the service was unavailable)
- [x] (Signing in) Something else
- [x] Another problem using your GOV.UK account
- [x] (ID Check App) You had a problem linking the app to your web browser
- [x] (ID Check App) You had a problem taking a photo of your identity document (for example, passport or driving licence)
- [x] (ID Check App) You had a problem scanning your face
- [x] (ID Check App) There was a technical problem (for example you saw an error message)
- [x] (ID Check App) Something else
- [x] A problem proving your identity
- [x] GOV.UK email subscriptions
- [x] A suggestion or feedback about using your GOV.UK account

## Why?

Analysis has revealed the need to communicate and ensure a limit of 1200 characters on text areas within user support forms. See the Jira ticket for a full description.

## How?

The approach to achieve this has been: 

1. To add a `ZENDESK_FIELD_MAX_LENGTH` constant that represents the maximum length of fields submitted to Zendesk. This introduces more complexity than simply having the value hard-coded in several places but a single source of truth ensures changes to the constant will immediately cascade to the controller, validation logic and messages, and for number localisation.
2. Adds a new validation rules to prevent submissions that exceed this length.
3. Introduces a new object constant `PLACEHOLDER_REPLACEMENTS` to hold patterns that look for placeholders and their replacements
4. Introduces a `replaceErrorMessagePlaceholders()` function that iterates over error messages to match patterns and make replacements found in `PLACEHOLDER_REPLACEMENTS`. These serve to prepare an error list for use within the error summary (because the error summary expects a list it is not possible to use Nunjucks filters here)
5. Implementes the `govukCharacterCount` macro using these mechanisms on pages using it, using Nunjucks filters when instantiating the component (rather than doing the filter upstream)
6. Extracting the existing code that de-duped error messages in `validation.ts` into a function to make the code a bit easier to understand
7. Introduce `validation.test.ts` and new unit tests for these functions
