### PR TITLE
AUT-974 - Add SWE content to `Create a GOV.UK account of sign in` page

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -20,6 +20,7 @@
   <li>{{'pages.signInOrCreate.moreAbout.listItem2' | translate}}</li>
   <li>{{'pages.signInOrCreate.moreAbout.listItem3' | translate}}</li>
   <li>{{'pages.signInOrCreate.moreAbout.listItem4' | translate}}</li>
+  <li>{{'pages.signInOrCreate.moreAbout.listItem5' | translate}}</li>
 </ul>
 <p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph2' | translate}}</p>
 <p class="govuk-body">{{'pages.signInOrCreate.moreAbout.paragraph3' | translate}}</p>

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -158,9 +158,10 @@
         "header": "Am gyfrifon GOV.UK",
         "paragraph1": "Mae cyfrifon GOV.UK yn newydd. Ar hyn o bryd gallwch ond defnyddio eich cyfrif GOV.UK gyda:",
         "listItem1": "Gwneud cais am drwydded gweithredwr cerbyd",
-        "listItem2": "Tanysgrifiadau e-byst GOV.UK",
-        "listItem3": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
-        "listItem4": "Gwneud cais am wiriad DBS sylfaenol",
+        "listItem2": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
+        "listItem3": "Tanysgrifiadau e-byst GOV.UK",
+        "listItem4": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
+        "listItem5": "Gwneud cais am wiriad DBS sylfaenol",
         "paragraph2": "Nid yw cyfrifon GOV.UK yn gweithio gyda phob cyfrif neu wasanaeth y llywodraeth hyd yma (er enghraifft Porth y Llywodraeth neu Gredyd Cynhwysol).",
         "paragraph3": "Yn y dyfodol, byddwch yn gallu defnyddio eich cyfrif GOV.UK i gael mynediad i holl wasanaethau ar GOV.UK."
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -158,9 +158,10 @@
         "header": "About GOV.UK accounts",
         "paragraph1": "GOV.UK accounts are new. At the moment you can only use your GOV.UK account with:",
         "listItem1": "Apply for a vehicle operator licence",
-        "listItem2": "GOV.UK email subscriptions ",
-        "listItem3": "LITE (Licensing for International Trade and Enterprise)",
-        "listItem4": "Request a basic DBS check",
+        "listItem2": "Apply to become a registered social worker in England",
+        "listItem3": "GOV.UK email subscriptions ",
+        "listItem4": "LITE (Licensing for International Trade and Enterprise)",
+        "listItem5": "Request a basic DBS check",
         "paragraph2": "GOV.UK accounts do not work with all government accounts and services yet (for example Government Gateway or Universal Credit).",
         "paragraph3": "In the future, you’ll be able to use your GOV.UK account to access all services on GOV.UK."
       },


### PR DESCRIPTION
## What?

 - Add SWE content to `Create a GOV.UK account of sign in` page

## Why?

- To reflect the services that have onboarded 

![Screenshot 2023-02-03 at 10 01 56](https://user-images.githubusercontent.com/35073557/216572010-fb5e533c-1115-48c0-8547-0e1d82fee0bd.png)

