### PR TITLE
ACI-144 - Update cookie links to point to GOV.UK accounts cookie policy 

### DIFF
--- a/src/components/common/footer/terms-conditions.njk
+++ b/src/components/common/footer/terms-conditions.njk
@@ -20,7 +20,7 @@
       {{'pages.termsAndConditions.section1.paragraph3.linkText1' | translate}}
     </a>
     {{'pages.termsAndConditions.section1.paragraph3.text2' | translate}}
-    <a href="https://www.gov.uk/help/cookies" class="govuk-link">{{'pages.termsAndConditions.section1.paragraph3.linkText2' | translate}}</a>
+    <a href="/cookies" class="govuk-link">{{'pages.termsAndConditions.section1.paragraph3.linkText2' | translate}}</a>
     {{'pages.termsAndConditions.section1.paragraph3.text3' | translate}}
   </p>
   <p class="govuk-body">{{'pages.termsAndConditions.section1.paragraph4' | translate}}</p>

--- a/src/components/common/layout/banner.njk
+++ b/src/components/common/layout/banner.njk
@@ -4,11 +4,11 @@
 {% endset %}
 
 {% set acceptHtml %}
-  <p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="https://www.gov.uk/help/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph2' | translate }}</p>
+  <p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph1' | translate }}<a class="govuk-link" href="/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'general.cookie.cookieBanner.cookeBannerAccept.paragraph2' | translate }}</p>
 {% endset %}
 
 {% set rejectedHtml %}
-  <p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph1' | translate }}<a class="govuk-link" href="https://www.gov.uk/help/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph2' | translate }}</p>
+  <p class="govuk-body">{{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph1' | translate }}<a class="govuk-link" href="/cookies">{{ 'general.cookie.cookieBanner.changeCookiePreferencesLink' | translate }}</a> {{ 'general.cookie.cookieBanner.cookeBannerReject.paragraph2' | translate }}</p>
 {% endset %}
 
 {{ govukCookieBanner({

--- a/src/components/updated-terms-conditions/index-mandatory.njk
+++ b/src/components/updated-terms-conditions/index-mandatory.njk
@@ -15,7 +15,7 @@
            href="/privacy-notice">{{ 'pages.updatedTermsAndCondsMandatory.info.privacyNoticeText' | translate }}</a>
         {{ 'pages.updatedTermsAndCondsMandatory.info.and' | translate }}
         <a class="govuk-white-text"
-           href="https://www.gov.uk/help/cookies">{{ 'pages.updatedTermsAndCondsMandatory.info.cookiesPolicyText' | translate }}</a>
+           href="/cookies">{{ 'pages.updatedTermsAndCondsMandatory.info.cookiesPolicyText' | translate }}</a>
            {{ 'pages.updatedTermsAndCondsMandatory.info.end' | translate }}
 </p>
 

--- a/src/components/updated-terms-conditions/index-non-service-rejected.njk
+++ b/src/components/updated-terms-conditions/index-non-service-rejected.njk
@@ -15,7 +15,7 @@
            href="/privacy-notice">{{ 'pages.updatedTermsAndCondsNonServiceRejected.info.privacyNoticeText' | translate }}</a>
         {{ 'pages.updatedTermsAndCondsNonServiceRejected.info.and' | translate }}
         <a class="govuk-white-text"
-           href="https://www.gov.uk/help/cookies">{{ 'pages.updatedTermsAndCondsNonServiceRejected.info.cookiesPolicyText' | translate }}</a>
+           href="/cookies">{{ 'pages.updatedTermsAndCondsNonServiceRejected.info.cookiesPolicyText' | translate }}</a>
            {{ 'pages.updatedTermsAndCondsNonServiceRejected.info.end' | translate }}
 </p>
 

--- a/src/components/updated-terms-conditions/index.njk
+++ b/src/components/updated-terms-conditions/index.njk
@@ -15,7 +15,7 @@
        href="{{ 'pages.updatedTermsAndConds.paragraph1.privacyNoticeHref' | translate }}">{{ 'pages.updatedTermsAndConds.paragraph1.privacyNoticeText' | translate }}</a>
     {{ 'pages.updatedTermsAndConds.paragraph1.and' | translate }}
     <a class="govuk-white-text"
-       href="https://www.gov.uk/help/cookies">{{ 'pages.updatedTermsAndConds.paragraph1.cookiesPolicyText' | translate }}</a>.
+       href="/cookies">{{ 'pages.updatedTermsAndConds.paragraph1.cookiesPolicyText' | translate }}</a>.
 </p>
 <p class="govuk-body govuk-white-text">{{ 'pages.updatedTermsAndConds.paragraph2' | translate }}</p>
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -820,7 +820,7 @@
           "text1": "Darllenwch y telerau ac amodau hyn, yr ",
           "linkText1": "hysbysiad preifatrwydd cyfrifon GOV.UK",
           "text2": " a ",
-          "linkText2": "pholisi cwcis GOV.UK",
+          "linkText2": "Polisi cwcis cyfrifon GOV.UK",
           "text3": "cyn defnyddio’r cyfrif GOV.UK. Mae’r hysbysiad preifatrwydd yn egluro’r telerau rydym yn prosesu unrhyw ddata personol y byddwn yn ei gasglu gennych neu eich bod yn ei ddarparu i ni. Mae’r polisi cwcis yn rhoi gwybodaeth am y cwcis rydym yn eu defnyddio a sut rydym yn eu defnyddio pan rydych yn defnyddio GOV.UK neu eich cyfrif GOV.UK."
         },
         "paragraph4": "Drwy gofrestru ar gyfer a pharhau i ddefnyddio cyfrif GOV.UK, rydych yn cytuno i’r telerau ac amodau hyn, yr hysbysiad preifatrwydd a’r polisi cwcis.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -821,7 +821,7 @@
           "text1": "Please read these terms and conditions, the ",
           "linkText1": "GOV.UK accounts privacy notice",
           "text2": " and the ",
-          "linkText2": "GOV.UK cookies policy",
+          "linkText2": "GOV.UK accounts cookies policy",
           "text3": "before using the GOV.UK account. The privacy notice explains the terms on which we process any personal data we collect from you or that you provide to us. The cookie policy gives information about the cookies we use and how we use them when you use GOV.UK or your GOV.UK account."
         },
         "paragraph4": "By registering for and continuing to use a GOV.UK account, you agree to these terms and conditions, the privacy notice and cookies policy.",


### PR DESCRIPTION
## What?

- Link to Accounts cookie policy rather than the GOV.UK cookie policy from the rejected terms and conditions screens
-  Update the cookie policy link and text in the terms and conditions
- Update cookie banner to link to correct cookie's policy

## Why?

- We have a different cookie policy to GOV.UK and it is the GOV.UK accounts cookie policy that we should be linking to in these scenarios 