### PR TITLE
ACI-140: Redirect user to correct screen after OTP has been entered 5+times

### DIFF
--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -4,14 +4,22 @@ import { mfaService } from "../common/mfa/mfa-service";
 import { MfaServiceInterface } from "../common/mfa/types";
 import { sendMfaGeneric } from "../common/mfa/send-mfa-controller";
 import { PATH_NAMES } from "../../app.constants";
+import { pathWithQueryParam } from "../common/constants";
 
 export function resendMfaCodeGet(req: Request, res: Response): void {
   if (
     req.session.user.wrongCodeEnteredLock &&
     new Date().toUTCString() < req.session.user.wrongCodeEnteredLock
   ) {
+    const newCodeLink = req.query?.isResendCodeRequest
+      ? pathWithQueryParam(
+          PATH_NAMES.RESEND_MFA_CODE,
+          "isResendCodeRequest",
+          "true"
+        )
+      : PATH_NAMES.RESEND_MFA_CODE;
     res.render("security-code-error/index-security-code-entered-exceeded.njk", {
-      newCodeLink: PATH_NAMES.RESEND_MFA_CODE,
+      newCodeLink: newCodeLink,
       isAuthApp: false,
     });
   } else if (

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -14,7 +14,7 @@ export function securityCodeInvalidGet(req: Request, res: Response): void {
       Date.now() + 15 * 60000
     ).toUTCString();
   }
-  res.render("security-code-error/index.njk", {
+  return res.render("security-code-error/index.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
     isAuthApp: isAuthApp(req.query.actionType as SecurityCodeErrorType),
     isBlocked: isNotEmailCode,
@@ -74,8 +74,13 @@ function getNewCodePath(actionType: SecurityCodeErrorType) {
       );
     case SecurityCodeErrorType.OtpMaxCodesSent:
     case SecurityCodeErrorType.OtpBlocked:
-    case SecurityCodeErrorType.OtpMaxRetries:
       return PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER;
+    case SecurityCodeErrorType.OtpMaxRetries:
+      return pathWithQueryParam(
+        PATH_NAMES.RESEND_MFA_CODE,
+        "isResendCodeRequest",
+        "true"
+      );
     case SecurityCodeErrorType.EmailMaxCodesSent:
     case SecurityCodeErrorType.EmailBlocked:
       return PATH_NAMES.SECURITY_CODE_CHECK_TIME_LIMIT;

--- a/src/components/security-code-error/tests/security-code-error-controller.test.ts
+++ b/src/components/security-code-error/tests/security-code-error-controller.test.ts
@@ -101,7 +101,11 @@ describe("security code  controller", () => {
       securityCodeInvalidGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("security-code-error/index.njk", {
-        newCodeLink: PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
+        newCodeLink: pathWithQueryParam(
+          PATH_NAMES.RESEND_MFA_CODE,
+          "isResendCodeRequest",
+          "true"
+        ),
         isAuthApp: false,
         isBlocked: true,
       });


### PR DESCRIPTION
## What?

Block user from accessing enter-code page before the 15 mins code lock as elapsed

- Refactor `newCodeLink` to redirect the user to `render-mfa-code` page instead of `enter-phone-number` page via `SecurityCodeErrorType.OtpMaxRetries`

## Why?

To fix Phone OTP bug when a user is creating their One Login account and they enter their OTP more than 5+ times incorrectly
