### PR TITLE
AUT-956: Addition of and amendments to existing "What service were you trying to use?" fields

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -290,6 +290,9 @@ export function getQuestionsFromFormType(
       additionalDescription: req.t(
         "pages.contactUsQuestions.provingIdentity.section2.header"
       ),
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header"
+      ),
     },
     idCheckApp: {
       issueDescription: `${req.t(

--- a/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
@@ -13,12 +13,12 @@
 
     {% include 'contact-us/questions/_what_happened.njk' %}
 
+    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
+
     {{ govukWarningText({
         text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
         iconFallbackText: "Warning"
     }) }}
-
-    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 

--- a/src/components/contact-us/questions/_id-check-app-linking-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-linking-problem.njk
@@ -13,12 +13,12 @@
 
 {% include 'contact-us/questions/_what_happened.njk' %}
 
+{% include 'contact-us/questions/_service_trying_to_use.njk' %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
     iconFallbackText: "Warning"
 }) }}
-
-{% include 'contact-us/questions/_service_trying_to_use.njk' %}
 
 {% include 'contact-us/questions/_reply_by_email.njk' %}
 

--- a/src/components/contact-us/questions/_id-check-app-something-else.njk
+++ b/src/components/contact-us/questions/_id-check-app-something-else.njk
@@ -42,12 +42,12 @@
         } if (errors['additionalDescription'])
     }) }}
 
+    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
+
     {{ govukWarningText({
         text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
         iconFallbackText: "Warning"
     }) }}
-
-    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 

--- a/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
@@ -13,12 +13,12 @@
 
     {% include 'contact-us/questions/_what_happened.njk' %}
 
+    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
+
     {{ govukWarningText({
         text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
         iconFallbackText: "Warning"
     }) }}
-
-    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 

--- a/src/components/contact-us/questions/_id-check-app-technical-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-technical-problem.njk
@@ -42,12 +42,12 @@
         } if (errors['additionalDescription'])
     }) }}
 
+    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
+
     {{ govukWarningText({
         text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
         iconFallbackText: "Warning"
     }) }}
-
-    {% include 'contact-us/questions/_service_trying_to_use.njk' %}
 
     {% include 'contact-us/questions/_reply_by_email.njk' %}
 

--- a/src/components/contact-us/questions/_proving-identity-problem-questions.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-questions.njk
@@ -41,6 +41,8 @@
     } if (errors['additionalDescription'])
 }) }}
 
+{% include 'contact-us/questions/_service_trying_to_use.njk' %}
+
 {{ govukWarningText({
     text:'pages.contactUsQuestions.personalInformation.paragraph1' | translateEnOnly,
     iconFallbackText: "Warning"


### PR DESCRIPTION
## What?

This PR does two things: 

1. Adds a new "What service were you trying to use?" field to the "Problem proving your identity" support form 
2. Changes the placement of existing "What service were you trying to use?" fields within other support forms so that they appear above the warning text (as requested by Interaction Design). 

The existing forms that have been rearranged in this way are:
- "You had a technical problem" (under the ID Check App)
- "You had a problem scanning your face using the GOV.UK ID Check app"
- "You had a problem linking the app to your web browser" (under the ID Check App)
- "Something else" (under the ID Check App)
- "You had a problem taking a photo of your identity document" (under the ID Check App)

## Why?

The additional field added in (1) is needed by the support team. The rearrangement of fields in (2) has been requested by Interaction Design.

## Visual changes
Screenshots below show how the pages appear _after_ the changes.

### "Problem proving your identity" support form 
<img width="706" alt="Screenshot 2023-01-24 at 12 52 46" src="https://user-images.githubusercontent.com/16000203/214296602-f4ff4eb9-ba18-4e08-b6c2-8630c18e14a7.png">


### "You had a technical problem" (under the ID Check App)
<img width="705" alt="Screenshot 2023-01-24 at 12 53 47" src="https://user-images.githubusercontent.com/16000203/214296774-23c557d4-e6f0-4685-ba7b-6a19ac84a630.png">


### "You had a problem scanning your face using the GOV.UK ID Check app"
<img width="707" alt="Screenshot 2023-01-24 at 12 54 23" src="https://user-images.githubusercontent.com/16000203/214296915-82660075-dfde-4376-820e-7104d2f79a24.png">


### "You had a problem linking the app to your web browser" (under the ID Check App)
<img width="705" alt="Screenshot 2023-01-24 at 12 55 06" src="https://user-images.githubusercontent.com/16000203/214297054-454e2f7b-243a-49c9-83fe-4bf871c44624.png">


### "Something else" (under the ID Check App)
<img width="707" alt="Screenshot 2023-01-24 at 12 55 39" src="https://user-images.githubusercontent.com/16000203/214297194-2a68f391-6f6c-49f6-a07b-86b56be0fe2c.png">


### "You had a problem taking a photo of your identity document" (under the ID Check App)
<img width="704" alt="Screenshot 2023-01-24 at 12 56 25" src="https://user-images.githubusercontent.com/16000203/214297329-84949799-afe8-4366-80be-d27ef09551ee.png">


