### PR TITLE
AUT-992 -  Update cookie links in privacy policy 

### DIFF
--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -51,8 +51,10 @@
     <li>
       {{'pages.privacy.section2.bulletPoint6.text1' | translate}}
       <a href="https://www.gov.uk/help/privacy-notice" class="govuk-link">{{'pages.privacy.section2.bulletPoint6.linkText1' | translate}}</a>
-      {{'pages.privacy.section2.bulletPoint6.and' | translate}}
+      {{'pages.privacy.section2.bulletPoint6.comma' | translate}}
       <a href="https://www.gov.uk/support/cookies" class="govuk-link">{{'pages.privacy.section2.bulletPoint6.linkText2' | translate}}</a>
+      {{'pages.privacy.section2.bulletPoint6.and' | translate}}
+      <a href="/cookies" class="govuk-link">{{'pages.privacy.section2.bulletPoint6.linkText3' | translate}}</a>
       {{'pages.privacy.section2.bulletPoint6.text2' | translate}}
     </li>
     <li>{{'pages.privacy.section2.bulletPoint7' | translate}}</li>

--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -86,7 +86,7 @@
     <li>{{'pages.privacy.section3.bulletPoint10' | translate}}</li>
     <li>
       {{'pages.privacy.section3.bulletPoint11.text3' | translate}}
-      <a href="https://www.gov.uk/help/cookies" class="govuk-link">{{'pages.privacy.section3.bulletPoint11.linkText' | translate}}</a>
+      <a href="/cookies" class="govuk-link">{{'pages.privacy.section3.bulletPoint11.linkText' | translate}}</a>
       {{'pages.privacy.section3.bulletPoint11.text4' | translate}}
     </li>
     <li>{{'pages.privacy.section3.bulletPoint12' | translate}}</li>

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -986,8 +986,10 @@
         "bulletPoint6": {
           "text1": "gwybodaeth am sut rydych yn defnyddio eich cyfrif a gwefan GOV.UK, sy’n cael ei gasglu yng nghofnodion y system, a chan gwcis Google Analytics os ydych yn rhoi caniatâd - mae’r ",
           "linkText1": "hysbysiad preifatrwydd GOV.UK",
-          "and": " a ",
+          "comma": " , ",
           "linkText2": "pholisi cwcis GOV.UK",
+          "and": " a ",
+          "linkText3": "Polisi cwcis cyfrifon GOV.UK",
           "text2": " yn darparu mwy o wybodaeth am hyn"
         },
         "bulletPoint7": "dynodwyr ar-lein, fel eich cyfeiriad Protocol Rhyngrwyd (IP), a gwybodaeth dechnegol am y ddyfais rydych yn ei defnyddio gan gynnwys y model, porwr gwe a system weithredu, sy’n cael ei gasglu’n awtomatig mewn cofnodion system pan fyddwch yn defnyddio GOV.UK",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1017,7 +1017,6 @@
         "bulletPoint11": {
           "text3": "gwella a deall sut rydych yn defnyddio eich cyfrif GOV.UK",
           "linkText": "defnyddio cwcis Google Analytics",
-          "linkHref": "https://www.gov.uk/help/cookies",
           "text4": "(gallwch ddewis peidio â derbyn y cwcis hyn)"
         },
         "bulletPoint12": "ymateb i unrhyw adborth rydych yn ei anfon atom, os ydych chi wedi gofyn i ni wneud",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -986,8 +986,10 @@
         "bulletPoint6": {
           "text1": "information on how you use your account and the GOV.UK website, which is collected in the system logs, and by Google Analytics cookies if you give consent - the ",
           "linkText1": "GOV.UK privacy notice",
-          "and": " and ",
+          "comma": " , ",
           "linkText2": "GOV.UK cookies policy",
+          "and": " and ",
+          "linkText3": "GOV.UK accounts cookies policy",
           "text2": " provide more information about this"
         },
         "bulletPoint7": "online identifiers, such as your Internet Protocol (IP) address, and technical information about the device you use including the model, web browser and operating system, which is automatically collected in system logs when you use GOV.UK",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1017,7 +1017,6 @@
         "bulletPoint11": {
           "text3": "improve and understand how you use your GOV.UK account",
           "linkText": "using Google Analytics cookies",
-          "linkHref": "https://www.gov.uk/help/cookies",
           "text4": "(you can choose not to accept these cookies)"
         },
         "bulletPoint12": "respond to any feedback you send us, if you’ve asked us to",


### PR DESCRIPTION
## What?

-  Update cookie links and text in privacy policy. There has been changes made to 2 parts of the privacy policy here. 

## Why?

- We were either not including a reference to the GOV.UK accounts cookie policy or including a reference but linking to the GOV.UK cookie policy.
- Below shows screenshots of the changes for Scenario 1. There are no screenshots for Scenario 2 as that is just a change of the link href.

**Scenario 1 before**
<img width="609" alt="Screenshot 2023-01-30 at 13 29 15" src="https://user-images.githubusercontent.com/35073557/215490706-26aed663-d0e4-4a35-960d-84cb95d81112.png">

**Scenario 1 after**
<img width="744" alt="Screenshot 2023-01-30 at 13 17 41" src="https://user-images.githubusercontent.com/35073557/215490589-2925b2f5-c9e2-41f7-8ec6-3b38600797af.png">
