### PR TITLE
ACI-16-18: Create new T&Cs rejected page for non-service and refactor mandatory services page

### DIFF
--- a/src/components/updated-terms-conditions/index-mandatory.njk
+++ b/src/components/updated-terms-conditions/index-mandatory.njk
@@ -32,33 +32,10 @@
         "value": "accept"
     }) }}
 
-    <br />
-
-    <p class="govuk-body govuk-white-text">
-        {{ 'pages.updatedTermsAndCondsMandatory.section2.paragraph1' | translate }}
-        {{ govukButton({
-            "text": 'pages.updatedTermsAndCondsMandatory.section2.govUkHomePageText' | translate,
-            "type": "Submit",
-            "preventDoubleClick": true,
-            classes: 'govuk-btn-link',
-            "name": "termsAndConditionsResult",
-            "value": "govUk"
-        }) }}
-    </p>
-
-    <p class="govuk-body govuk-white-text">
-        {{ 'pages.updatedTermsAndCondsMandatory.section2.paragraph2' | translate }}
-        {{ govukButton({
-            "text": 'pages.updatedTermsAndCondsMandatory.section2.contactUsText' | translate,
-            "type": "Submit",
-            "preventDoubleClick": true,
-            classes: 'govuk-btn-link',
-            "name": "termsAndConditionsResult",
-            "value": "contactUs"
-        }) }}
-    </p>
-
-
-
 </form>
+
+<a href={{ redirectUri }} class="govuk-white-link inverted-button-link govuk-body">
+    {{ 'pages.updatedTermsAndCondsMandatory.goBackToService' | translate }}
+</a>
+
 {% endblock %}

--- a/src/components/updated-terms-conditions/index-non-service-rejected.njk
+++ b/src/components/updated-terms-conditions/index-non-service-rejected.njk
@@ -1,0 +1,48 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% set pageTitleName = 'pages.updatedTermsAndCondsNonServiceRejected.title' | translate %}
+{% set rowClasses = 'interrupt-screen' %}
+{% block content %}
+
+<h1 class="govuk-white-text govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.updatedTermsAndCondsNonServiceRejected.header' | translate}}</h1>
+
+<p class="govuk-body govuk-white-text">
+     {{ 'pages.updatedTermsAndCondsNonServiceRejected.info.text' | translate }}
+        <a class="govuk-white-text"
+           href="/terms-and-conditions">{{ 'pages.updatedTermsAndCondsNonServiceRejected.info.termsAndConditionsText' | translate }}</a>,
+        <a class="govuk-white-text"
+           href="/privacy-notice">{{ 'pages.updatedTermsAndCondsNonServiceRejected.info.privacyNoticeText' | translate }}</a>
+        {{ 'pages.updatedTermsAndCondsNonServiceRejected.info.and' | translate }}
+        <a class="govuk-white-text"
+           href="https://www.gov.uk/help/cookies">{{ 'pages.updatedTermsAndCondsNonServiceRejected.info.cookiesPolicyText' | translate }}</a>
+           {{ 'pages.updatedTermsAndCondsNonServiceRejected.info.end' | translate }}
+</p>
+
+<form id="form-tracking"  action="/updated-terms-and-conditions" method="post" novalidate>
+
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+    {{ govukButton({
+        "text": 'pages.updatedTermsAndCondsNonServiceRejected.agreeAndContinue' | translate,
+        "type": "Submit",
+        "preventDoubleClick": true,
+        classes: 'govuk-blue-text govuk-white-button inverted-button',
+        "name": "termsAndConditionsResult",
+        "value": "accept"
+    }) }}
+
+    <p class="govuk-body govuk-white-text">
+        {{ 'pages.updatedTermsAndCondsNonServiceRejected.section2.paragraph1' | translate }}
+        <a class="govuk-white-text"
+           href="https://www.gov.uk">{{ 'pages.updatedTermsAndCondsNonServiceRejected.section2.govUkHomePageText' | translate }}</a>
+    </p>
+
+    <p class="govuk-body govuk-white-text">
+        {{ 'pages.updatedTermsAndCondsNonServiceRejected.section2.paragraph2' | translate }}
+        <a class="govuk-white-text"
+                   href="/contact-us">{{ 'pages.updatedTermsAndCondsNonServiceRejected.section2.contactUsText' | translate }}</a>
+    </p>
+
+</form>
+{% endblock %}

