### PR TITLE
AUT-969 - Increase the international phone number limit to 25

### DIFF
--- a/src/components/enter-phone-number/enter-phone-number-validation.ts
+++ b/src/components/enter-phone-number/enter-phone-number-validation.ts
@@ -67,7 +67,7 @@ export function validateEnterPhoneNumberRequest(): ValidationChainFunc {
         return true;
       })
       .custom((value, { req }) => {
-        if (!lengthInRangeWithoutSpaces(value, 5, 16)) {
+        if (!lengthInRangeWithoutSpaces(value, 5, 25)) {
           throw new Error(
             req.t(
               "pages.enterPhoneNumber.internationalPhoneNumber.validationError.internationalFormat"


### PR DESCRIPTION

## What?

 - Increase the international phone number limit to 25

## Why?

- Some international dialing codes range from having 2 to 7 numbers. Therefore our current 15 number limit might disclude some international numbers.

