### PR TITLE
AUT-921: Add new Zendesk identifier tag

### DIFF
--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -10,6 +10,14 @@ import {
 import { defaultZendeskClient } from "../../utils/zendesk";
 import { getZendeskGroupIdPublic } from "../../config";
 import { CreateTicketPayload, ZendeskInterface } from "../../utils/types";
+import { ZENDESK_THEMES } from "../../app.constants";
+
+export function getZendeskIdentifierTag(theme: string): string {
+  if (theme === ZENDESK_THEMES.ID_CHECK_APP) {
+    return "sign_in_app";
+  }
+  return "govuk_sign_in";
+}
 
 export function contactUsService(
   zendeskClient: ZendeskInterface = defaultZendeskClient
@@ -31,7 +39,10 @@ export function contactUsService(
           ),
         },
         group_id: getZendeskGroupIdPublic(),
-        tags: ["govuk_sign_in", ...prefixThemeTags(contactForm.themes)],
+        tags: [
+          getZendeskIdentifierTag(contactForm.themes.theme),
+          ...prefixThemeTags(contactForm.themes),
+        ],
       },
     };
 

--- a/src/components/contact-us/tests/contact-us-service.test.ts
+++ b/src/components/contact-us/tests/contact-us-service.test.ts
@@ -1,0 +1,21 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { ZENDESK_THEMES } from "../../../app.constants";
+import { getZendeskIdentifierTag } from "../contact-us-service";
+
+describe("contact-us-service", () => {
+  describe("getZendeskIdentifierTag", () => {
+    it("should return 'sign_in_app' when passed the ID_CHECK_APP theme", () => {
+      expect(getZendeskIdentifierTag(ZENDESK_THEMES.ID_CHECK_APP)).to.equal(
+        "sign_in_app"
+      );
+    });
+    for (const theme in ZENDESK_THEMES) {
+      it(`should return 'govuk_sign_in' when passed ${theme}`, () => {
+        if (theme !== ZENDESK_THEMES.ID_CHECK_APP) {
+          expect(getZendeskIdentifierTag(theme)).to.equal("govuk_sign_in");
+        }
+      });
+    }
+  });
+});


### PR DESCRIPTION
## What?

Add new `sign_in_app` Zendesk tag that will be sent in place of`govuk_sign_in` where support requests relate to the ID Check app. 

## Why?

This tag was requested by the Support Team during the demo of new ID Check app support forms. It will allow them to differentiate and change the routing of requests that relate to the GOV.UK ID Check app.

## Related PRs

* #869 Introduced the ID Check app support forms
* #895 Tweaked the Zendesk submission in response to a feedback from the Support Team
* #896 Added the feature flag to build
