### PR TITLE
ACI-15: Change the content for optional services on T&Cs reject page

### DIFF
--- a/src/components/updated-terms-conditions/index-optional.njk
+++ b/src/components/updated-terms-conditions/index-optional.njk
@@ -9,10 +9,7 @@
 
 <p class="govuk-body govuk-white-text">
     {{ 'pages.updatedTermsAndCondsOptional.paragraph1' | translate }}
-</p>
-
-<p class="govuk-body govuk-white-text">
-    {{ 'pages.updatedTermsAndCondsOptional.paragraph2' | translate + clientInfo.client_name + 'pages.updatedTermsAndCondsOptional.paragraph2Continued' | translate }}
+    <a class="govuk-white-text" href="{{ redirectUri }}">{{ 'pages.updatedTermsAndCondsOptional.paragraph1Continued' | translate }}</a>
 </p>
 
 <form id="form-tracking" action="/updated-terms-and-conditions" method="post" novalidate>
@@ -20,23 +17,18 @@
     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
     {{ govukButton({
-        "text": 'pages.updatedTermsAndCondsOptional.agreeAndContinue' | translate,
+        "text": 'pages.updatedTermsAndCondsOptional.agreeToTheTerms' | translate,
         "type": "Submit",
         "preventDoubleClick": true,
         classes: 'govuk-blue-text govuk-white-button inverted-button',
-        "name": "acceptOrReject",
+        "name": "termsAndConditionsResult",
         "value": "accept"
     }) }}
 
-    <br />
-    {{ govukButton({
-        "text": 'pages.updatedTermsAndCondsOptional.goBackToService' | translate + clientName,
-        "type": "Submit",
-        "preventDoubleClick": true,
-        classes: 'govuk-btn-link inverted-button-link',
-        "name": "acceptOrReject",
-        "value": "reject"
-    }) }}
-
 </form>
+
+<a href="{{ redirectUri }}" class="govuk-white-link inverted-button-link govuk-body">
+    {{'pages.updatedTermsAndCondsOptional.continueWithoutSaving' | translate}}
+</a>
+
 {% endblock %}

--- a/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
+++ b/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
@@ -22,6 +22,7 @@ export function updatedTermsRejectedGet(req: Request, res: Response): void {
 
   return res.render("updated-terms-conditions/" + view, {
     clientName: req.session.client.name,
+    redirectUri: req.session.client.redirectUri,
   });
 }
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -560,13 +560,12 @@
       "goBackToService": "Ewch yn ôl i "
     },
     "updatedTermsAndCondsOptional": {
-      "title": "Cytuno i’r telerau defnydd wedi’u diweddaru i fynd yn eich blaen",
-      "header": "Cytuno i’r telerau defnydd wedi’u diweddaru i fynd yn eich blaen",
-      "paragraph1": "Mae angen i chi gytuno i’n diweddariad o’r",
-      "paragraph2": "Gallwch ddal cwblhau eich ",
-      "paragraph2Continued": " heb ei arbed.",
-      "agreeAndContinue": "Cytuno a pharhau",
-      "goBackToService": "Cwblhewch eich "
+      "title": "Mae angen i chi gytuno i’r telerau defnydd diwygiedig i arbed eich cynnydd",
+      "header": "Mae angen i chi gytuno i’r telerau defnydd diwygiedig i arbed eich cynnydd",
+      "paragraph1": "Os nad ydych yn cytuno, gallwch ",
+      "paragraph1Continued": "barhau heb arbed eich cynnydd.",
+      "agreeToTheTerms": "Cytuno i’r telerau",
+      "continueWithoutSaving": "Parhau heb arbed"
     },
     "cookiePolicy": {
       "title": "Polisi cwcis cyfrifon GOV.UK",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -560,13 +560,12 @@
       "goBackToService": "Go back to "
     },
     "updatedTermsAndCondsOptional": {
-      "title": "Agree to the updated terms of use to continue",
-      "header": "Agree to the updated terms of use to continue",
-      "paragraph1": "You need to agree to our updated",
-      "paragraph2": "You can still complete your ",
-      "paragraph2Continued": " without saving it.",
-      "agreeAndContinue": "Agree and continue",
-      "goBackToService": "Complete your "
+      "title": "You need to agree to the updated terms of use to save your progress",
+      "header": "You need to agree to the updated terms of use to save your progress",
+      "paragraph1": "If you do not agree, you can ",
+      "paragraph1Continued": "continue without saving your progress.",
+      "agreeToTheTerms": "Agree to the terms",
+      "continueWithoutSaving": "Continue without saving"
     },
     "cookiePolicy": {
       "title": "GOV.UK accounts cookies policy",


### PR DESCRIPTION
## What?

- Change the content for optional services on T&Cs reject page
- User should be able to continue without saving, via `redirect_uri`

## Why?

- So as to align the current page with the page on [Figma](https://www.figma.com/file/aVqNC4pKaebZchIU691f31/DI-Authentication?node-id=14739%3A60383&t=cWhR2MNCoQvxKw43-0)
