### PR TITLE
AUT-955: Align staging frontend redis sizing with production for performance testing

### DIFF
--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -1,5 +1,6 @@
 environment         = "staging"
 common_state_bucket = "di-auth-staging-tfstate"
+redis_node_size     = "cache.m4.xlarge"
 
 frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512


### PR DESCRIPTION
## What?

Align staging frontend redis sizing with production for performance testing.

## Why?

Staging will be used for performance testing so should match production sizing.

## Related PRs

#903 
