### PR TITLE
AUT-969 - Update hint and validation content for enter phone number

### DIFF
--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -85,7 +85,7 @@ describe("Integration::enter phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#phoneNumber-error").text()).to.contains(
-          "Enter a phone number"
+          "Enter a UK mobile phone number"
         );
       })
       .expect(400, done);
@@ -198,7 +198,7 @@ describe("Integration::enter phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a phone number"
+          "Enter a mobile phone number"
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
@@ -219,7 +219,7 @@ describe("Integration::enter phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a phone number in the correct format"
+          "Enter a mobile phone number in the correct format, including the country code"
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
@@ -240,7 +240,7 @@ describe("Integration::enter phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a phone number using only numbers or the + symbol"
+          "Enter a mobile phone number using only numbers or the + symbol"
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
@@ -261,7 +261,7 @@ describe("Integration::enter phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a phone number in the correct format"
+          "Enter a mobile phone number in the correct format, including the country code"
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })
@@ -282,7 +282,7 @@ describe("Integration::enter phone number", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#internationalPhoneNumber-error").text()).to.contains(
-          "Enter a phone number in the correct format"
+          "Enter a mobile phone number in the correct format, including the country code"
         );
         expect($("#phoneNumber-error").text()).to.contains("");
       })

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -335,7 +335,7 @@
       "ukPhoneNumber": {
         "label": "Rhif ffôn symudol y DU",
         "validationError": {
-          "required": "Rhowch rif ffôn",
+          "required": "Rhowch rif ffôn symudol y DU",
           "international": "Rhowch rif ffôn symudol yn y DU",
           "length": "Rhowch rif ffôn symudol yn y DU, fel 07700 900000",
           "plusNumericOnly": "Rhowch rif ffôn symudol yn y DU gan ddefnyddio rhifau yn unig neu’r symbol +"
@@ -344,11 +344,11 @@
       "internationalPhoneNumber": {
         "checkBoxLabel": "Nid oes gennyf rif ffôn symudol y DU",
         "label": "Rhif ffôn symudol",
-        "hint": "Dylech gynnwys y cod gwlad, er enghraifft +3537777666555",
+        "hint": "Dylech gynnwys y cod gwlad, er enghraifft +33 am Ffrainc",
         "validationError": {
-          "required": "Rhowch rif ffôn",
-          "plusNumericOnly": "Rhowch rif ffôn gan ddefnyddio rhifau yn unig neu’r symbol +",
-          "internationalFormat": "Rhowch rif ffôn yn y ffurf cywir"
+          "required": "Rhowch rif ffôn symudol",
+          "plusNumericOnly": "Rhowch rif ffôn symudol gan ddefnyddio rhifau yn unig neu’r symbol +",
+          "internationalFormat": "Rhowch rif ffôn symudol yn y ffurf gywir, gan gynnwys y cod gwlad"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -335,7 +335,7 @@
       "ukPhoneNumber": {
         "label": "UK mobile phone number",
         "validationError": {
-          "required": "Enter a phone number",
+          "required": "Enter a UK mobile phone number",
           "international": "Enter a UK mobile phone number",
           "length": "Enter a UK mobile phone number, like 07700 900000",
           "plusNumericOnly": "Enter a UK mobile phone number using only numbers or the + symbol"
@@ -344,11 +344,11 @@
       "internationalPhoneNumber": {
         "checkBoxLabel": "I do not have a UK mobile number",
         "label": "Mobile phone number",
-        "hint": "Include the country code, for example +3537777666555",
+        "hint": "Include the country code, for example +33 for France",
         "validationError": {
-          "required": "Enter a phone number",
-          "plusNumericOnly": "Enter a phone number using only numbers or the + symbol",
-          "internationalFormat": "Enter a phone number in the correct format"
+          "required": "Enter a mobile phone number",
+          "plusNumericOnly": "Enter a mobile phone number using only numbers or the + symbol",
+          "internationalFormat": "Enter a mobile phone number in the correct format, including the country code"
         }
       }
     },


### PR DESCRIPTION
## What?

- Hint text for international mobile number field to become: Include the country code, for example +33 for France
- Validation error message for ‘invalid format’ on international mobile number field to become: Enter a mobile phone number in the correct format, including the country code
- Validation error message for ‘no user input’ on international mobile number field to become: Enter a mobile phone number
- Validation error message for ‘no user input’ on Uk mobile number field to become: Enter a UK mobile phone number
- Validation error message for ‘Characters other than digits + or - used’ on international mobile number field to become: Enter a mobile phone number using only numbers or the + symbol


## Why?

- So the messaging we give to the users is clearer