### PR TITLE
AUT-921: Add support form feature flag to build

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -5,7 +5,8 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
-support_language_cy = "1"
+support_language_cy        = "1"
+support_id_check_app_forms = "1"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"


### PR DESCRIPTION
## What?

Adds `support_id_check_app_forms = "1"` feature flag to Build

## Why?

The forms need to be available on Build for automated testing. 

## Related PRs

The PR that introduced the support forms is #869. A subsequent PR amended the Zendesk submission slightly #895
