### PR TITLE
AUT-1042: Remove dumb quotes

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -296,7 +296,7 @@
       "header": "Creu eich cyfrinair",
       "password": {
         "label": "Rhowch gyfrinair",
-        "hintText": "Mae'n rhaid iddo fod yn o leiaf 8 nod o hyd a rhaid cynnwys llythrennau a rhifau. Peidiwch defnyddio cyfrinair cyffredin iawn, fel ’password’ neu ddilyniant o rifau.",
+        "hintText": "Mae’n rhaid iddo fod yn o leiaf 8 nod o hyd a rhaid cynnwys llythrennau a rhifau. Peidiwch defnyddio cyfrinair cyffredin iawn, fel ’password’ neu ddilyniant o rifau.",
         "validationError": {
           "required": "Rhowch eich cyfrinair",
           "maxLength": "Mae’n rhaid i’ch cyfrinair fod yn llai na 256 nod",
@@ -1678,12 +1678,12 @@
         "paragraph2": "Os nad oes gennych ffôn clyfar neu lechen, chwiliwch ar-lein am ap dilysydd ar gyfer eich cyfrifiadur.",
         "paragraph3": "Gallwch ddefnyddio unrhyw ap dilysydd."
       },
-      "step2": "2. Defnyddiwch eich ap dilysydd i sganio'r cod QR.",
+      "step2": "2. Defnyddiwch eich ap dilysydd i sganio’r cod QR.",
       "cannotScanDetails": {
-        "summaryText": "Ni allaf sganio'r cod QR",
-        "paragraph1": "Gallwch roi yr allwedd gyfrinachol i'ch ap dilysydd yn lle hynny.",
+        "summaryText": "Ni allaf sganio’r cod QR",
+        "paragraph1": "Gallwch roi yr allwedd gyfrinachol i’ch ap dilysydd yn lle hynny.",
         "paragraph2": "Allwedd gyfrinachol: ",
-        "paragraph3": "Mae rhai apiau dilysydd yn galw'r allwedd gyfrinachol yn 'cod'."
+        "paragraph3": "Mae rhai apiau dilysydd yn galw’r allwedd gyfrinachol yn ‘cod’."
       },
       "step3": "3. Bydd yr ap dilysydd yn dangos cod diogelwch.",
       "step4": "4. Rhowch y cod diogelwch.",
@@ -1781,15 +1781,15 @@
       "header": "Creu eich cyfrinair",
       "password": {
         "label": "Rhowch gyfrinair",
-        "paragraph1": "Mae'n rhaid i'ch cyfrinair:",
+        "paragraph1": "Mae’n rhaid i’ch cyfrinair:",
         "bulletPoint1": "fod yn o leiaf 8 nod o hyd",
         "bulletPoint2": "cynnwys llythrennau a rhifau",
-        "paragraph2": "Peidiwch defnyddio cyfrinair cyffredin iawn, fel 'password' neu ddilyniant o rifau.",
+        "paragraph2": "Peidiwch defnyddio cyfrinair cyffredin iawn, fel ‘password’ neu ddilyniant o rifau.",
         "validationError": {
           "required": "Rhowch eich cyfrinair",
-          "maxLength": "Mae'n rhaid i'ch cyfrinair fod yn llai na 256 nod",
-          "commonPassword": "Rhowch gyfrinair cryfach. Peidiwch defnyddio cyfrineiriau cyffredin iawn, fel 'password' neu ddilyniant o rifau.",
-          "alphaNumeric": "Mae'n rhaid i'ch cyfrinair fod yn o leiaf 8 nod o hyd a rhaid iddo gynnwys llythrennau a rhifau"
+          "maxLength": "Mae’n rhaid i’ch cyfrinair fod yn llai na 256 nod",
+          "commonPassword": "Rhowch gyfrinair cryfach. Peidiwch defnyddio cyfrineiriau cyffredin iawn, fel ‘password’ neu ddilyniant o rifau.",
+          "alphaNumeric": "Mae’n rhaid i’ch cyfrinair fod yn o leiaf 8 nod o hyd a rhaid iddo gynnwys llythrennau a rhifau"
         }
       },
       "confirmPassword": {
@@ -1804,10 +1804,10 @@
         "text": "Ffordd dda o greu cyfrinair diogel a chofiadwy yw defnyddio 3 gair ar hap. Gallwch ddefnyddio rhifau, symbolau a gofodau."
       },
       "termsOfUse": {
-        "heading": "Cytuno i'n telerau defnyddio",
-        "paragraph1": "Drwy barhau, rydych yn cadarnhau eich bod yn cytuno i'n:",
+        "heading": "Cytuno i’n telerau defnyddio",
+        "paragraph1": "Drwy barhau, rydych yn cadarnhau eich bod yn cytuno i’n:",
         "bullet1LinkText": "hysbysiad preifatrwydd (agor mewn tab newydd)",
-        "bullet1Text": ", sy'n egluro sut rydym yn defnyddio eich gwybodaeth bersonol",
+        "bullet1Text": ", sy’n egluro sut rydym yn defnyddio eich gwybodaeth bersonol",
         "bullet1LinkHref": "/privacy-notice",
         "bullet2LinkText": "telerau ac amodau (agor mewn tab newydd)",
         "bullet2LinkHref": "/terms-and-conditions"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -162,7 +162,7 @@
         "listItem3": "LITE (Licensing for International Trade and Enterprise)",
         "listItem4": "Request a basic DBS check",
         "paragraph2": "GOV.UK accounts do not work with all government accounts and services yet (for example Government Gateway or Universal Credit).",
-        "paragraph3": "In the future, you'll be able to use your GOV.UK account to access all services on GOV.UK."
+        "paragraph3": "In the future, you’ll be able to use your GOV.UK account to access all services on GOV.UK."
       },
       "createButtonText": "Create a GOV.UK account"
     },
