### PR TITLE
AUT-969 - Enable internal phone numbers for staging

### DIFF
--- a/ci/tasks/deploy-frontend.yml
+++ b/ci/tasks/deploy-frontend.yml
@@ -22,7 +22,6 @@ params:
   ZENDESK_GROUP_ID_PUBLIC: ((build-zendesk-group-id-public))
   BASIC_AUTH_USERNAME: ((no-basic-auth-username))
   BASIC_AUTH_PASSWORD: ((no-basic-auth-password))
-  SUPPORT_INTERNATIONAL_NUMBERS: "0"
   INCOMING_TRAFFIC_CIDR_BLOCKS: '["0.0.0.0/0"]'
   BASIC_AUTH_BYPASS_CIDR_BLOCKS: '[]'
   SUPPORT_MFA_OPTIONS: "0"
@@ -84,7 +83,6 @@ run:
         -var "sidecar_image_uri=${SIDECAR_IMAGE_URI}" \
         -var "sidecar_image_tag=${SIDECAR_IMAGE_TAG}" \
         -var "sidecar_image_digest=${SIDECAR_IMAGE_DIGEST}" \
-        -var "support_international_numbers=${SUPPORT_INTERNATIONAL_NUMBERS}" \
         -var "support_mfa_options=${SUPPORT_MFA_OPTIONS}" \
         -var "support_language_cy=${SUPPORT_LANGUAGE_CY}" \
         -var "support_password_reset_required=${SUPPORT_PASSWORD_RESET_REQUIRED}" \

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -5,7 +5,8 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
-support_language_cy = "1"
+support_international_numbers = "0"
+support_language_cy           = "1"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -5,7 +5,8 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
-support_language_cy = "1"
+support_international_numbers = "0"
+support_language_cy           = "1"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -8,7 +8,7 @@ frontend_task_definition_memory = 1024
 frontend_auto_scaling_min_count = 4
 frontend_auto_scaling_max_count = 12
 ecs_desired_count               = 4
-
+support_international_numbers   = "0"
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -12,7 +12,7 @@ gtm_id                  = ""
 support_language_cy     = "1"
 support_mfa_options     = "1"
 
-support_international_numbers   = 0
+support_international_numbers   = "0"
 frontend_task_definition_cpu    = 256
 frontend_task_definition_memory = 512
 frontend_auto_scaling_enabled   = true

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -8,7 +8,8 @@ frontend_task_definition_memory = 1024
 frontend_auto_scaling_min_count = 4
 frontend_auto_scaling_max_count = 12
 
-support_language_cy = "1"
+support_language_cy           = "1"
+support_international_numbers = "1"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"


### PR DESCRIPTION
## What?

- Set the support_international_numbers terraform variable for all environments. This will be set to "0" apart from staging where it will be set to "1"

## Why?

- This will allow us to test out international phone numbers in staging before we roll out to other environments
- Stop setting this variable via the deploy-frontend.yml. This file picks up the environment variable via the concourse pipeline which is overkill when it can be set as a terraform variable in the relevant <environment>.tfvars file.

