### PR TITLE
AUT-1062: Ensure translation file keys are the same

### DIFF
--- a/src/locales/tests/locale.test.ts
+++ b/src/locales/tests/locale.test.ts
@@ -5,7 +5,7 @@ import welshTranslations from "../cy/translation.json";
 
 export function traverseObjectProperties(
   obj: any,
-  func: (key: string, value: string) => void
+  func: (key: string, value?: string) => void
 ): any {
   const properties = Object.keys(obj);
   properties.forEach((i) => {
@@ -29,5 +29,34 @@ describe("locale files", () => {
   });
   it("should not contain any typographically incorrect quotes (aka 'straight quotes') in English translations", () => {
     traverseObjectProperties(englishTranslations, testExpectation);
+  });
+});
+
+describe("locale file structure", () => {
+  const welshTranslationFileKeys: string[] = [];
+  const englishTranslationFileKeys: string[] = [];
+
+  traverseObjectProperties(welshTranslations, (key) => {
+    welshTranslationFileKeys.push(key);
+  });
+
+  traverseObjectProperties(englishTranslations, (key) => {
+    englishTranslationFileKeys.push(key);
+  });
+
+  it("should be that locale files have the same number of keys", () => {
+    expect(englishTranslationFileKeys.length).to.equal(
+      welshTranslationFileKeys.length
+    );
+  });
+
+  it("should be that locale files have the same keys when sorted", () => {
+    expect([...englishTranslationFileKeys].sort()).to.eql(
+      [...welshTranslationFileKeys].sort()
+    );
+  });
+
+  it("should be that locale files have the same keys in the same position", () => {
+    expect(englishTranslationFileKeys).to.eql(welshTranslationFileKeys);
   });
 });


### PR DESCRIPTION
## What?

Introduce tests to ensure that the English and Welsh translation files have the same shape (i.e. the same property keys all the way down through nesting).

## Why?

To ensure there is no potential for drift between the files
