### PR TITLE
AUT-955: Align frontend staging sizing with production.

### DIFF
--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -4,6 +4,8 @@ common_state_bucket = "di-auth-staging-tfstate"
 frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
+frontend_auto_scaling_min_count = 4
+frontend_auto_scaling_max_count = 12
 
 support_language_cy = "1"
 


### PR DESCRIPTION

## What?

Align frontend staging sizing with production.

## Why?

Staging will be used for performance testing so should match production sizing.