--- a/src/components/updated-terms-conditions/tests/updated-terms-conditions.test.ts
+++ b/src/components/updated-terms-conditions/tests/updated-terms-conditions.test.ts
@@ -6,10 +6,15 @@ import { Request, Response } from "express";
 import {
   updatedTermsConditionsGet,
   updatedTermsConditionsPost,
+  updatedTermsRejectedGet,
 } from "../updated-terms-conditions-controller";
 
 import { UpdateProfileServiceInterface } from "../../common/update-profile/types";
-import { EXTERNAL_LINKS, PATH_NAMES } from "../../../app.constants";
+import {
+  EXTERNAL_LINKS,
+  PATH_NAMES,
+  SERVICE_TYPE,
+} from "../../../app.constants";
 import {
   mockRequest,
   mockResponse,
@@ -137,6 +142,43 @@ describe("updated terms conditions controller", () => {
       expect(fakeService.updateProfile).not.to.been.called;
       expect(res.redirect).to.have.calledWith(
         `${PATH_NAMES.CONTACT_US}?supportType=PUBLIC`
+      );
+    });
+  });
+
+  describe("updatedTermsRejectedGet", () => {
+    it("should redirect to optional service reject page when service type is Optional", async () => {
+      req.session.client.serviceType = SERVICE_TYPE.OPTIONAL;
+      req.session.client.name = "client name";
+      req.session.client.redirectUri = "redirect uri";
+
+      await updatedTermsRejectedGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "updated-terms-conditions/index-optional.njk"
+      );
+    });
+
+    it("should redirect to mandatory service reject page when service type is Mandatory", async () => {
+      req.session.client.serviceType = SERVICE_TYPE.MANDATORY;
+      req.session.client.name = "client name";
+      req.session.client.redirectUri = "redirect uri";
+
+      await updatedTermsRejectedGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "updated-terms-conditions/index-mandatory.njk"
+      );
+    });
+
+    it("should redirect to non-service reject page when service type is not set", async () => {
+      req.session.client.name = "client name";
+      req.session.client.redirectUri = "redirect uri";
+
+      await updatedTermsRejectedGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "updated-terms-conditions/index-non-service-rejected.njk"
       );
     });
   });

