### PR TITLE
PYIC-2185 Update unhappy path content

### DIFF
--- a/src/components/photo-id/index-no-photo-id.njk
+++ b/src/components/photo-id/index-no-photo-id.njk
@@ -13,7 +13,7 @@
 
     {% include "common/errors/errorSummary.njk" %}
 
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.photoId.header' | translate}}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.noPhotoId.header' | translate}}</h1>
 
     <p class="govuk-body">{{'pages.noPhotoId.section1.paragraph1' | translate}}</p>
 
@@ -32,4 +32,8 @@
         }) }}
 
     </form>
+
+    <p class="govuk-body"><a target="_blank" rel="noopener noreferrer" href="{{'general.contactAccounts.contactLinkHref' | translate}}" class="govuk-link">{{'general.contactAccounts.contactLinkText' | translate}}</a></p>
+
+
 {% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -44,6 +44,10 @@
     "continue": {
       "label": "Parhau"
     },
+    "contactAccounts": {
+      "contactLinkHref": "https://signin.account.gov.uk/contact-us",
+      "contactLinkText": "Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)"
+    },
     "header": {
       "homepageHref": "https://www.gov.uk/"
     },
@@ -1692,14 +1696,14 @@
       }
     },
     "noPhotoId": {
-      "title": "Mae’n ddrwg gennym, ni allwn brofi pwy ydych chi",
-      "header": "Mae’n ddrwg gennym, ni allwn brofi pwy ydych chi",
+      "title": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych chi fel hyn",
+      "header": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych chi fel hyn",
       "section1": {
-        "paragraph1": "Ar hyn o bryd gallwch ond profi pwy ydych chi gyda’ch cyfrif GOV.UK os oes gennych ID gyda llun."
+        "paragraph1": "Ar hyn o bryd, dim ond os oes gennych ID llun y gallwch brofi pwy ydych chi gyda’ch cyfrif GOV.UK."
       },
       "section2": {
         "subHeading": "Beth allwch chi ei wneud",
-        "paragraph1": "Parhau i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi."
+        "paragraph1": "Ewch yn eich blaen i’r gwasanaeth roeddech chi’n ceisio ei ddefnyddio a chwilio am ffyrdd eraill i brofi pwy ydych chi."
       }
     },
     "securityCodeEnteredExceeded": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -44,6 +44,10 @@
     "continue": {
       "label": "Continue"
     },
+    "contactAccounts": {
+      "contactLinkHref": "https://signin.account.gov.uk/contact-us",
+      "contactLinkText": "Contact the GOV.UK account team (opens in a new tab)"
+    },
     "header": {
       "homepageHref": "https://www.gov.uk/"
     },
@@ -1704,8 +1708,8 @@
       }
     },
     "noPhotoId": {
-      "title": "No photo id",
-      "header": "Sorry, we cannot prove your identity",
+      "title": "You must have a photo ID to prove your identity this way",
+      "header": "You must have a photo ID to prove your identity this way",
       "section1": {
         "paragraph1": "You can currently only prove your identity with your GOV.UK account if you have a photo ID."
       },


### PR DESCRIPTION
## What?

Unhappy path content for the `no-photo-id` page (in English and Welsh) has been updated, and the `.njk` file has a single edit to use the correct json file key for the `h1` content on this page.

## Why?

Content designers are standardising the format of unhappy path pages throughout the journey

## Related PRs

[PYIC-2185](https://govukverify.atlassian.net/jira/software/c/projects/PYIC/boards/187?modal=detail&selectedIssue=PYIC-2185&assignee=6228bdb48a4bb60068f5b1d8)


[PYIC-2185]: https://govukverify.atlassian.net/browse/PYIC-2185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