@@ -296,7 +296,7 @@
       "header": "Create your password",
       "password": {
         "label": "Enter a password",
-        "hintText": "It must be at least 8 characters and must include letters and numbers. Do not use a very common password, such as 'password' or a sequence of numbers.",
+        "hintText": "It must be at least 8 characters and must include letters and numbers. Do not use a very common password, such as ‘password’ or a sequence of numbers.",
         "validationError": {
           "required": "Enter your password",
           "maxLength": "Your password must be less than 256 characters",
@@ -353,8 +353,8 @@
       }
     },
     "accountCreated": {
-      "title": "You've created your GOV.UK account",
-      "header": "You've created your GOV.UK account",
+      "title": "You’ve created your GOV.UK account",
+      "header": "You’ve created your GOV.UK account",
       "text": "Now continue to use the service.",
       "inset": "Your progress on ",
       "insetContinued": " has been saved.",
@@ -1626,7 +1626,7 @@
         "insetAlternativeLanguageAppWarning": "The GOV.UK ID Check app is currently only available in English."
       },
       "section2": {
-        "paragraph1": "You'll need:",
+        "paragraph1": "You’ll need:",
         "listItem1_1": "a GOV.UK account – we’ll ask you to create or sign in to your account when you continue",
         "listItem1_2": "your photo ID",
         "listItem1_3": "your current home address (you might also need your previous address if you’ve recently moved)",
@@ -1636,7 +1636,7 @@
         "section3": {
           "radioOption1": "Continue with your GOV.UK account"
         },
-        "paragraph1": "You'll need:",
+        "paragraph1": "You’ll need:",
         "listItem1_1": "a GOV.UK account – we’ll ask you to create or sign in to your account when you continue",
         "listItem1_2": "your photo ID",
         "listItem1_3": "your current home address (you might also need your previous address if you’ve recently moved)",
@@ -1683,7 +1683,7 @@
         "summaryText": "I cannot scan the QR code",
         "paragraph1": "You can enter the secret key into your authenticator app instead.",
         "paragraph2": "Secret key: ",
-        "paragraph3": "Some authenticator apps call the secret key a 'code'."
+        "paragraph3": "Some authenticator apps call the secret key a ‘code’."
       },
       "step3": "3. The authenticator app will show a security code.",
       "step4": "4. Enter the security code.",

--- a/src/locales/tests/locale.test.ts
+++ b/src/locales/tests/locale.test.ts
@@ -1,0 +1,33 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import englishTranslations from "../en/translation.json";
+import welshTranslations from "../cy/translation.json";
+
+export function traverseObjectProperties(
+  obj: any,
+  func: (key: string, value: string) => void
+): any {
+  const properties = Object.keys(obj);
+  properties.forEach((i) => {
+    if (obj[i] === Object(obj[i])) {
+      return traverseObjectProperties(obj[i], func);
+    }
+    func(i, obj[i]);
+  });
+}
+
+export function testExpectation(key: string, value: string): void {
+  expect(value).to.not.contain(
+    "'",
+    "translated values should not contain dumb quotes"
+  );
+}
+
+describe("locale files", () => {
+  it("should not contain any dumb quotes in Welsh translations", () => {
+    traverseObjectProperties(welshTranslations, testExpectation);
+  });
+  it("should not contain any dumb quotes in English translations", () => {
+    traverseObjectProperties(englishTranslations, testExpectation);
+  });
+});


### PR DESCRIPTION
## What?

This PR does two things: 
- [x] Removes existing instances of "dumb quotes" from locale files replacing them with their "smart quote" counterparts.
- [x] Introduces a unit test that recursively iterates over properties of the locale files so that all string values are tested to ensure they don't contain a dumb quote. 

## Why?

Typographical change approved by Content Design and Interaction Design. Previous PRs (#847) have removed dumb quotes and we need a way to ensure they don't come back. 

## Visual changes

### Before

This page shows the mix of "smart quotes" and "dumb quotes" that were present

![before](https://user-images.githubusercontent.com/16000203/214565026-a3d857d1-0904-4437-be4d-366051a8181b.png)

### After

This page shows the page with "smart quotes" only

![after](https://user-images.githubusercontent.com/16000203/214565173-ce04dc17-1ec6-4181-a63a-bf32ad5529f7.png)


## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.