--- a/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
+++ b/src/components/updated-terms-conditions/updated-terms-conditions-controller.ts
@@ -15,10 +15,15 @@ export function updatedTermsConditionsGet(req: Request, res: Response): void {
 }
 
 export function updatedTermsRejectedGet(req: Request, res: Response): void {
-  const view =
-    req.session.client.serviceType === SERVICE_TYPE.OPTIONAL
-      ? "index-optional.njk"
-      : "index-mandatory.njk";
+  let view: string;
+
+  if (req.session.client.serviceType === SERVICE_TYPE.OPTIONAL) {
+    view = "index-optional.njk";
+  } else if (req.session.client.serviceType === SERVICE_TYPE.MANDATORY) {
+    view = "index-mandatory.njk";
+  } else {
+    view = "index-non-service-rejected.njk";
+  }
 
   return res.render("updated-terms-conditions/" + view, {
     clientName: req.session.client.name,

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -544,6 +544,28 @@
       "doNotAgree": "Nid wyf yn cytuno"
     },
     "updatedTermsAndCondsMandatory": {
+      "title": "Cytuno i’r telerau defnydd diwygiedig i barhau",
+      "header": "Cytuno i’r telerau defnydd diwygiedig i barhau",
+      "info": {
+        "text": "Mae angen i chi gytuno i’n",
+        "and": "a",
+        "termsAndConditionsText": "telerau ac amodau",
+        "privacyNoticeText": "hysbysiad preifatrwydd",
+        "cookiesPolicyText": "polisi cwcis",
+        "end": "diwygiedig i ddefnyddio’r gwasanaeth hwn."
+      },
+      "agreeAndContinue": "Cytuno a pharhau",
+      "goBackToService": "Ewch yn ôl i’r gwasanaeth roeddech yn ei ddefnyddio."
+    },
+    "updatedTermsAndCondsOptional": {
+      "title": "Mae angen i chi gytuno i’r telerau defnydd diwygiedig i arbed eich cynnydd",
+      "header": "Mae angen i chi gytuno i’r telerau defnydd diwygiedig i arbed eich cynnydd",
+      "paragraph1": "Os nad ydych yn cytuno, gallwch ",
+      "paragraph1Continued": "barhau heb arbed eich cynnydd.",
+      "agreeToTheTerms": "Cytuno i’r telerau",
+      "continueWithoutSaving": "Parhau heb arbed"
+    },
+    "updatedTermsAndCondsNonServiceRejected": {
       "title": "Cytuno i’r telerau defnydd wedi’u diweddaru i fynd yn eich blaen",
       "header": "Cytuno i’r telerau defnydd wedi’u diweddaru i fynd yn eich blaen",
       "info": {
@@ -560,16 +582,7 @@
         "paragraph2": "Os nad ydych angen eich cyfrif mwyach, neu os ydych am ddileu gwybodaeth sydd wedi’i arbed yn eich cyfrif, gallwch ",
         "contactUsText": "gysylltu â ni."
       },
-      "agreeAndContinue": "Cytuno a pharhau",
-      "goBackToService": "Ewch yn ôl i "
-    },
-    "updatedTermsAndCondsOptional": {
-      "title": "Mae angen i chi gytuno i’r telerau defnydd diwygiedig i arbed eich cynnydd",
-      "header": "Mae angen i chi gytuno i’r telerau defnydd diwygiedig i arbed eich cynnydd",
-      "paragraph1": "Os nad ydych yn cytuno, gallwch ",
-      "paragraph1Continued": "barhau heb arbed eich cynnydd.",
-      "agreeToTheTerms": "Cytuno i’r telerau",
-      "continueWithoutSaving": "Parhau heb arbed"
+      "agreeAndContinue": "Cytuno a pharhau"
     },
     "cookiePolicy": {
       "title": "Polisi cwcis cyfrifon GOV.UK",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -552,16 +552,10 @@
         "termsAndConditionsText": "terms and conditions",
         "privacyNoticeText": "privacy notice",
         "cookiesPolicyText": "cookies policy",
-        "end": "to keep using your account."
-      },
-      "section2": {
-        "paragraph1": "If you do not agree to the new terms, you cannot use your GOV.UK account.",
-        "govUkHomePageText": "Go to the GOV.UK homepage.",
-        "paragraph2": "If you no longer need your account, or want to delete information saved in your account, you can ",
-        "contactUsText": "contact us."
+        "end": "to use this service."
       },
       "agreeAndContinue": "Agree and continue",
-      "goBackToService": "Go back to "
+      "goBackToService": "Go back to the service your were using."
     },
     "updatedTermsAndCondsOptional": {
       "title": "You need to agree to the updated terms of use to save your progress",
@@ -570,6 +564,25 @@
       "paragraph1Continued": "continue without saving your progress.",
       "agreeToTheTerms": "Agree to the terms",
       "continueWithoutSaving": "Continue without saving"
+    },
+    "updatedTermsAndCondsNonServiceRejected": {
+      "title": "Agree to the updated terms of use to continue",
+      "header": "Agree to the updated terms of use to continue",
+      "info": {
+        "text": "You need to agree to our updated",
+        "and": "and",
+        "termsAndConditionsText": "terms and conditions",
+        "privacyNoticeText": "privacy notice",
+        "cookiesPolicyText": "cookies policy",
+        "end": "to keep using your account."
+      },
+      "section2": {
+        "paragraph1": "If you do not agree to the new terms, you cannot use your GOV.UK account.",
+        "govUkHomePageText": "Go to the GOV.UK homepage.",
+        "paragraph2": "If you no longer need your account, or want to delete information saved in your account, you can ",
+        "contactUsText": "contact us."
+      },
+      "agreeAndContinue": "Agree and continue"
     },
     "cookiePolicy": {
       "title": "GOV.UK accounts cookies policy",


### PR DESCRIPTION
## What?

Create new T&Cs rejected page for non-service scenarios and refactor content for mandatory services T&Cs page
- Three possible outcomes to determin which view is displayed:
- `index-mandatory.njk` for Mandatory services
- `index-optional.njk` for optional services
- `index-non-service-rejected.njk` for non service scenarios
- The view is determined by the client service type via `req.session.client.serviceType`

## Why?

So as to align the current page with the page on [Figma](https://www.figma.com/file/aVqNC4pKaebZchIU691f31/DI-Authentication?node-id=14739%3A60383&t=cWhR2MNCoQvxKw43-0)

## Related PRs

[Change for optional services](https://github.com/alphagov/di-authentication-frontend/pull/891)
