### PR TITLE
AUT-971: Update support forms to include IPNs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -76,6 +76,7 @@ import { enterAuthenticatorAppCodeRouter } from "./components/enter-authenticato
 import { cookiesRouter } from "./components/common/cookies/cookies-routes";
 import { errorPageRouter } from "./components/common/errors/error-routes";
 import { photoIdRouter } from "./components/photo-id/photo-id-routes";
+import { setInternationalPhoneNumberSupportMiddleware } from "./middleware/set-international-phone-number-support-middleware";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -181,6 +182,7 @@ async function createApp(): Promise<express.Application> {
   app.use(setHtmlLangMiddleware);
   app.use(initialiseSessionMiddleware);
   app.use(crossDomainTrackingMiddleware);
+  app.use(setInternationalPhoneNumberSupportMiddleware);
 
   registerRoutes(app);
 

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -137,6 +137,7 @@ export function contactUsQuestionsGet(req: Request, res: Response): void {
     referer: req.query.referer,
     pageTitleHeading: pageTitle,
     zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+    ipnSupport: res.locals.ipnSupport,
   });
 }
 

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -80,6 +80,9 @@ export function contactUsService(
         case "email":
           securityCodeMethod = "Email";
           break;
+        case "text_message":
+          securityCodeMethod = "Text message";
+          break;
         case "text_message_uk_number":
           securityCodeMethod = "Text message to a UK phone number";
           break;

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -80,8 +80,12 @@ export function contactUsService(
         case "email":
           securityCodeMethod = "Email";
           break;
-        case "text_message":
-          securityCodeMethod = "Text message";
+        case "text_message_uk_number":
+          securityCodeMethod = "Text message to a UK phone number";
+          break;
+        case "text_message_international_number":
+          securityCodeMethod =
+            "Text message to a phone number from a different country";
           break;
         case "authenticator_app":
           securityCodeMethod = "Authenticator app";

--- a/src/components/contact-us/questions/_security_send_method.njk
+++ b/src/components/contact-us/questions/_security_send_method.njk
@@ -1,3 +1,48 @@
+{% if theme == 'account_creation' %}
+    {% set items = [
+        {
+            value: "email",
+            checked: securityCodeSentMethod === 'email',
+            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translateEnOnly
+        },
+        {
+            value: "text_message_uk_number",
+            checked: securityCodeSentMethod === 'text_message_uk_number',
+            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translateEnOnly
+        },
+        {
+            value: "text_message_international_number",
+            checked: securityCodeSentMethod === 'text_message_international_number',
+            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translateEnOnly
+        },
+        {
+            value: "authenticator_app",
+            checked: securityCodeSentMethod === 'authenticator_app',
+            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio4' | translateEnOnly
+        }
+    ] %}
+{% endif %}
+
+{% if theme == 'signing_in' %}
+    {% set items = [
+        {
+            value: "text_message_uk_number",
+            checked: securityCodeSentMethod === 'text_message_uk_number',
+            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translateEnOnly
+        },
+        {
+            value: "text_message_international_number",
+            checked: securityCodeSentMethod === 'text_message_international_number',
+            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translateEnOnly
+        },
+        {
+            value: "authenticator_app",
+            checked: securityCodeSentMethod === 'authenticator_app',
+            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio4' | translateEnOnly
+        }
+    ] %}
+{% endif %}
+
 {% if theme == 'account_creation' or theme == 'signing_in' %}
     {{ govukRadios({
         name: "securityCodeSentMethod",
@@ -8,28 +53,7 @@
                 classes: "govuk-fieldset__legend--m"
             }
         },
-        items: [
-            {
-                value: "email",
-                checked: securityCodeSentMethod === 'email',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translateEnOnly
-            },
-            {
-                value: "text_message_uk_number",
-                checked: securityCodeSentMethod === 'text_message_uk_number',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translateEnOnly
-            },
-            {
-                value: "text_message_international_number",
-                checked: securityCodeSentMethod === 'text_message_international_number',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translateEnOnly
-            },
-            {
-                value: "authenticator_app",
-                checked: securityCodeSentMethod === 'authenticator_app',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio4' | translateEnOnly
-            }
-        ],
+        items: items,
         errorMessage: {
             text: errors['securityCodeSentMethod'].text
         } if (errors['securityCodeSentMethod'])

--- a/src/components/contact-us/questions/_security_send_method.njk
+++ b/src/components/contact-us/questions/_security_send_method.njk
@@ -1,47 +1,87 @@
-{% if theme == 'account_creation' %}
-    {% set items = [
-        {
-            value: "email",
-            checked: securityCodeSentMethod === 'email',
-            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translateEnOnly
-        },
-        {
-            value: "text_message_uk_number",
-            checked: securityCodeSentMethod === 'text_message_uk_number',
-            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translateEnOnly
-        },
-        {
-            value: "text_message_international_number",
-            checked: securityCodeSentMethod === 'text_message_international_number',
-            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translateEnOnly
-        },
-        {
-            value: "authenticator_app",
-            checked: securityCodeSentMethod === 'authenticator_app',
-            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio4' | translateEnOnly
-        }
-    ] %}
+{% if ipnSupport %}
+    {% if theme == 'account_creation' %}
+        {% set items = [
+            {
+                value: "email",
+                checked: securityCodeSentMethod === 'email',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.email' | translateEnOnly
+            },
+            {
+                value: "text_message_uk_number",
+                checked: securityCodeSentMethod === 'text_message_uk_number',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageUkNumber' | translateEnOnly
+            },
+            {
+                value: "text_message_international_number",
+                checked: securityCodeSentMethod === 'text_message_international_number',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageInternationalNumber' | translateEnOnly
+            },
+            {
+                value: "authenticator_app",
+                checked: securityCodeSentMethod === 'authenticator_app',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translateEnOnly
+            }
+        ] %}
+    {% endif %}
+
+    {% if theme == 'signing_in' %}
+        {% set items = [
+            {
+                value: "text_message_uk_number",
+                checked: securityCodeSentMethod === 'text_message_uk_number',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageUkNumber' | translateEnOnly
+            },
+            {
+                value: "text_message_international_number",
+                checked: securityCodeSentMethod === 'text_message_international_number',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessageInternationalNumber' | translateEnOnly
+            },
+            {
+                value: "authenticator_app",
+                checked: securityCodeSentMethod === 'authenticator_app',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translateEnOnly
+            }
+        ] %}
+    {% endif %}
 {% endif %}
 
-{% if theme == 'signing_in' %}
-    {% set items = [
-        {
-            value: "text_message_uk_number",
-            checked: securityCodeSentMethod === 'text_message_uk_number',
-            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translateEnOnly
-        },
-        {
-            value: "text_message_international_number",
-            checked: securityCodeSentMethod === 'text_message_international_number',
-            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translateEnOnly
-        },
-        {
-            value: "authenticator_app",
-            checked: securityCodeSentMethod === 'authenticator_app',
-            text: 'pages.contactUsQuestions.securityCodeSentMethod.radio4' | translateEnOnly
-        }
-    ] %}
+{% if not ipnSupport %}
+    {% if theme == 'account_creation' %}
+        {% set items = [
+            {
+                value: "email",
+                checked: securityCodeSentMethod === 'email',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.email' | translateEnOnly
+            },
+            {
+                value: "text_message",
+                checked: securityCodeSentMethod === 'text_message',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessage' | translateEnOnly
+            },
+            {
+                value: "authenticator_app",
+                checked: securityCodeSentMethod === 'authenticator_app',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translateEnOnly
+            }
+        ] %}
+    {% endif %}
+
+    {% if theme == 'signing_in' %}
+        {% set items = [
+            {
+                value: "text_message",
+                checked: securityCodeSentMethod === 'text_message',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.textMessage' | translateEnOnly
+            },
+            {
+                value: "authenticator_app",
+                checked: securityCodeSentMethod === 'authenticator_app',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.authApp' | translateEnOnly
+            }
+        ] %}
+    {% endif %}
 {% endif %}
+
 
 {% if theme == 'account_creation' or theme == 'signing_in' %}
     {{ govukRadios({

--- a/src/components/contact-us/questions/_security_send_method.njk
+++ b/src/components/contact-us/questions/_security_send_method.njk
@@ -1,4 +1,4 @@
-{% if theme == 'account_creation' %}
+{% if theme == 'account_creation' or theme == 'signing_in' %}
     {{ govukRadios({
         name: "securityCodeSentMethod",
         fieldset: {
@@ -15,14 +15,19 @@
                 text: 'pages.contactUsQuestions.securityCodeSentMethod.radio1' | translateEnOnly
             },
             {
-                value: "text_message",
-                checked: securityCodeSentMethod === 'text_message',
+                value: "text_message_uk_number",
+                checked: securityCodeSentMethod === 'text_message_uk_number',
                 text: 'pages.contactUsQuestions.securityCodeSentMethod.radio2' | translateEnOnly
+            },
+            {
+                value: "text_message_international_number",
+                checked: securityCodeSentMethod === 'text_message_international_number',
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translateEnOnly
             },
             {
                 value: "authenticator_app",
                 checked: securityCodeSentMethod === 'authenticator_app',
-                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio3' | translateEnOnly
+                text: 'pages.contactUsQuestions.securityCodeSentMethod.radio4' | translateEnOnly
             }
         ],
         errorMessage: {

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -50,6 +50,7 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         referer: REFERER,
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'GOV.UK email subscriptions' radio option was chosen", () => {
@@ -62,9 +63,10 @@ describe("contact us questions controller", () => {
         theme: "email_subscriptions",
         subtheme: undefined,
         backurl: "/contact-us",
-        pageTitleHeading: "pages.contactUsQuestions.emailSubscriptions.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.emailSubscriptions.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'A suggestion or feedback' radio option was chosen", () => {
@@ -77,9 +79,10 @@ describe("contact us questions controller", () => {
         theme: "suggestions_feedback",
         subtheme: undefined,
         backurl: "/contact-us",
-        pageTitleHeading: "pages.contactUsQuestions.suggestionOrFeedback.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.suggestionOrFeedback.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
 
@@ -93,9 +96,10 @@ describe("contact us questions controller", () => {
         theme: "proving_identity",
         subtheme: undefined,
         backurl: "/contact-us",
-        pageTitleHeading: "pages.contactUsQuestions.provingIdentity.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.provingIdentity.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
 
@@ -118,9 +122,10 @@ describe("contact us questions controller", () => {
         theme: "signing_in",
         subtheme: "no_security_code",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -134,9 +139,10 @@ describe("contact us questions controller", () => {
         theme: "signing_in",
         subtheme: "invalid_security_code",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'You do not have access to the phone number' radio option was chosen", () => {
@@ -150,9 +156,10 @@ describe("contact us questions controller", () => {
         theme: "signing_in",
         subtheme: "no_phone_number_access",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.noPhoneNumberAccess.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.noPhoneNumberAccess.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'You've forgotten your password' radio option was chosen", () => {
@@ -166,9 +173,10 @@ describe("contact us questions controller", () => {
         theme: "signing_in",
         subtheme: "forgotten_password",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.forgottenPassword.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.forgottenPassword.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'Your account cannot be found' radio option was chosen", () => {
@@ -182,9 +190,10 @@ describe("contact us questions controller", () => {
         theme: "signing_in",
         subtheme: "account_not_found",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.accountNotFound.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.accountNotFound.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -198,9 +207,10 @@ describe("contact us questions controller", () => {
         theme: "signing_in",
         subtheme: "technical_error",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -214,9 +224,10 @@ describe("contact us questions controller", () => {
         theme: "signing_in",
         subtheme: "something_else",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
   });
@@ -233,9 +244,10 @@ describe("contact us questions controller", () => {
         theme: "account_creation",
         subtheme: "no_security_code",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -249,9 +261,10 @@ describe("contact us questions controller", () => {
         theme: "account_creation",
         subtheme: "invalid_security_code",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'You do not have a UK number' radio option was chosen", () => {
@@ -265,9 +278,10 @@ describe("contact us questions controller", () => {
         theme: "account_creation",
         subtheme: "no_uk_mobile_number",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.noUKMobile.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.noUKMobile.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -281,9 +295,10 @@ describe("contact us questions controller", () => {
         theme: "account_creation",
         subtheme: "technical_error",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -297,9 +312,10 @@ describe("contact us questions controller", () => {
         theme: "account_creation",
         subtheme: "something_else",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.accountCreation.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.accountCreation.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
     it("should render contact-us-questions if a 'problem with authenticator app' radio option was chosen", () => {
@@ -313,9 +329,10 @@ describe("contact us questions controller", () => {
         theme: "account_creation",
         subtheme: "authenticator_app_problem",
         backurl: "/contact-us-further-information",
-        pageTitleHeading: "pages.contactUsQuestions.authenticatorApp.title",
         referer: REFERER,
+        pageTitleHeading: "pages.contactUsQuestions.authenticatorApp.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
+        ipnSupport: undefined,
       });
     });
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1451,10 +1451,11 @@
         }
       },
       "securityCodeSentMethod": {
-        "radio1": "",
-        "radio2": "",
-        "radio3": "",
-        "radio4": "",
+        "email": "",
+        "textMessage": "",
+        "textMessageUkNumber": "",
+        "textMessageInternationalNumber": "",
+        "authApp": "",
         "errorMessage": ""
       },
       "noSecurityCode": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1451,10 +1451,11 @@
         }
       },
       "securityCodeSentMethod": {
-        "radio1": "E-bost",
-        "radio2": "Neges destun",
-        "radio3": "Ap dilysydd",
-        "errorMessage": "Dewiswch os anfonwyd y cod trwy e-bost neu neges destun"
+        "radio1": "",
+        "radio2": "",
+        "radio3": "",
+        "radio4": "",
+        "errorMessage": ""
       },
       "noSecurityCode": {
         "title": "You did not get a security code",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1451,10 +1451,11 @@
         }
       },
       "securityCodeSentMethod": {
-        "radio1": "Email",
-        "radio2": "Text message to a UK phone number",
-        "radio3": "Text message to a phone number from a different country",
-        "radio4": "Authenticator app",
+        "email": "Email",
+        "textMessage": "Text message",
+        "textMessageUkNumber": "Text message to a UK phone number",
+        "textMessageInternationalNumber": "Text message to a phone number from a different country",
+        "authApp": "Authenticator app",
         "errorMessage": "Select whether the code was sent by email or text message"
       },
       "noSecurityCode": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1452,8 +1452,9 @@
       },
       "securityCodeSentMethod": {
         "radio1": "Email",
-        "radio2": "Text message",
-        "radio3": "Authenticator app",
+        "radio2": "Text message to a UK phone number",
+        "radio3": "Text message to a phone number from a different country",
+        "radio4": "Authenticator app",
         "errorMessage": "Select whether the code was sent by email or text message"
       },
       "noSecurityCode": {

--- a/src/middleware/set-international-phone-number-support-middleware.ts
+++ b/src/middleware/set-international-phone-number-support-middleware.ts
@@ -1,0 +1,11 @@
+import { NextFunction, Request, Response } from "express";
+import { supportInternationalNumbers } from "../config";
+
+export function setInternationalPhoneNumberSupportMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  res.locals.ipnSupport = supportInternationalNumbers();
+  next();
+}

--- a/test/unit/middleware/set-international-phone-number-support-middleware.test.ts
+++ b/test/unit/middleware/set-international-phone-number-support-middleware.test.ts
@@ -1,0 +1,43 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import { NextFunction, Request, Response } from "express";
+import { sinon } from "../../utils/test-utils";
+import { setInternationalPhoneNumberSupportMiddleware } from "../../../src/middleware/set-international-phone-number-support-middleware";
+import { mockRequest, mockResponse } from "mock-req-res";
+
+describe("Set international phone number support middleware", () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    req = mockRequest();
+    res = mockResponse();
+    next = sinon.fake();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("setInternationalPhoneNumberSupportMiddleware", () => {
+    it("should add ipnSupport to response locals", () => {
+      setInternationalPhoneNumberSupportMiddleware(
+        req as Request,
+        res as Response,
+        next
+      );
+      expect(res.locals).to.have.property("ipnSupport");
+    });
+
+    it("should call next function", () => {
+      req = {};
+      setInternationalPhoneNumberSupportMiddleware(
+        req as Request,
+        res as Response,
+        next
+      );
+      expect(next).to.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
## What?

Introduces additional option for "How did you expect to get the security code?" to differentiate between UK phone numbers and IPNs on four forms: 

|                                 | A problem creating a GOV.UK account | A problem signing in to your GOV.UK account |  
|---------------------------------|-------------------------------------|---------------------------------------------|
| Did not receive a security code | Form updated to include new option | Form updated to include new option  | 
| Security code didn't work       | Form updated to include new option |  Form updated to include new option | 

These changes are behind the international phone numbers feature flag.

### Screenshots

#### Problem creating a GOV.UK account "Did not receive a security code"
![You-did-not-get-a-security-code-GOV-UK-account](https://user-images.githubusercontent.com/16000203/215461987-075f4afb-10a4-45b1-9617-13c4c1d24f50.png)

##### Zendesk submission
<img width="872" alt="Screenshot 2023-01-30 at 11 14 47" src="https://user-images.githubusercontent.com/16000203/215462396-b0d299d6-4607-4dbe-939e-54bea37ba672.png">

##### Zendesk submission
<img width="931" alt="Screenshot 2023-01-30 at 11 17 09" src="https://user-images.githubusercontent.com/16000203/215462827-8acae626-fe47-4762-85cb-0e75dede1225.png">

#### Problem creating a GOV.UK account "Security code didn't work"
![The-security-code-does-not-work-GOV-UK-account (1)](https://user-images.githubusercontent.com/16000203/215463700-7d36a246-3542-4855-9c2d-bb50efa01e39.png)

##### Zendesk submission
<img width="823" alt="Screenshot 2023-01-30 at 11 24 51" src="https://user-images.githubusercontent.com/16000203/215464438-87a149c3-3644-47b7-94df-48f7008b09c1.png">

##### Zendesk submission
<img width="895" alt="Screenshot 2023-01-30 at 11 22 44" src="https://user-images.githubusercontent.com/16000203/215464108-55d73954-36f1-4e0b-9993-50f87b3d841d.png">

#### A problem signing in to your GOV.UK account "Did not receive a security code"
![You-did-not-get-a-security-code-GOV-UK-account](https://user-images.githubusercontent.com/16000203/215510480-62e373cc-7883-48d0-a702-ce9638fa5b36.png)

##### Zendesk submission
<img width="860" alt="Screenshot 2023-01-30 at 11 56 11" src="https://user-images.githubusercontent.com/16000203/215470735-058d71fa-3afa-4c9f-a330-934d02780296.png">

##### Zendesk submission
<img width="839" alt="Screenshot 2023-01-30 at 11 58 32" src="https://user-images.githubusercontent.com/16000203/215470933-117ed134-c4d6-4086-83f6-12adbee7d882.png">

#### A problem signing in to your GOV.UK account "Security code didn't work"
![The-security-code-does-not-work-GOV-UK-account (1)](https://user-images.githubusercontent.com/16000203/215510985-ace538d5-0839-4468-85d0-82c7ce005d49.png)


##### Zendesk submission
<img width="798" alt="Screenshot 2023-01-30 at 12 00 50" src="https://user-images.githubusercontent.com/16000203/215471847-b11ddc86-c8d7-4f5f-af06-710c94db6c8f.png">

##### Zendesk submission
<img width="862" alt="Screenshot 2023-01-30 at 12 01 06" src="https://user-images.githubusercontent.com/16000203/215471882-ccc9bbec-a1fc-4334-a701-53bf5f7efc15.png">

## Why?

Allows users to indicate whether they have used a UK or international phone number when submitting a support request

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

