### PR TITLE
ACI-138/AUT-292 -  Show correct error pages when user is forced to wait 15 mins due to OTP block 

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -193,4 +193,9 @@ export const IPV_ERROR_CODES = {
   IDENTITY_PROCESSING_TIMEOUT: "Identity check timeout",
 };
 
+export const LOCKED_COOKIE_OTP_VALUES = {
+  WRONG_CODE_USED_TOO_MANY_TIMES: "wrongCodeEnteredTooManyTimes",
+  CODE_REQUESTED_TOO_MANY_TIMES: "codeRequestedTooManyTimes",
+};
+
 export const COOKIES_PREFERENCES_SET = "cookies_preferences_set";

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -193,9 +193,4 @@ export const IPV_ERROR_CODES = {
   IDENTITY_PROCESSING_TIMEOUT: "Identity check timeout",
 };
 
-export const LOCKED_COOKIE_OTP_VALUES = {
-  WRONG_CODE_USED_TOO_MANY_TIMES: "wrongCodeEnteredTooManyTimes",
-  CODE_REQUESTED_TOO_MANY_TIMES: "codeRequestedTooManyTimes",
-};
-
 export const COOKIES_PREFERENCES_SET = "cookies_preferences_set";

--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -82,11 +82,6 @@ export const ERROR_CODE_MAPPING: { [p: string]: string } = {
     SECURITY_CODE_ERROR,
     SecurityCodeErrorType.EmailMaxCodesSent
   ),
-  [ERROR_CODES.VERIFY_PHONE_NUMBER_CODE_REQUEST_BLOCKED]: pathWithQueryParam(
-    PATH_NAMES["SECURITY_CODE_WAIT"],
-    SECURITY_CODE_ERROR,
-    SecurityCodeErrorType.OtpBlocked
-  ),
   [ERROR_CODES.ENTERED_INVALID_VERIFY_EMAIL_CODE_MAX_TIMES]: pathWithQueryParam(
     PATH_NAMES["SECURITY_CODE_INVALID"],
     SECURITY_CODE_ERROR,

--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -1,7 +1,7 @@
 import { PATH_NAMES } from "../../app.constants";
 import { getNextState } from "./state-machine/state-machine";
 
-const SECURITY_CODE_ERROR = "actionType";
+export const SECURITY_CODE_ERROR = "actionType";
 
 export enum SecurityCodeErrorType {
   MfaMaxCodesSent = "mfaMaxCodesSent",
@@ -120,11 +120,11 @@ export function getErrorPathByCode(errorCode: number): string | undefined {
   return nextPath;
 }
 
-function pathWithQueryParam(
+export function pathWithQueryParam(
   path: string,
   queryParam?: string,
   value?: string | SecurityCodeErrorType
-) {
+): string {
   if (queryParam && value) {
     const queryParams = new URLSearchParams({
       [queryParam]: value,

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -12,7 +12,7 @@ import {
   formatValidationError,
   renderBadRequest,
 } from "../../utils/validation";
-import { MFA_METHOD_TYPE } from "../../app.constants";
+import { MFA_METHOD_TYPE, PATH_NAMES } from "../../app.constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 
 const TEMPLATE_NAME = "enter-authenticator-app-code/index.njk";
@@ -21,7 +21,17 @@ export function enterAuthenticatorAppCodeGet(
   req: Request,
   res: Response
 ): void {
-  res.render(TEMPLATE_NAME);
+  if (
+    req.session.user.wrongCodeEnteredLock &&
+    new Date().toUTCString() < req.session.user.wrongCodeEnteredLock
+  ) {
+    res.render("security-code-error/index-security-code-entered-exceeded.njk", {
+      newCodeLink: PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
+      isAuthApp: true,
+    });
+  } else {
+    res.render(TEMPLATE_NAME);
+  }
 }
 
 export const enterAuthenticatorAppCodePost = (

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -3,15 +3,24 @@ import { ExpressRouteFunc } from "../../types";
 import { mfaService } from "../common/mfa/mfa-service";
 import { MfaServiceInterface } from "../common/mfa/types";
 import { sendMfaGeneric } from "../common/mfa/send-mfa-controller";
+import { PATH_NAMES } from "../../app.constants";
 
 export function resendMfaCodeGet(req: Request, res: Response): void {
-  const isStillLockedOutBy15MinOtpCodeBlockWindow = req.cookies?.re;
-
-  if (isStillLockedOutBy15MinOtpCodeBlockWindow) {
+  if (
+    req.session.user.wrongCodeEnteredLock &&
+    new Date().toUTCString() < req.session.user.wrongCodeEnteredLock
+  ) {
+    res.render("security-code-error/index-security-code-entered-exceeded.njk", {
+      newCodeLink: PATH_NAMES.RESEND_MFA_CODE,
+      isAuthApp: false,
+    });
+  } else if (
+    req.session.user.codeRequestLock &&
+    new Date().toUTCString() < req.session.user.codeRequestLock
+  ) {
     const newCodeLink = req.query?.isResendCodeRequest
       ? "/resend-code?isResendCodeRequest=true"
       : "/resend-code";
-
     res.render("security-code-error/index-wait.njk", {
       newCodeLink,
     });

--- a/src/components/security-code-error/index-security-code-entered-exceeded.njk
+++ b/src/components/security-code-error/index-security-code-entered-exceeded.njk
@@ -1,16 +1,29 @@
 {% extends "common/layout/base.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
-{% set pageTitleName = 'pages.securityCodeEnteredExceeded.title' | translate %}
+{% if isAuthApp %}
+    {% set pageTitleName = 'pages.securityCodeAuthAppEnteredExceeded.title' | translate %}
+{% else %}
+    {% set pageTitleName = 'pages.securityCodeEnteredExceeded.title' | translate %}
+{% endif %}
 
 {% block content %}
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeEnteredExceeded.header' | translate }}</h1>
-
-    <p class="govuk-body">{{'pages.securityCodeEnteredExceeded.info.paragraph1' | translate}}</p>
-    <p class="govuk-body">
-        {{'pages.securityCodeEnteredExceeded.info.paragraph2Start' | translate}}
-        <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeEnteredExceeded.info.link' | translate}}</a>
-        {{'pages.securityCodeEnteredExceeded.info.paragraph2End' | translate}}
-    </p>
+    {% if isAuthApp %}
+        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeAuthAppEnteredExceeded.header' | translate }}</h1>
+        <p class="govuk-body">{{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph1' | translate}}</p>
+        <p class="govuk-body">
+            {{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph2Start' | translate}}
+            <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeAuthAppEnteredExceeded.info.link' | translate}}</a>
+            {{'pages.securityCodeAuthAppEnteredExceeded.info.paragraph2End' | translate}}
+        </p>
+    {% else %}
+        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.securityCodeEnteredExceeded.header' | translate }}</h1>
+        <p class="govuk-body">{{'pages.securityCodeEnteredExceeded.info.paragraph1' | translate}}</p>
+        <p class="govuk-body">
+            {{'pages.securityCodeEnteredExceeded.info.paragraph2Start' | translate}}
+            <a class="govuk-link" rel="noreferrer" href="{{ newCodeLink }}">{{'pages.securityCodeEnteredExceeded.info.link' | translate}}</a>
+            {{'pages.securityCodeEnteredExceeded.info.paragraph2End' | translate}}
+        </p>
+    {% endif %}
 
 {% endblock %}

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from "express";
-import { SecurityCodeErrorType } from "../common/constants";
+import {
+  SecurityCodeErrorType,
+  pathWithQueryParam,
+  SECURITY_CODE_ERROR,
+} from "../common/constants";
 import { PATH_NAMES } from "../../app.constants";
 
 export function securityCodeInvalidGet(req: Request, res: Response): void {
@@ -15,7 +19,6 @@ export function securityCodeTriesExceededGet(
   res: Response
 ): void {
   res.cookie("re", "true", { maxAge: 15 * 60 * 1000, httpOnly: true });
-
   return res.render("security-code-error/index-too-many-requests.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
     isResendCodeRequest: req.query.isResendCodeRequest,
@@ -36,7 +39,10 @@ export function securityCodeEnteredExceededGet(
   res: Response
 ): void {
   res.render("security-code-error/index-security-code-entered-exceeded.njk", {
-    newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
+    newCodeLink: isAuthApp(req.query.actionType as SecurityCodeErrorType)
+      ? PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE
+      : PATH_NAMES.RESEND_MFA_CODE,
+    isAuthApp: isAuthApp(req.query.actionType as SecurityCodeErrorType),
   });
 }
 
@@ -46,7 +52,17 @@ function getNewCodePath(actionType: SecurityCodeErrorType) {
     case SecurityCodeErrorType.MfaBlocked:
       return PATH_NAMES.RESEND_MFA_CODE;
     case SecurityCodeErrorType.MfaMaxRetries:
-      return PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED;
+      return pathWithQueryParam(
+        PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED,
+        SECURITY_CODE_ERROR,
+        SecurityCodeErrorType.MfaMaxRetries
+      );
+    case SecurityCodeErrorType.AuthAppMfaMaxRetries:
+      return pathWithQueryParam(
+        PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED,
+        SECURITY_CODE_ERROR,
+        SecurityCodeErrorType.AuthAppMfaMaxRetries
+      );
     case SecurityCodeErrorType.OtpMaxCodesSent:
     case SecurityCodeErrorType.OtpBlocked:
     case SecurityCodeErrorType.OtpMaxRetries:
@@ -55,9 +71,11 @@ function getNewCodePath(actionType: SecurityCodeErrorType) {
     case SecurityCodeErrorType.EmailBlocked:
       return PATH_NAMES.SECURITY_CODE_CHECK_TIME_LIMIT;
     case SecurityCodeErrorType.EmailMaxRetries:
-      return PATH_NAMES.RESEND_EMAIL_CODE + "?requestNewCode=true";
-    case SecurityCodeErrorType.AuthAppMfaMaxRetries:
-      return PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE;
+      return pathWithQueryParam(
+        PATH_NAMES.RESEND_EMAIL_CODE,
+        "requestNewCode",
+        "true"
+      );
   }
 }
 

--- a/src/components/security-code-error/security-code-error-routes.ts
+++ b/src/components/security-code-error/security-code-error-routes.ts
@@ -1,6 +1,6 @@
 import { PATH_NAMES } from "../../app.constants";
 
-import * as express from "express";
+import express from "express";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import {
   securityCodeCannotRequestCodeGet,

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -17,13 +17,18 @@ import {
   RequestOutput,
   ResponseOutput,
 } from "mock-req-res";
+import { PATH_NAMES } from "../../../app.constants";
 
 describe("security code  controller", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
 
   beforeEach(() => {
-    req = mockRequest();
+    req = mockRequest({
+      path: PATH_NAMES.CREATE_ACCOUNT_SET_PASSWORD,
+      session: { client: {}, user: { featureFlags: {} } },
+      log: { info: sinon.fake() },
+    });
     res = mockResponse();
   });
 
@@ -33,6 +38,9 @@ describe("security code  controller", () => {
 
   describe("securityCodeExpiredGet", () => {
     it("should render security code expired view", () => {
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
       req.query.actionType = SecurityCodeErrorType.EmailMaxCodesSent;
 
       securityCodeInvalidGet(req as Request, res as Response);

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -66,13 +66,25 @@ describe("security code  controller", () => {
   });
 
   describe("securityCodeEnteredExceededGet", () => {
-    it("should render security code invalid request view", () => {
+    it("should render security code invalid request view when SMS code has been used max number of times", () => {
       req.query.actionType = SecurityCodeErrorType.MfaMaxRetries;
 
       securityCodeEnteredExceededGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
-        "security-code-error/index-security-code-entered-exceeded.njk"
+        "security-code-error/index-security-code-entered-exceeded.njk",
+        { newCodeLink: "/resend-code", isAuthApp: false }
+      );
+    });
+
+    it("should render security code invalid request view when Auth App code has been used max number of times", () => {
+      req.query.actionType = SecurityCodeErrorType.AuthAppMfaMaxRetries;
+
+      securityCodeEnteredExceededGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "security-code-error/index-security-code-entered-exceeded.njk",
+        { newCodeLink: "/enter-authenticator-app-code", isAuthApp: true }
       );
     });
   });

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -10,7 +10,11 @@ import {
   securityCodeTriesExceededGet,
   securityCodeEnteredExceededGet,
 } from "../security-code-error-controller";
-import { SecurityCodeErrorType } from "../../common/constants";
+import {
+  pathWithQueryParam,
+  SECURITY_CODE_ERROR,
+  SecurityCodeErrorType,
+} from "../../common/constants";
 import {
   mockRequest,
   mockResponse,
@@ -37,62 +41,185 @@ describe("security code  controller", () => {
   });
 
   describe("securityCodeExpiredGet", () => {
-    it("should render security code expired view", () => {
+    it("should render invalid OTP code for EmailMaxRetries error when email OTP code has been invalid max number of times", () => {
       req.session.user = {
         email: "joe.bloggs@test.com",
       };
-      req.query.actionType = SecurityCodeErrorType.EmailMaxCodesSent;
+      req.query.actionType = SecurityCodeErrorType.EmailMaxRetries;
 
       securityCodeInvalidGet(req as Request, res as Response);
 
-      expect(res.render).to.have.calledWith("security-code-error/index.njk");
+      expect(res.render).to.have.calledWith("security-code-error/index.njk", {
+        newCodeLink: pathWithQueryParam(
+          PATH_NAMES.RESEND_EMAIL_CODE,
+          "requestNewCode",
+          "true"
+        ),
+        isAuthApp: false,
+        isBlocked: false,
+      });
+    });
+
+    it("should render invalid OTP code for MfaMaxRetries error when email OTP code has been invalid max number of times", () => {
+      req.session.user = {
+        email: "joe.bloggs@test.com",
+      };
+      req.query.actionType = SecurityCodeErrorType.MfaMaxRetries;
+
+      securityCodeInvalidGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("security-code-error/index.njk", {
+        newCodeLink: pathWithQueryParam(
+          PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED,
+          SECURITY_CODE_ERROR,
+          SecurityCodeErrorType.MfaMaxRetries
+        ),
+        isAuthApp: false,
+        isBlocked: true,
+      });
+    });
+
+    it("should render invalid OTP code for AuthAppMfaMaxRetries error when email OTP code has been invalid max number of times", () => {
+      req.query.actionType = SecurityCodeErrorType.AuthAppMfaMaxRetries;
+
+      securityCodeInvalidGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("security-code-error/index.njk", {
+        newCodeLink: pathWithQueryParam(
+          PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED,
+          SECURITY_CODE_ERROR,
+          SecurityCodeErrorType.AuthAppMfaMaxRetries
+        ),
+        isAuthApp: true,
+        isBlocked: true,
+      });
+    });
+
+    it("should render invalid OTP code for OtpMaxRetries error when email OTP code has been invalid max number of times", () => {
+      req.query.actionType = SecurityCodeErrorType.OtpMaxRetries;
+
+      securityCodeInvalidGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith("security-code-error/index.njk", {
+        newCodeLink: PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
+        isAuthApp: false,
+        isBlocked: true,
+      });
     });
   });
 
   describe("securityCodeTriesExceededGet", () => {
-    it("should render security code requested too many times view", () => {
+    it("should render index-too-many-requests.njk for EmailMaxCodesSent when max number of codes have been sent", () => {
       req.query.actionType = SecurityCodeErrorType.EmailMaxCodesSent;
 
       securityCodeTriesExceededGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
-        "security-code-error/index-too-many-requests.njk"
+        "security-code-error/index-too-many-requests.njk",
+        {
+          newCodeLink: PATH_NAMES.SECURITY_CODE_CHECK_TIME_LIMIT,
+          isResendCodeRequest: undefined,
+        }
+      );
+    });
+
+    it("should render index-too-many-requests.njk for MfaMaxRetries when max number of codes have been sent", () => {
+      req.query.actionType = SecurityCodeErrorType.MfaMaxRetries;
+
+      securityCodeTriesExceededGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "security-code-error/index-too-many-requests.njk",
+        {
+          newCodeLink: pathWithQueryParam(
+            PATH_NAMES.SECURITY_CODE_ENTERED_EXCEEDED,
+            SECURITY_CODE_ERROR,
+            SecurityCodeErrorType.MfaMaxRetries
+          ),
+          isResendCodeRequest: undefined,
+        }
+      );
+    });
+
+    it("should render index-too-many-requests.njk for OtpMaxCodesSent when max number of codes have been sent", () => {
+      req.query.actionType = SecurityCodeErrorType.OtpMaxCodesSent;
+
+      securityCodeTriesExceededGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "security-code-error/index-too-many-requests.njk",
+        {
+          newCodeLink: PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
+          isResendCodeRequest: undefined,
+        }
       );
     });
   });
 
   describe("securityCodeCannotRequestGet", () => {
-    it("should render security code invalid request view", () => {
-      req.query.actionType = SecurityCodeErrorType.EmailMaxCodesSent;
+    it("should render index-too-many-requests.njk for OtpBlocked when user is blocked from requesting anymore OTPs", () => {
+      req.query.actionType = SecurityCodeErrorType.OtpBlocked;
 
       securityCodeCannotRequestCodeGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
-        "security-code-error/index-too-many-requests.njk"
+        "security-code-error/index-too-many-requests.njk",
+        {
+          newCodeLink: PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
+        }
+      );
+    });
+
+    it("should render index-too-many-requests.njk for MfaBlocked when user is blocked from requesting anymore OTPs", () => {
+      req.query.actionType = SecurityCodeErrorType.MfaBlocked;
+
+      securityCodeCannotRequestCodeGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "security-code-error/index-too-many-requests.njk",
+        {
+          newCodeLink: PATH_NAMES.RESEND_MFA_CODE,
+        }
+      );
+    });
+
+    it("should render index-too-many-requests.njk for MfaBlocked when user is blocked from requesting anymore OTPs", () => {
+      req.query.actionType = SecurityCodeErrorType.EmailBlocked;
+
+      securityCodeCannotRequestCodeGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "security-code-error/index-too-many-requests.njk",
+        {
+          newCodeLink: PATH_NAMES.SECURITY_CODE_CHECK_TIME_LIMIT,
+        }
       );
     });
   });
 
   describe("securityCodeEnteredExceededGet", () => {
-    it("should render security code invalid request view when SMS code has been used max number of times", () => {
+    it("should render index-security-code-entered-exceeded.njk when SMS code has been used max number of times", () => {
       req.query.actionType = SecurityCodeErrorType.MfaMaxRetries;
 
       securityCodeEnteredExceededGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
         "security-code-error/index-security-code-entered-exceeded.njk",
-        { newCodeLink: "/resend-code", isAuthApp: false }
+        { newCodeLink: PATH_NAMES.RESEND_MFA_CODE, isAuthApp: false }
       );
     });
 
-    it("should render security code invalid request view when Auth App code has been used max number of times", () => {
+    it("should render index-security-code-entered-exceeded.njk when Auth App code has been used max number of times", () => {
       req.query.actionType = SecurityCodeErrorType.AuthAppMfaMaxRetries;
 
       securityCodeEnteredExceededGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith(
         "security-code-error/index-security-code-entered-exceeded.njk",
-        { newCodeLink: "/enter-authenticator-app-code", isAuthApp: true }
+        {
+          newCodeLink: PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE,
+          isAuthApp: true,
+        }
       );
     });
   });

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1713,6 +1713,16 @@
         "paragraph2End": " ar ôl 15 munud."
       }
     },
+    "securityCodeAuthAppEnteredExceeded": {
+      "title": "Ni allwch roi cod diogelwch ar hyn o bryd ",
+      "header": "Ni allwch roi cod diogelwch ar hyn o bryd ",
+      "info": {
+        "paragraph1": "Mae hyn oherwydd eich bod wedi rhoi y cod diogelwch gormod o weithau.",
+        "paragraph2Start": "Gallwch ",
+        "link": "roi cynnig arall",
+        "paragraph2End": " ar ôl 15 munud."
+      }
+    },
     "signInRetryBlocked": {
       "title": "Mae eich cyfrif wedi’i gloi",
       "header": "Mae eich cyfrif wedi’i gloi",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1725,6 +1725,16 @@
         "paragraph2End": " after 15 minutes."
       }
     },
+    "securityCodeAuthAppEnteredExceeded": {
+      "title": "You cannot enter a security code at the moment ",
+      "header": "You cannot enter a security code at the moment ",
+      "info": {
+        "paragraph1": "This is because you entered the wrong security code too many times.",
+        "paragraph2Start": "You can ",
+        "link": "try again",
+        "paragraph2End": " after 15 minutes."
+      }
+    },
     "signInRetryBlocked": {
       "title": "Your account is locked",
       "header": "Your account is locked",

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,8 @@ export interface UserSession {
   authAppQrCodeUrl?: string;
   isPasswordChangeRequired?: boolean;
   featureFlags?: any;
+  wrongCodeEnteredLock?: string;
+  codeRequestLock?: string;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What?

- Allow user to request a new MFA OTP when the 15 minute period has elapsed
- Enforce a 15 minute block period when a user enters the auth app OTP incorrectly a max number of times 
- Add additonal test coverage

## Why?

- When a user enters 6 invalid codes on the auth app enter otp they are taken to the 'You entered the wrong security code too many times', when they select try again they are taken to the Enter the 6 digit security code shown in your authenticator app' Fix that so the try again link takes them to the 'You cannot enter a security code at the moment' screen
- Remove the cookie and set the invalid expiry on the session. This will stop impacting users logging into a different GOV.UK account within the same session.