### PR TITLE
AUT-995: Change content on the 'Check your phone'

### DIFF
--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -50,8 +50,7 @@
     <li>{{'pages.privacy.section2.bulletPoint5' | translate}}</li>
     <li>
       {{'pages.privacy.section2.bulletPoint6.text1' | translate}}
-      <a href="https://www.gov.uk/help/privacy-notice" class="govuk-link">{{'pages.privacy.section2.bulletPoint6.linkText1' | translate}}</a>
-      {{'pages.privacy.section2.bulletPoint6.comma' | translate}}
+      <a href="https://www.gov.uk/help/privacy-notice" class="govuk-link">{{'pages.privacy.section2.bulletPoint6.linkText1' | translate}}</a>{{'pages.privacy.section2.bulletPoint6.comma' | translate}}
       <a href="https://www.gov.uk/support/cookies" class="govuk-link">{{'pages.privacy.section2.bulletPoint6.linkText2' | translate}}</a>
       {{'pages.privacy.section2.bulletPoint6.and' | translate}}
       <a href="/cookies" class="govuk-link">{{'pages.privacy.section2.bulletPoint6.linkText3' | translate}}</a>

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -106,7 +106,7 @@ describe("Integration:: contact us - public user", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#subtheme-error").text()).to.contains(
-          "Select the problem you had when signing in to your account"
+          "Select the problem you had when signing in to your GOV.UK One Login"
         );
       })
       .expect(400, done);

--- a/src/components/enter-mfa/enter-mfa-controller.ts
+++ b/src/components/enter-mfa/enter-mfa-controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { NOTIFICATION_TYPE } from "../../app.constants";
+import {MFA_METHOD_TYPE, NOTIFICATION_TYPE} from "../../app.constants";
 import { VerifyCodeInterface } from "../common/verify-code/types";
 import { codeService } from "../common/verify-code/verify-code-service";
 import { verifyCodePost } from "../common/verify-code/verify-code-controller";
@@ -11,6 +11,7 @@ const TEMPLATE_NAME = "enter-mfa/index.njk";
 export function enterMfaGet(req: Request, res: Response): void {
   res.render(TEMPLATE_NAME, {
     phoneNumber: req.session.user.phoneNumber,
+    isAuthApp: req.session.user.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP
   });
 }
 

--- a/src/components/enter-mfa/enter-mfa-controller.ts
+++ b/src/components/enter-mfa/enter-mfa-controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import {MFA_METHOD_TYPE, NOTIFICATION_TYPE} from "../../app.constants";
+import { MFA_METHOD_TYPE, NOTIFICATION_TYPE } from "../../app.constants";
 import { VerifyCodeInterface } from "../common/verify-code/types";
 import { codeService } from "../common/verify-code/verify-code-service";
 import { verifyCodePost } from "../common/verify-code/verify-code-controller";
@@ -11,7 +11,7 @@ const TEMPLATE_NAME = "enter-mfa/index.njk";
 export function enterMfaGet(req: Request, res: Response): void {
   res.render(TEMPLATE_NAME, {
     phoneNumber: req.session.user.phoneNumber,
-    isAuthApp: req.session.user.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP
+    isAuthApp: req.session.user.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP,
   });
 }
 

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -2,17 +2,30 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set pageTitleName = 'pages.enterMfa.title' | translate %}
+{% set pageTitleName = 'pages.youNeedToEnterASecurityCode.title' | translate %}
 
 {% block content %}
 
   {% include "common/errors/errorSummary.njk" %}
 
-  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterMfa.header' | translate }}</h1>
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.youNeedToEnterASecurityCode.header' | translate }}</h1>
 
-  <p class="govuk-body">{{'pages.enterMfa.info.paragraph1' | translate }}</p>
-  <p class="govuk-body">{{'pages.enterMfa.info.paragraph2' | translate }}</p>
+  <p class="govuk-body">{{'pages.youNeedToEnterASecurityCode.paragraph1' | translate }}</p>
+
+  {% if isAuthApp %}
+
+  {% else %}
+    {% set insetTextHtml %}
+    <p class="govuk-body">{{'pages.youNeedToEnterASecurityCode.paragraph3' | translate }}</p>
+    {% endset %}
+
+    {{ govukInsetText({
+        html: insetTextHtml
+      }) }}
+    <p class="govuk-body">{{'pages.youNeedToEnterASecurityCode.paragraph4' | translate }}</p>
+  {% endif %}
 
   <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">
     <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
@@ -35,8 +48,7 @@
 
     {% set detailsHTML %}
     <p class="govuk-body">
-      {{'pages.enterMfa.details.text1' | translate}}
-      <a href="{{'pages.enterMfa.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterMfa.details.sendCodeLinkText'| translate}}</a>
+      <a href="{{'pages.youNeedToEnterASecurityCode.sendTheCodeAgain' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.youNeedToEnterASecurityCode.sendTheCodeAgain'| translate}}</a>
       {{'pages.enterMfa.details.text 2' | translate}}
     </p>
     {% endset %}

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -4,66 +4,99 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% set pageTitleName = 'pages.youNeedToEnterASecurityCode.title' | translate %}
+{% set pageTitleName = 'pages.enterMfa.title' | translate %}
 
 {% block content %}
 
-  {% include "common/errors/errorSummary.njk" %}
+    {% include "common/errors/errorSummary.njk" %}
 
-  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.youNeedToEnterASecurityCode.header' | translate }}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.enterMfa.header' | translate }}</h1>
+    <p class="govuk-body">{{ 'pages.enterMfa.info.paragraph1' | translate }} </p>
 
-  <p class="govuk-body">{{'pages.youNeedToEnterASecurityCode.paragraph1' | translate }}</p>
+    {% if isAuthApp %}
+        {% set insetTextHtml %}
+            <p class="govuk-body">
+                {{ 'pages.enterMfa.info.paragraph3' | translate }}
+                <span class="govuk-!-font-weight-bold">{{ 'pages.enterMfa.info.authenticatorApp' | translate }}</span>
+                <span>{{ 'pages.enterMfa.info.paragraph3End' | translate }}</span>
+            </p>
+        {% endset %}
 
-  {% if isAuthApp %}
+    {% else %}
+        {% set insetTextHtml %}
+            <p class="govuk-body">{{ 'pages.enterMfa.info.paragraph4' | translate }}</p>
+        {% endset %}
 
-  {% else %}
-    {% set insetTextHtml %}
-    <p class="govuk-body">{{'pages.youNeedToEnterASecurityCode.paragraph3' | translate }}</p>
-    {% endset %}
+    {% endif %}
 
     {{ govukInsetText({
         html: insetTextHtml
-      }) }}
-    <p class="govuk-body">{{'pages.youNeedToEnterASecurityCode.paragraph4' | translate }}</p>
-  {% endif %}
-
-  <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">
-    <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
-    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-
-    {{ govukInput({
-  label: {
-  text: 'pages.enterMfa.code.label' | translate
-  },
-  classes: "govuk-input--width-10 govuk-!-font-weight-bold",
-  id: "code",
-  name: "code",
-  inputmode: "numeric",
-  spellcheck: false,
-  autocomplete:"off",
-  errorMessage: {
-  text: errors['code'].text
-  } if (errors['code'])})
-  }}
-
-    {% set detailsHTML %}
-    <p class="govuk-body">
-      <a href="{{'pages.youNeedToEnterASecurityCode.sendTheCodeAgain' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.youNeedToEnterASecurityCode.sendTheCodeAgain'| translate}}</a>
-      {{'pages.enterMfa.details.text 2' | translate}}
-    </p>
-    {% endset %}
-
-    {{ govukDetails({
-      summaryText: 'pages.enterMfa.details.summaryText' | translate,
-      html: detailsHTML
     }) }}
 
-    {{ govukButton({
-  "text": "general.continue.label" | translate,
-  "type": "Submit",
-  "preventDoubleClick": true
-  }) }}
+    {% if not isAuthApp %}
+        <p class="govuk-body">{{ 'pages.enterMfa.info.paragraph2' | translate }}</p>
+    {% endif %}
 
-  </form>
+    <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">
+        <input type="hidden" name="phoneNumber" value="{{ phoneNumber }}" />
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+        {% if isAuthApp %}
+
+            {{ govukInput({
+                label: {
+                    text: 'pages.enterMfa.code.label' | translate
+                },
+                hint: {
+                    text: 'pages.enterMfa.code.labelSummary' | translateEnOnly
+                },
+                classes: "govuk-input--width-10 govuk-!-font-weight-bold",
+                id: "code",
+                name: "code",
+                inputmode: "numeric",
+                spellcheck: false,
+                autocomplete:"off",
+                errorMessage: {
+                    text: errors['code'].text
+                } if (errors['code'])}) }}
+
+        {% else %}
+
+            {{ govukInput({
+                label: {
+                    text: 'pages.enterMfa.code.label2' | translate
+                },
+                classes: "govuk-input--width-10 govuk-!-font-weight-bold",
+                id: "code",
+                name: "code",
+                inputmode: "numeric",
+                spellcheck: false,
+                autocomplete:"off",
+                errorMessage: {
+                    text: errors['code'].text
+                } if (errors['code'])}) }}
+
+            {% set detailsHTML %}
+                <p class="govuk-body">
+                    <a href="{{ 'pages.enterMfa.details.sendCodeLinkHref' | translate }}" class="govuk-link"
+                       rel="noreferrer noopener">{{ 'pages.enterMfa.details.sendTheCodeAgain'| translate }}</a>
+                    {{ 'pages.enterMfa.details.text 2' | translate }}
+                </p>
+            {% endset %}
+
+            {{ govukDetails({
+                summaryText: 'pages.enterMfa.details.summaryText' | translate,
+                html: detailsHTML
+            }) }}
+
+        {% endif %}
+
+        {{ govukButton({
+            "text": "general.continue.label" | translate,
+            "type": "Submit",
+            "preventDoubleClick": true
+        }) }}
+
+    </form>
 
 {% endblock %}

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -134,7 +134,7 @@ export function enterPasswordPost(
     req.session.user.isLatestTermsAndConditionsAccepted =
       userLogin.data.latestTermsAndConditionsAccepted;
     req.session.user.isPasswordChangeRequired = isPasswordChangeRequired;
-req.session.user.mfaMethodType = userLogin.data.mfaMethodType;
+    req.session.user.mfaMethodType = userLogin.data.mfaMethodType;
 
     if (
       userLogin.data.mfaRequired &&

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -134,6 +134,7 @@ export function enterPasswordPost(
     req.session.user.isLatestTermsAndConditionsAccepted =
       userLogin.data.latestTermsAndConditionsAccepted;
     req.session.user.isPasswordChangeRequired = isPasswordChangeRequired;
+req.session.user.mfaMethodType = userLogin.data.mfaMethodType;
 
     if (
       userLogin.data.mfaRequired &&

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -159,7 +159,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       .expect(function (res) {
         const $ = cheerio.load(res.text);
         expect($("#password-error").text()).to.contains(
-          "Your account is already using that password. Enter a different password"
+          "You are already using that password. Enter a different password"
         );
       })
       .expect(400, done);

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2,8 +2,7 @@
   "general": {
     "provider": "GOV.UK",
     "pageTitle": "Mewngofnodi i GOV.UK",
-    "serviceName": "Mewngofnodwch i neu greu eich cyfrif GOV.UK",
-    "serviceNameTitle": "Cyfrif GOV.UK",
+    "serviceNameTitle": "GOV.UK One Login",
     "errorTitlePrefix": "Gwall",
     "back": "Yn ôl",
     "warning": "Rhybudd",
@@ -13,13 +12,13 @@
       "tag": "beta",
       "content": "Mae hwn yn wasanaeth newydd – bydd eich <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i’w wella."
     },
-    "authenticatorAppIssuer": "Cyfrif GOV.UK",
+    "authenticatorAppIssuer": "GOV.UK One Login",
     "yes": "Gallwch",
     "no": "Na",
     "cookie": {
       "cookieBanner": {
-        "title": "Cwcis ar gyfrif GOV.UK",
-        "heading": "Cwcis ar gyfrif GOV.UK",
+        "title": "Cwcis ar GOV.UK One Login",
+        "heading": "Cwcis ar GOV.UK One Login",
         "paragraph1": "Rydym yn defnyddio rhai cwcis hanfodol i wneud i’r gwasanaeth hwn weithio.",
         "paragraph2": "Hoffem hefyd ddefnyddio cwcis dadansoddi er mwyn i ni allu deall sut rydych yn defnyddio’r gwasanaeth a gwneud gwelliannau.",
         "buttonAcceptText": "Derbyn cwcis dadansoddi",
@@ -46,7 +45,7 @@
     },
     "contactAccounts": {
       "contactLinkHref": "https://signin.account.gov.uk/contact-us",
-      "contactLinkText": "Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)"
+      "contactLinkText": "Cysylltu â thîm GOV.UK One Login (agor mewn tab newydd)"
     },
     "header": {
       "homepageHref": "https://www.gov.uk/"
@@ -117,11 +116,11 @@
       }
     },
     "sessionRequiredMidJourneyError": {
-      "title": "Sorry, you cannot access your account from this page",
-      "header": "Sorry, you cannot access your account from this page",
+      "title": "Mae’n ddrwg gennym, ni allwch gael mynediad i GOV.UK One Login o’r dudalen hon",
+      "header": "Mae’n ddrwg gennym, ni allwch gael mynediad i GOV.UK One Login o’r dudalen hon",
       "content": {
         "paragraph1": {
-          "text1": "Go to your GOV.UK account",
+          "text1": "Ewch i’ch GOV.UK One Login",
           "text2": ", or find the service you need from the ",
           "text3": "GOV.UK homepage"
         },
@@ -132,19 +131,19 @@
   "pages": {
     "signInOrCreate": {
       "mandatory": {
-        "title": "Creu cyfrif GOV.UK neu fewngofnodi",
-        "header": "Creu cyfrif GOV.UK neu fewngofnodi"
+        "title": "Creu GOV.UK One Login neu fewngofnodi",
+        "header": "Creu GOV.UK One Login neu fewngofnodi"
       },
       "optional": {
-        "title": "Creu cyfrif i arbed eich cynnydd",
-        "header": "Creu cyfrif i arbed eich cynnydd"
+        "title": "Creu GOV.UK One Login neu fewngofnodi i arbed eich cynnydd",
+        "header": "Creu GOV.UK One Login neu fewngofnodi i arbed eich cynnydd"
       },
       "paragraph": "Byddwch angen:",
       "bullet1": "cyfeiriad e-bost",
       "bullet2": "ffordd o gael codau diogelwch - gall hwn fod yn rhif ffôn symudol y DU neu’n ap dilysydd",
       "bullet2IntNumbers": "ffordd o gael codau diogelwch - gall hwn fod yn rhif ffôn symudol neu’n ap dilysydd",
       "insetAlternativeLanguage": {
-        "paragraph1": "Mae’r cyfrif GOV.UK hefyd ar gael ",
+        "paragraph1": "Mae GOV.UK One Login hefyd ar gael ",
         "linkText": {
           "inPageLanguage": "yn Saesneg",
           "inDestinationLanguage": "(English)",
@@ -152,20 +151,20 @@
         },
         "linkHref": "?lng=en"
       },
-      "paragraph2": "Os oes gennych gyfrif GOV.UK yn barod gallwch",
+      "paragraph2": "Os oes gennych GOV.UK One Login yn barod gallwch",
       "signInText": "fewngofnodi",
       "moreAbout": {
-        "header": "Am gyfrifon GOV.UK",
-        "paragraph1": "Mae cyfrifon GOV.UK yn newydd. Ar hyn o bryd gallwch ond defnyddio eich cyfrif GOV.UK gyda:",
+        "header": "Am GOV.UK One Login",
+        "paragraph1": "Mae GOV.UK One Login yn newydd. Ar hyn o bryd gallwch ond defnyddio eich GOV.UK One Login gyda:",
         "listItem1": "Gwneud cais am drwydded gweithredwr cerbyd",
         "listItem2": "Gwneud cais i ddod yn weithiwr cymdeithasol cofrestredig yn Lloegr",
         "listItem3": "Tanysgrifiadau e-byst GOV.UK",
         "listItem4": "LITE (Trwyddedu ar gyfer Masnach a Menter Ryngwladol)",
         "listItem5": "Gwneud cais am wiriad DBS sylfaenol",
-        "paragraph2": "Nid yw cyfrifon GOV.UK yn gweithio gyda phob cyfrif neu wasanaeth y llywodraeth hyd yma (er enghraifft Porth y Llywodraeth neu Gredyd Cynhwysol).",
-        "paragraph3": "Yn y dyfodol, byddwch yn gallu defnyddio eich cyfrif GOV.UK i gael mynediad i holl wasanaethau ar GOV.UK."
+        "paragraph2": "Nid yw GOV.UK One Login yn gweithio gyda phob cyfrif neu wasanaeth y llywodraeth hyd yma (er enghraifft Porth y Llywodraeth neu Gredyd Cynhwysol).",
+        "paragraph3": "Yn y dyfodol, byddwch yn gallu defnyddio eich GOV.UK One Login i gael mynediad i holl wasanaethau ar GOV.UK."
       },
-      "createButtonText": "Creu cyfrif GOV.UK"
+      "createButtonText": "Creu GOV.UK One Login"
     },
     "enterEmailCreateAccount": {
       "title": "Rhowch eich cyfeiriad e-bost",
@@ -179,8 +178,8 @@
       }
     },
     "enterEmailExistingAccount": {
-      "title": "Rhowch eich cyfeiriad e-bost i fewngofnodi i’ch cyfrif GOV.UK",
-      "header": "Rhowch eich cyfeiriad e-bost i fewngofnodi i’ch cyfrif GOV.UK",
+      "title": "Rhowch eich cyfeiriad e-bost i fewngofnodi i’ch GOV.UK One Login",
+      "header": "Rhowch eich cyfeiriad e-bost i fewngofnodi i’ch GOV.UK One Login",
       "email": {
         "label": "Cyfeiriad e-bost",
         "validationError": {
@@ -191,34 +190,34 @@
       }
     },
     "accountNotFoundOneLogin": {
-      "title": "Ni ddarganfyddwyd cyfrif GOV.UK",
-      "header": "Ni ddarganfyddwyd cyfrif GOV.UK",
-      "paragraph1": "Nid oes cyfrif GOV.UK ar gyfer ",
-      "insetText1": "Mae cyfrifon GOV.UK yn newydd. Ar hyn o bryd, maent ar wahân i gyfrifon eraill y llywodraeth.",
+      "title": "Ni ddarganfyddwyd GOV.UK One Login",
+      "header": "Ni ddarganfyddwyd GOV.UK One Login",
+      "paragraph1": "Nid oes GOV.UK One Login ar gyfer ",
+      "insetText1": "Mae GOV.UK One Login yn newydd. Nid yw yn gweithio gyda phob cyfrif neu wasanaeth y llywodraeth hyd yma.",
       "paragraph2": "Os ydych chi’n ceisio cael mynediad i’ch cyfrif ar gyfer gwasanaeth y llywodraeth, fel Credyd Cynhwysol neu’ch cyfrif treth personol, mewngofnodwch i’ch cyfrif ar gyfer y gwasanaeth hwnnw.",
       "signInToServiceButtonText": "Mewngofnodi i wasanaeth",
       "tryAnotherLinkText": "Rhowch gynnig ar gyfeiriad e-bost arall",
       "tryAnotherLinkHref": "/enter-email-existing-account"
     },
     "accountNotFoundMandatory": {
-      "title": "Ni ddarganfyddwyd cyfrif GOV.UK",
-      "header": "Ni ddarganfyddwyd cyfrif GOV.UK",
-      "paragraph1": "Nid oes cyfrif GOV.UK ar gyfer ",
-      "insetText1": "Mae cyfrifon GOV.UK yn newydd. Ar hyn o bryd, maent ar wahân i gyfrifon eraill y llywodraeth, fel Porth y Llywodraeth neu Gredyd Cynhwysol.",
-      "paragraph2": "Mae angen i chi greu cyfrif GOV.UK hyd yn oed os oes gennych fath arall o gyfrif llywodraeth yn barod.",
-      "createAccountButtonText": "Creu cyfrif GOV.UK",
+      "title": "Ni ddarganfyddwyd GOV.UK One Login",
+      "header": "Ni ddarganfyddwyd GOV.UK One Login",
+      "paragraph1": "Nid oes GOV.UK One Login ar gyfer ",
+      "insetText1": "Mae GOV.UK One Login yn newydd. Nid yw yn gweithio gyda phob cyfrif neu wasanaeth y llywodraeth hyd yma, er enghraifft Porth y Llywodraeth neu Gredyd Cynhwysol.",
+      "paragraph2": "Mae angen i chi greu GOV.UK One Login hyd yn oed os oes gennych gyfrif ar gyfer adran arall o’r llywodraeth yn barod.",
+      "createAccountButtonText": "Creu GOV.UK One Login",
       "createAccountButtonHref": "/enter-email",
       "tryAnotherLinkText": "Rhowch gynnig ar gyfeiriad e-bost arall",
       "tryAnotherLinkHref": "/enter-email-existing-account"
     },
     "accountNotFoundOptional": {
-      "title": "Ni ddarganfyddwyd cyfrif GOV.UK",
-      "header": "Ni ddarganfyddwyd cyfrif GOV.UK",
+      "title": "Ni ddarganfyddwyd GOV.UK One Login",
+      "header": "Ni ddarganfyddwyd GOV.UK One Login",
       "paragraph1": "Ni allem ddod o hyd i gyfrif GOV.UK sy’n ddefnyddio’r cyfeiriad e-bost hwn.",
       "insetText1": "Efallai bod gennych gyfrifon eraill y llywodraeth fel Porth y Llywodraeth neu eich cyfrif treth personol.",
       "insetText2": "Mae’r cyfrif GOV.UK ar wahân i’r cyfrifon eraill hyn gan y llywodraeth.",
-      "insetText3": "Mae angen i chi greu cyfrif GOV.UK, hyd yn oed os oes gennych gyfrif llywodraeth arall.",
-      "createAccountButtonText": "Creu cyfrif GOV.UK",
+      "insetText3": "Mae angen i chi greu GOV.UK One Login, hyd yn oed os oes gennych gyfrif llywodraeth arall.",
+      "createAccountButtonText": "Creu GOV.UK One Login",
       "createAccountButtonHref": "/enter-email",
       "tryAnotherLinkText": "Rhowch gynnig ar gyfeiriad e-bost arall",
       "tryAnotherLinkHref": "/enter-email-existing-account"
@@ -239,9 +238,9 @@
       }
     },
     "enterPasswordAccountExists": {
-      "title": "Mae gennych gyfrif GOV.UK",
-      "header": "Mae gennych gyfrif GOV.UK",
-      "paragraph1": "Mae yna gyfrif GOV.UK eisoes yn defnyddio ",
+      "title": "Mae gennych GOV.UK One Login",
+      "header": "Mae gennych GOV.UK One Login",
+      "paragraph1": "Mae yna GOV.UK One Login eisoes yn defnyddio ",
       "info": "Rhowch eich cyfrinair i fewngofnodi.",
       "password": {
         "label": "Cyfrinair",
@@ -354,8 +353,8 @@
       }
     },
     "accountCreated": {
-      "title": "Rydych wedi creu eich cyfrif GOV.UK",
-      "header": "Rydych wedi creu eich cyfrif GOV.UK",
+      "title": "Rydych wedi creu eich GOV.UK One Login",
+      "header": "Rydych wedi creu eich GOV.UK One Login",
       "text": "Nawr ewch yn eich blaen i ddefnyddio’r gwasanaeth.",
       "inset": "Mae eich cynnydd ar ",
       "insetContinued": " wedi cael ei arbed.",
@@ -463,14 +462,20 @@
       "header": "Gwiriwch eich ffôn",
       "info": {
         "paragraph1": "Rydym wedi anfon cod at y rhif ffôn yn gysylltiedig â’ch cyfrif.",
-        "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud."
+        "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud.",
+        "paragraph3": "I gael cod diogelwch, agorwch yr ",
+        "authenticatorApp": "ap dilysydd ",
+        "paragraph3End": "rydych wedi’i ddefnyddio i greu eich GOV.UK One Login",
+        "paragraph4": "We sent a code to the phone number linked to your account."
       },
       "resend": {
         "link": "Gofynnwch am god newydd",
         "paragraph1": "os nad yw’r cod yn gweithio neu mae wedi dod i ben, neu ni dderbynioch un."
       },
       "code": {
-        "label": "Rhowch y cod diogelwch 6 digid",
+        "label": "Rhowch y cod diogelwch",
+        "label2": "Rhowch y cod diogelwch 6 digid",
+        "labelSummary": "Dyma’r rhif 6-digid a ddangosir yn eich ap dilysydd",
         "validationError": {
           "required": "Rhowch y cod diogelwch",
           "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
@@ -481,8 +486,7 @@
       },
       "details": {
         "summaryText": "Problemau gyda’r cod?",
-        "text1": "Gallwn ",
-        "sendCodeLinkText": "anfon y cod eto",
+        "sendTheCodeAgain": "Anfon y cod eto",
         "sendCodeLinkHref": "/resend-code",
         "text 2": " os nad yw’r cod yn gweithio neu ni wnaethoch ei dderbyn."
       }
@@ -493,7 +497,7 @@
       "continue": "Cael cod diogelwch",
       "message": "Gall negeseuon testun weithiau gymryd ychydig funudau i gyrraedd.",
       "phoneNumber": {
-        "default": "Byddwn yn anfon cod at y rhif ffôn sy’n gysylltiedig â’ch cyfrif",
+        "default": "Byddwn yn anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login",
         "isResendCodeRequest": "Byddwn yn anfon cod i: [mobile]."
       },
       "email": {
@@ -508,19 +512,19 @@
       "govukLinkText": "Ewch i hafan GOV.UK",
       "paragraph1": "neu",
       "signInLinkText": "mewngofnodwch",
-      "paragraph2": "i’ch cyfrif GOV.UK."
+      "paragraph2": "i’ch GOV.UK One Login."
     },
     "shareInfo": {
-      "title": "Rhannu gwybodaeth o’ch cyfrif GOV.UK",
-      "header": "Rhannu gwybodaeth o’ch cyfrif GOV.UK",
+      "title": "Rhannu gwybodaeth o’ch GOV.UK One Login",
+      "header": "Rhannu gwybodaeth o’ch GOV.UK One Login",
       "continue": "Parhau",
       "bulletPointSectionHeader": "Mae’r gwasanaeth hwn angen defnyddio eich:",
-      "paragraph1": "Rydych wedi ychwanegu’r wybodaeth hon i’ch cyfrif GOV.UK pan wnaethoch greu’r cyfrif. Gallwch ddewis ei rannu gyda’r gwasanaeth yn lle ei roi i mewn eto pan fyddwch yn defnyddio’r gwasanaeth.",
+      "paragraph1": "Rydych wedi ychwanegu’r wybodaeth hon i’ch GOV.UK One Login pan wnaethoch ei greu. Gallwch ddewis ei rannu gyda’r gwasanaeth yn lle ei roi i mewn eto pan fyddwch yn defnyddio’r gwasanaeth.",
       "paragraph2": "Bydd y gwasanaeth ond yn defnyddio’r wybodaeth yma i gysylltu â chi am y gwasanaeth. Ni fydd yn rhannu eich gwybodaeth ag unrhyw un arall. Bydd yn cadw eich gwybodaeth cyhyd ag y mae ei angen neu mae’r gyfraith yn ei gwneud yn ofynnol iddo.",
-      "paragraph3": "Os ydych yn dewis peidio rhannu gwybodaeth o’ch cyfrif GOV.UK, efallai y dal gofynnir i chi am y wybodaeth honno wrth i chi ddefnyddio’r gwasanaeth. Er enghraifft os ydych yn dewis peidio rhannu eich cyfeiriad e-bost a’ch rhif ffôn ac mae’r gwasanaeth angen ffordd i gysylltu â chi.",
-      "essentialHeader": "Ydych chi eisiau rhannu gwybodaeth o’ch cyfrif GOV.UK? ",
+      "paragraph3": "Os ydych yn dewis peidio â rhannu gwybodaeth o’ch GOV.UK One Login,efallai y gofynnir i chi am y wybodaeth honno o hyd wrth i chi ddefnyddio’r gwasanaeth. Er enghraifft os ydych yn dewis peidio â rhannu eich cyfeiriad e-bost a’ch rhif ffôn ac mae’r gwasanaeth angen ffordd i gysylltu â chi.",
+      "essentialHeader": "Ydych chi eisiau rhannu gwybodaeth o’ch GOV.UK One Login? ",
       "radios": {
-        "shareMy": "Ydych chi eisiau rhannu gwybodaeth o’ch cyfrif GOV.UK?",
+        "shareMy": "Ydych chi eisiau rhannu gwybodaeth o’ch GOV.UK One Login?",
         "radioText": {
           "agree": "Rhannwch fy nghyfeiriad e-bost a’m rhif ffôn",
           "doNotAgree": "Peidiwch rhannu fy nghyfeiriad e-bost â’m rhif ffôn",
@@ -529,8 +533,8 @@
       }
     },
     "updatedTermsAndConds": {
-      "title": "Diweddariad telerau defnyddio cyfrif GOV.UK",
-      "header": "Diweddariad telerau defnyddio cyfrif GOV.UK",
+      "title": "Diweddariad telerau defnyddio GOV.UK One Login",
+      "header": "Diweddariad telerau defnyddio GOV.UK One Login",
       "paragraph1": {
         "text": "Rydym wedi diweddaru ein ",
         "and": "a",
@@ -575,26 +579,26 @@
         "termsAndConditionsText": "telerau ac amodau",
         "privacyNoticeText": "hysbysiad preifatrwydd",
         "cookiesPolicyText": "polisi cwcis",
-        "end": "wedi’u diweddaru i barhau i ddefnyddio eich cyfrif."
+        "end": "i barhau i ddefnyddio eich cyfrif."
       },
       "section2": {
-        "paragraph1": "Os nad ydych yn cytuno i’r telerau newydd, ni allwch ddefnyddio eich cyfrif GOV.UK.",
+        "paragraph1": "Os nad ydych yn cytuno i’r telerau newydd, ni allwch ddefnyddio eich GOV.UK One Login.",
         "govUkHomePageText": "Ewch i hafan GOV.UK.",
-        "paragraph2": "Os nad ydych angen eich cyfrif mwyach, neu os ydych am ddileu gwybodaeth sydd wedi’i arbed yn eich cyfrif, gallwch ",
+        "paragraph2": "Os nad ydych angen eich GOV.UK One Login mwyach, neu os ydych am ddileu gwybodaeth sydd wedi’i arbed yn eich GOV.UK One Login, gallwch ",
         "contactUsText": "gysylltu â ni."
       },
       "agreeAndContinue": "Cytuno a pharhau"
     },
     "cookiePolicy": {
-      "title": "Polisi cwcis cyfrifon GOV.UK",
-      "header": "Polisi cwcis cyfrifon GOV.UK",
+      "title": "Polisi cwcis GOV.UK One Login",
+      "header": "Polisi cwcis GOV.UK One Login",
       "info": {
-        "paragraph1": "Dim ond cyfrifon GOV.UK. mae’r polisi cwcis hwn yn ei gwmpasu. Darllenwch brif ",
+        "paragraph1": "Dim ond ar gyfer GOV.UK One Login mae’r polisi cwcis hwn yn ei gwmpasu. Darllenwch brif ",
         "govUkCookiesLinkHref": "https://www.gov.uk/help/cookies",
         "govUkCookiesLinkText": "bolisi cwcis GOV.UK",
         "paragraph2": " i gael gwybod am gwcis sy’n cael eu defnyddio ar GOV.UK.",
-        "paragraph3": "Mae cwcis yn ffeiliau sy’n cael eu cadw ar eich ffôn, llechen neu gyfrifiadur pan fyddwch yn ymweld â gwefan. Rydym yn defnyddio cwcis i wneud i cyfrif GOV.UK weithio.",
-        "paragraph4": "Efallai y byddwn hefyd yn defnyddio cwcis dadansoddeg i ddysgu am sut rydych yn defnyddio’r cyfrif a’n helpu i’w wella. Byddwn yn gofyn am eich caniatâd cyn i ni wneud hyn.",
+        "paragraph3": "Mae cwcis yn ffeiliau sy’n cael eu cadw ar eich ffôn, llechen neu gyfrifiadur pan fyddwch yn ymweld â gwefan. Rydym yn defnyddio cwcis i wneud i GOV.UK One Login weithio.",
+        "paragraph4": "Efallai y byddwn hefyd yn defnyddio cwcis dadansoddeg i ddysgu am sut rydych yn defnyddio GOV.UK One Login a’n helpu i’w wella. Byddwn yn gofyn am eich caniatâd cyn i ni wneud hyn.",
         "paragraph5": "Nid yw cwcis yn cael eu defnyddio i’ch adnabod chi’n bersonol.",
         "paragraph6": "Darganfyddwch fwy am",
         "linkHref": "https://ico.org.uk/your-data-matters/online/cookies/",
@@ -605,7 +609,7 @@
         "header": "Cwcis hollol hanfodol",
         "info": {
           "paragraph1": "Rydym yn defnyddio cwcis hanfodol i:",
-          "bulletPoint1": "wneud i’r cyfrif weithio",
+          "bulletPoint1": "wneud i GOV.UK One Login weithio",
           "bulletPoint2": "cadw eich gwybodaeth yn ddiogel",
           "bulletPoint3": "canfod gweithgarwch twyllodrus neu faleisus ac achosion o dorri ein telerau ac amodau",
           "table": {
@@ -656,7 +660,7 @@
       },
       "cookiesMessage": {
         "header": "Neges cwcis",
-        "paragraph1": "Efallai y gwelwch faner pan fyddwch yn defnyddio eich cyfrif GOV.UK yn eich gwahodd i dderbyn cwcis neu adolygu eich gosodiadau. Byddwn yn gosod cwcis i: ",
+        "paragraph1": "Efallai y gwelwch faner pan fyddwch yn defnyddio eich GOV.UK One Login yn eich gwahodd i dderbyn cwcis neu adolygu eich gosodiadau. Byddwn yn gosod cwcis i: ",
         "bulletPoint1": "adael i’ch cyfrifiadur wybod eich bod wedi gweld y neges hon fel nad yw’n cael ei ddangos i chi eto",
         "bulletPoint2": "storio eich gosodiadau",
         "table": {
@@ -675,8 +679,8 @@
       },
       "settingsCookies": {
         "header": "Cwcis sy’n cofio eich gosodiadau",
-        "paragraph1": "Mae’r cwcis hyn yn gwneud pethau fel cofio eich dewisiadau a’r dewisiadau rydych yn eu gwneud, er mwyn personoli eich profiad o ddefnyddio eich cyfrif GOV.UK.",
-        "paragraph2": "Rydym yn gosod cwci pan fyddwch yn defnyddio eich cyfrif GOV.UK i arbed eich dewis iaith. Ar hyn o bryd, mae hyn yn mynd yn ddiofyn i’r Saesneg.",
+        "paragraph1": "Mae’r cwcis hyn yn gwneud pethau fel cofio eich dewisiadau a’r dewisiadau rydych yn eu gwneud, er mwyn personoli eich profiad o ddefnyddio eich GOV.UK One Login.",
+        "paragraph2": "Rydym yn gosod cwci pan fyddwch yn defnyddio eich GOV.UK One Login i arbed eich dewis iaith. Ar hyn o bryd, mae hyn yn mynd yn ddiofyn i’r Saesneg.",
         "table": {
           "headers": {
             "col1": "Enw",
@@ -685,17 +689,17 @@
           },
           "rows": {
             "row1": {
-              "col2": "Cofio’r iaith rydych yn defnyddio’r cyfrif ynddi",
+              "col2": "Cofio’r iaith rydych yn defnyddio yn GOV.UK One Login",
               "col3": "1 flwyddyn"
             }
           }
         }
       },
       "analytics": {
-        "header": "Cwcis sy’n mesur sut rydych yn defnyddio eich cyfrif GOV.UK",
+        "header": "Cwcis sy’n mesur sut rydych yn defnyddio eich GOV.UK One Login",
         "info": {
-          "paragraph1": "Rydym yn defnyddio cwcis Google Analytics i gasglu gwybodaeth dienw am sut rydych yn defnyddio’ch cyfrif GOV.UK, er enghraifft pa dudalennau rydych yn ymweld â hwy a beth rydych yn clicio arno.",
-          "paragraph2": "Mae hyn yn ein helpu ni i ddeall sut allwn ni wella’r cyfrif."
+          "paragraph1": "Rydym yn defnyddio cwcis Google Analytics i gasglu gwybodaeth dienw am sut rydych yn defnyddio GOV.UK One Login, er enghraifft pa dudalennau rydych yn ymweld â hwy a beth rydych yn clicio arno.",
+          "paragraph2": "Mae hyn yn ein helpu ni i ddeall sut allwn ni wella GOV.UK One Login."
         },
         "table": {
           "headers": {
@@ -705,23 +709,23 @@
           },
           "rows": {
             "row1": {
-              "col2": "Ein helpu i gyfrif faint o bobl sy’n ymweld â chyfrif GOV.UK trwy wirio a ydych wedi ymweld o’r blaen",
+              "col2": "Ein helpu i gyfrif faint o bobl sy’n ymweld â GOV.UK trwy wirio a ydych wedi ymweld o’r blaen",
               "col3": "2 flynedd"
             },
             "row2": {
-              "col2": "Ein helpu i gyfrif faint o bobl sy’n ymweld â chyfrif GOV.UK trwy wirio a ydych wedi ymweld o’r blaen",
+              "col2": "Ein helpu i gyfrif faint o bobl sy’n ymweld â GOV.UK trwy wirio a ydych wedi ymweld o’r blaen",
               "col3": "24 awr"
             },
             "row3": {
-              "col2": "Ein helpu i gyfrif faint o bobl sy’n ymweld â chyfrif GOV.UK trwy wirio a ydych wedi ymweld o’r blaen",
+              "col2": "Ein helpu i gyfrif faint o bobl sy’n ymweld â GOV.UK trwy wirio a ydych wedi ymweld o’r blaen",
               "col3": "Pan fyddwch yn cau eich porwr gwe"
             }
           }
         }
       },
       "settings": {
-        "yesRadioButton": "Defnyddiwch gwcis sy’n mesur sut rwy’n defnyddio fy nghyfrif GOV.UK",
-        "noRadioButton": "Peidiwch defnyddio cwcis sy’n mesur sut rwy’n defnyddio fy nghyfrif GOV.UK",
+        "yesRadioButton": "Defnyddiwch gwcis sy’n mesur sut rwy’n defnyddio GOV.UK One Login",
+        "noRadioButton": "Peidiwch â defnyddio cwcis sy’n mesur sut rwy’n defnyddio GOV.UK One Login",
         "saveButton": "Arbed gosodiadau cwcis"
       },
       "successBanner": {
@@ -731,46 +735,46 @@
       }
     },
     "accessibilityStatement": {
-      "title": "Datganiad hygyrchedd ar gyfer cyfrifon GOV.UK",
-      "header": "Datganiad hygyrchedd ar gyfer cyfrifon GOV.UK",
+      "title": "Datganiad hygyrchedd ar gyfer GOV.UK One Login",
+      "header": "Datganiad hygyrchedd ar gyfer GOV.UK One Login",
       "content": {
-        "paragraph1": "Mae cyfrifon GOV.UK yn rhan o wefan ehangach GOV.UK. Mae ",
+        "paragraph1": "Mae GOV.UK One Login yn rhan o wefan ehangach GOV.UK. Mae ",
         "linkText": "datganiad hygyrchedd ar ar wahân ar gyfer prif wefan GOV.UK",
-        "paragraph2": "Mae’r dudalen hon ond yn cynnwys gwybodaeth am gyfrifon GOV.UK, sydd ar gael yn www.signin.account.gov.uk."
+        "paragraph2": "Mae’r dudalen hon ond yn cynnwys gwybodaeth am GOV.UK One Login, sydd ar gael yn www.signin.account.gov.uk."
       },
       "section1": {
-        "header": "Defnyddio cyfrifon GOV.UK",
+        "header": "Defnyddio GOV.UK One Login",
         "paragraph1": {
-          "text1": "Mae cyfrifon GOV.UK yn cael eu rhedeg gan y ",
+          "text1": "Mae GOV.UK One Login yn cael eu rhedeg gan y ",
           "linkText": "Gwasanaeth Digidol y Llywodraeth (GDS)",
-          "text2": ", rhan o Swyddfa’r Cabinet. Rydym am i gynifer o bobl â phosibl allu defnyddio’r wefan hon. Er enghraifft, mae hynny’n golygu y dylech allu:"
+          "text2": ", rhan o Swyddfa’r Cabinet. Rydym am i gynifer o bobl â phosibl allu defnyddio GOV.UK One Login. Er enghraifft, mae hynny’n golygu y dylech allu:"
         },
         "bulletPoint1": "newid lliwiau, lefelau cyferbyniad a ffontiau",
         "bulletPoint2": "chwyddo hyd at 300% heb i’r testun ollwng oddi ar y sgrin",
-        "bulletPoint3": "llywio’r rhan fwyaf o’r wefan drwy ddefnyddio bysellfwrdd yn unig",
-        "bulletPoint4": "llywio’r rhan fwyaf o’r wefan drwy ddefnyddio meddalwedd adnabod lleferydd",
-        "bulletPoint5": "gwrando ar y rhan fwyaf o’r wefan drwy ddefnyddio darllenydd sgrin (gan gynnwys y fersiynau diweddaraf o JAWS, NVDA a VoiceOver)",
-        "paragraph2": "Rydym hefyd wedi gwneud testun yn y cyfrif mor syml â phosibl i’w ddeall.",
+        "bulletPoint3": "llywio’r rhan fwyaf o GOV.UK One Login drwy ddefnyddio bysellfwrdd yn unig",
+        "bulletPoint4": "llywio’r rhan fwyaf o GOV.UK One Login drwy ddefnyddio meddalwedd adnabod lleferydd",
+        "bulletPoint5": "gwrando ar y rhan fwyaf o GOV.UK One Login drwy ddefnyddio darllenydd sgrin (gan gynnwys y fersiynau diweddaraf o JAWS, NVDA a VoiceOver)",
+        "paragraph2": "Rydym hefyd wedi gwneud testun yn GOV.UK One Login mor syml â phosibl i’w ddeall.",
         "linkText": "Mae gan AbilityNet",
         "linkHref": "https://mcmw.abilitynet.org.uk/",
         "paragraph3": "gyngor ar sut i wneud eich dyfais yn haws i’w defnyddio os oes gennych anabledd."
       },
       "section2": {
-        "header": "Pa mor hygyrch yw cyfrifon GOV.UK ",
-        "paragraph1": "Nid yw’r rhannau canlynol o gyfrifon GOV.UK yn gwbl hygyrch:",
-        "bulletPoint1": "nid yw’n bosib stopio na newid hyd yr amseru allan pan fyddwch yn defnyddio, mewngofnodi i neu greu cyfrif",
+        "header": "Pa mor hygyrch yw GOV.UK One Login ",
+        "paragraph1": "Nid yw’r rhannau canlynol o GOV.UK One Login yn gwbl hygyrch:",
+        "bulletPoint1": "nid yw’n bosib stopio na newid hyd yr amseru allan pan fyddwch yn defnyddio, mewngofnodi i neu greu GOV.UK One Login",
         "bulletPoint2": "nid yw’n bosib i ddarllenydd sgrin wybod pryd mae’r e-byst rydym yn eu hanfon mewn iaith ar wahân i’r Saesneg",
         "bulletPoint3": "one page reloads automatically after a set time limit, and it’s not possible to stop or delay this",
         "paragraph2": "Byddwn yn diweddaru’r dudalen hon pan fydd y materion wedi cael eu datrys neu gyda gwybodaeth ynghylch pryd rydym yn bwriadu eu datrys."
       },
       "section3": {
-        "header": "Beth i’w wneud os ydych yn cael trafferth defnyddio cyfrifon GOV.UK",
-        "paragraph1": "Os ydych yn cael trafferth defnyddio cyfrifon GOV.UK, ",
+        "header": "Beth i’w wneud os ydych yn cael trafferth defnyddio GOV.UK One Login",
+        "paragraph1": "Os ydych yn cael trafferth defnyddio GOV.UK One Login, ",
         "linkText": "cysylltwch â ni"
       },
       "section4": {
-        "header": "Rhoi gwybod am broblemau hygyrchedd gyda cyfrifon GOV.UK",
-        "paragraph1": "Rydym bob amser yn ceisio gwella hygyrchedd cyfrifon GOV.UK. Os byddwch yn dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu’n credu nad ydym yn cwrdd â gofynion hygyrchedd, ",
+        "header": "Rhoi gwybod am broblemau hygyrchedd gyda GOV.UK One Login",
+        "paragraph1": "Rydym bob amser yn ceisio gwella hygyrchedd GOV.UK One Login. Os byddwch yn dod o hyd i unrhyw broblemau nad ydynt wedi’u rhestru ar y dudalen hon neu’n credu nad ydym yn cwrdd â gofynion hygyrchedd, ",
         "linkText": "cysylltwch â ni"
       },
       "section5": {
@@ -780,11 +784,11 @@
         "linkText": "cysylltwch â’r Gwasanaeth Cynghori a Chymorth Cydraddoldeb (EASS)"
       },
       "section6": {
-        "header": "Gwybodaeth dechnegol am hygyrchedd cyfrifon GOV.UK",
-        "paragraph1": "Mae Gwasanaeth Digidol y Llywodraeth wedi ymrwymo i wneud cyfrifon GOV.UK yn hygyrch, yn unol â Rheoliadau Cyrff y Sector Cyhoeddus (Gwefannau a Cheisiadau Symudol) (Rhif 2) Hygyrchedd 2018.",
+        "header": "Gwybodaeth dechnegol am hygyrchedd GOV.UK One Login",
+        "paragraph1": "Mae Gwasanaeth Digidol y Llywodraeth wedi ymrwymo i wneud GOV.UK One Login yn hygyrch, yn unol â Rheoliadau Cyrff y Sector Cyhoeddus (Gwefannau a Cheisiadau Symudol) (Rhif 2) Hygyrchedd 2018.",
         "subHeader": "Statws cydymffurfio",
         "paragraph2": {
-          "text1": "Mae cyfrifon GOV.UK yn cydymffurfio’n rhannol â safon AA",
+          "text1": "Mae GOV.UK One Login yn cydymffurfio’n rhannol â safon AA",
           "linkText": "Canllawiau Hygyrchedd Cynnwys Gwe fersiwn 2.1",
           "text2": " oherwydd y diffyg cydymffurfiaeth a restrir isod."
         }
@@ -793,7 +797,7 @@
         "header": "Cynnwys anhygyrch",
         "paragraph1": "Nid yw’r cynnwys a restrir isod yn hygyrch am y rhesymau canlynol.",
         "subHeader": "Diffyg cydymffurfio â’r rheoliadau hygyrchedd",
-        "paragraph2": "Pan fyddwch yn creu cyfrif neu fewngofnodi, os nad ydych yn gwneud unrhyw beth am 2 awr, bydd y broses yn stopio (amseru allan) neu byddwch yn cael eich allgofnodi. Nid yw yn bosib addasu, ymestyn na diffodd yr amseru allan. Mae hyn yn methu maen prawf llwyddiant WCAG 2.1  2.2.1 (Addasu Amseru)."
+        "paragraph2": "Pan fyddwch yn creu GOV.UK One Login neu fewngofnodi, os nad ydych yn gwneud unrhyw beth am 2 awr, bydd y broses yn stopio (amseru allan) neu byddwch yn cael eich allgofnodi. Nid yw’n bosibl addasu, ymestyn na diffodd yr amseru allan. Mae hyn yn methu maen prawf llwyddiant WCAG 2.1  2.2.1 (Addasu Amseru)."
       },
       "section8": {
         "header": "Beth rydym yn ei wneud i wella hygyrchedd",
@@ -802,63 +806,63 @@
       "section9": {
         "header": "Paratoi’r datganiad hygyrchedd hwn",
         "paragraph1": "Paratowyd y datganiad hwn ar 4 Tachwedd 2020. Cafodd ei adolygu ddiwethaf ar 29 Mehefin 2022.",
-        "paragraph2": "Cafodd cyfrifon GOV.UK eu profi ddiwethaf ar 13 Mehefin 2022. Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC), a gynhyrchodd adroddiad archwilio hygyrchedd ar 17 Mehefin 2022. Asesodd DAC gyfrifon GOV.UK yn erbyn y Canllawiau Hygyrchedd Cynnwys Gwe WCAG 2.1."
+        "paragraph2": "Cafodd GOV.UK One Login ei brofi ddiwethaf ar 13 Mehefin 2022. Cynhaliwyd y prawf gan y Ganolfan Hygyrchedd Digidol (DAC), a gynhyrchodd adroddiad archwilio hygyrchedd ar 17 Mehefin 2022. Asesodd DAC GOV.UK One Login yn erbyn y Canllawiau Hygyrchedd Cynnwys Gwe WCAG 2.1."
       }
     },
     "termsAndConditions": {
-      "title": "Telerau ac amodau cyfrif GOV.UK",
-      "header": "Telerau ac amodau cyfrif GOV.UK",
+      "title": "Telerau ac amodau GOV.UK One Login",
+      "header": "Telerau ac amodau GOV.UK One Login",
       "section1": {
         "paragraph1": {
-          "text1": "Mae’r telerau ac amodau hyn yn ymdrin yn benodol â chyfrifon GOV.UK. Gallwch ddefnyddio cyfrif GOV.UK i gael mynediad i a defnyddio rhai o wasanaethau a nodweddion y llywodraeth. Mae gan dudalennau sy’n rhan o’r cyfrif GOV.UK urlau sy’n cynnwys account.gov.uk. Os ydych yn defnyddio rhannau eraill o GOV.UK dylech hefyd ddarllen y ",
+          "text1": "Mae’r telerau ac amodau hyn yn ymdrin yn benodol â GOV.UK One Login. Gallwch ddefnyddio GOV.UK One Login i gael mynediad i a defnyddio rhai o wasanaethau a nodweddion y llywodraeth. Mae gan dudalennau sy’n rhan o GOV.UK One Login urls sy’n cynnwys account.gov.uk. Os ydych yn defnyddio rhannau eraill o GOV.UK dylech hefyd ddarllen y ",
           "linkText": "telerau ac amodau ar gyfer GOV.UK"
         },
         "paragraph2": {
-          "text1": "Rheolir y cyfrif GOV.UK gan ",
+          "text1": "Rheolir y GOV.UK One Login gan ",
           "linkText": "Gwasanaeth Digidol y Llywodraeth",
           "text2": " (GDS) ar ran y Goron. Mae GDS yn rhan o Swyddfa’r Cabinet a chaiff ei gyfeirio ato fel ’ni’ o hyn ymlaen."
         },
         "paragraph3": {
           "text1": "Darllenwch y telerau ac amodau hyn, yr ",
-          "linkText1": "hysbysiad preifatrwydd cyfrifon GOV.UK",
+          "linkText1": "hysbysiad preifatrwydd GOV.UK One Login",
           "text2": " a ",
           "linkText2": "Polisi cwcis cyfrifon GOV.UK",
-          "text3": "cyn defnyddio’r cyfrif GOV.UK. Mae’r hysbysiad preifatrwydd yn egluro’r telerau rydym yn prosesu unrhyw ddata personol y byddwn yn ei gasglu gennych neu eich bod yn ei ddarparu i ni. Mae’r polisi cwcis yn rhoi gwybodaeth am y cwcis rydym yn eu defnyddio a sut rydym yn eu defnyddio pan rydych yn defnyddio GOV.UK neu eich cyfrif GOV.UK."
+          "text3": "cyn defnyddio’r GOV.UK One Login. Mae’r hysbysiad preifatrwydd yn egluro’r telerau rydym yn prosesu unrhyw ddata personol y byddwn yn ei gasglu gennych neu eich bod yn ei ddarparu i ni. Mae’r polisi cwcis yn rhoi gwybodaeth am y cwcis rydym yn eu defnyddio a sut rydym yn eu defnyddio pan rydych yn defnyddio GOV.UK neu eich GOV.UK One Login."
         },
-        "paragraph4": "Drwy gofrestru ar gyfer a pharhau i ddefnyddio cyfrif GOV.UK, rydych yn cytuno i’r telerau ac amodau hyn, yr hysbysiad preifatrwydd a’r polisi cwcis.",
+        "paragraph4": "Drwy gofrestru ar gyfer a pharhau i ddefnyddio GOV.UK One Login, rydych yn cytuno i’r telerau ac amodau hyn, yr hysbysiad preifatrwydd a’r polisi cwcis.",
         "subHeader": "Newidiadau i’r telerau ac amodau hyn",
         "paragraph5": "Gallwn ddiweddaru’r telerau hyn, yn ogystal â’r polisi cwcis a’r hysbysiad preifatrwydd, ar unrhyw adeg heb rybudd.",
-        "paragraph6": "Os ydym yn newid y telerau ac amodau, byddwn yn gofyn i chi eu derbyn y tro nesaf y byddwch yn mewngofnodi i’ch cyfrif."
+        "paragraph6": "Os ydym yn newid y telerau ac amodau, byddwn yn gofyn i chi eu derbyn y tro nesaf y byddwch yn mewngofnodi i GOV.UK One Login."
       },
       "section2": {
-        "header": "Cael mynydiad i’ch cyfrif GOV.UK",
-        "paragraph1": "Rydych yn gyfrifol am wneud yr holl drefniadau i chi gael mynediad i’ch cyfrif GOV.UK. Mae hyn yn cynnwys darparu eich dyfais eich hun, system weithredu, porwr a chysylltiad rhyngrwyd. Dylech ddefnyddio dyfais sy’n defnyddio system weithredu Windows, OS, iOS neu Android. Rydym yn argymell eich bod yn defnyddio un o’r porwyr canlynol:",
+        "header": "Cael mynydiad i’ch GOV.UK One Login",
+        "paragraph1": "Rydych yn gyfrifol am wneud yr holl drefniadau i chi gael mynediad i’ch GOV.UK One Login. Mae hyn yn cynnwys darparu eich dyfais eich hun, system weithredu, porwr a chysylltiad rhyngrwyd. Dylech ddefnyddio dyfais sy’n defnyddio system weithredu Windows, OS, iOS neu Android. Rydym yn argymell eich bod yn defnyddio un o’r porwyr canlynol:",
         "bulletPoint1": "Y fersiwn diweddaraf o Google Chrome, Microsoft Edge, Mozilla Firefox, Samsung Internet neu Internet Explorer",
         "bulletPoint2": "Safari 12 neu ddiweddarach",
         "bulletPoint3": "Safari ar gyfer iOS 12.1 neu ddiweddarach",
-        "paragraph2": "Nid ydym yn gwarantu y bydd eich cyfrif GOV.UK bob amser ar gael, neu bydd y mynediad iddo yn ddi-wall. Byddwn yn darparu ffordd i chi roi gwybod am broblemau gyda’ch cyfrif.",
-        "paragraph3": "Gallwn atal, stopio, dileu, diweddaru neu newid y cyfrif GOV.UK heb rybudd ar unrhyw adeg."
+        "paragraph2": "Nid ydym yn gwarantu y bydd GOV.UK One Login bob amser ar gael, neu bydd y mynediad iddo yn ddi-wall. Byddwn yn darparu ffordd i chi roi gwybod am broblemau gyda GOV.UK One Login.",
+        "paragraph3": "Gallwn atal, stopio, dileu, diweddaru neu newid y GOV.UK One Login heb rybudd ar unrhyw adeg."
       },
       "section3": {
-        "header": "Cadw’ch cyfrif yn ddiogel",
+        "header": "Cadw eich GOV.UK One Login yn ddiogel",
         "paragraph1": {
-          "text1": "Mae gennym lawer o fesurau mewn lle i gadw’ch gwybodaeth yn ddiogel, ond fel perchennog eich cyfrif GOV.UK, mae gennych chi hefyd rywfaint o gyfrifoldeb am ddiogelwch eich cyfrif. Er enghraifft, dylech ddewis cyfrinair cryf ar gyfer eich cyfrif a sicrhau eich bod yn ei gadw’n ddiogel. Mae Canolfan Seiberddiogelwch Genedlaethol y DU (NCSC) yn darparu ",
-          "linkText": "cyngor ar gadw’ch cyfrifon ar-lein yn ddiogel"
+          "text1": "Mae gennym lawer o fesurau mewn lle i gadw’ch gwybodaeth yn ddiogel, ond fel perchennog eich GOV.UK One Login, mae gennych chi hefyd rywfaint o gyfrifoldeb am ei ddiogelwch. Er enghraifft, dylech ddewis cyfrinair cryf ar gyfer eich cyfrif a sicrhau eich bod yn ei gadw’n ddiogel. Mae Canolfan Seiberddiogelwch Genedlaethol y DU (NCSC) yn darparu ",
+          "linkText": "cyngor ddiogelwch ar-lein"
         },
-        "paragraph2": "Os ydych yn meddwl bod rhywun yn gwybod yr enw defnyddiwr a’r cyfrinair ar gyfer eich cyfrif GOV.UK, rhaid i chi ailosod eich cyfrinair cyn gynted â phosibl."
+        "paragraph2": "Os ydych yn meddwl bod rhywun yn gwybod yr enw defnyddiwr a’r cyfrinair ar gyfer eich GOV.UK One Login, rhaid i chi ailosod eich cyfrinair cyn gynted â phosibl."
       },
       "section4": {
-        "header": "Defnyddio eich cyfrif GOV.UK",
-        "paragraph1": "Byddwch yn defnyddio eich cyfrif i gael mynediad at wasanaethau’r llywodraeth ac i ddim pwrpas arall.",
+        "header": "Defnyddio eich GOV.UK One Login",
+        "paragraph1": "Byddwch yn defnyddio eich GOV.UK One Login i gael mynediad at wasanaethau’r llywodraeth ac nid at unrhyw  bwrpas arall.",
         "paragraph2": "Oni bai bod y gyfraith yn ei ganiatáu neu o dan y telerau ac amodau hyn, rhaid i chi:",
-        "bulletPoint1": "ddim copïo’r cyfrif GOV.UK ac eithrio lle mae copïo’n gysylltiedig â defnydd arferol",
-        "bulletPoint2": "ddim rhentu, prydlesu, is-drwyddedu, benthyca, cyfieithu, uno, addasu neu amrywio’r cyfrif GOV.UK",
-        "bulletPoint3": "ddim cyfuno neu’n ymgorffori’r cyfrif GOV.UK gydag unrhyw raglenni neu wasanaethau eraill",
-        "bulletPoint4": "peidio â dadosod, dadgrynhoi, gwrth-beiriannu na chreu gweithiau deilliadol yn seiliedig ar unrhyw ran o’r cyfrif",
-        "bulletPoint5": "cydymffurfio â’r holl ddeddfau rheoli technoleg neu allforio sy’n berthnasol i’r dechnoleg a ddefnyddir gan y cyfrif GOV.UK",
-        "paragraph3": "Rhaid i chi beidio defnyddio eich cyfrif GOV.UK:",
+        "bulletPoint1": "peidio â chopïo GOV.UK One Login ac eithrio lle mae copïo’n gysylltiedig â defnydd arferol",
+        "bulletPoint2": "peidio â rhentu, prydlesu, is-drwyddedu, benthyca, cyfieithu, uno, addasu neu amrywio GOV.UK One Login",
+        "bulletPoint3": "ddim cyfuno nac ymgorffori GOV.UK One Login gydag unrhyw raglenni neu wasanaethau eraill",
+        "bulletPoint4": "peidio â dadosod, dadgrynhoi, gwrth-beiriannu na chreu gweithiau deilliadol yn seiliedig ar unrhyw ran o GOV.UK One Login",
+        "bulletPoint5": "cydymffurfio â’r holl ddeddfau rheoli technoleg neu allforio sy’n berthnasol i’r dechnoleg a ddefnyddir gan GOV.UK One Login",
+        "paragraph3": "Rhaid i chi beidio â defnyddio eich GOV.UK One Login:",
         "bulletPoint6": "i drosglwyddo unrhyw ddeunydd sy’n sarhaus neu dramgwyddus",
-        "bulletPoint7": "i gasglu unrhyw ddata neu geisio difrïo unrhyw drosglwyddiadau i neu o’r gweinyddwyr sy’n rhedeg GOV.UK cyfrif",
+        "bulletPoint7": "i gasglu unrhyw ddata neu geisio difrïo unrhyw drosglwyddiadau i neu o’r gweinyddwyr sy’n rhedeg GOV.UK One Login",
         "bulletPoint8": "mewn ffordd a allai niweidio, analluogi, gorbwysleisio, amharu neu gyfaddawdu ein systemau neu ddiogelwch",
         "bulletPoint9": "mewn ffordd sy’n ymyrryd â defnyddwyr eraill",
         "bulletPoint10": "mewn unrhyw ddull anghyfreithlon neu dwyllodrus neu at unrhyw bwrpas anghyfreithlon neu dwyllodrus",
@@ -867,12 +871,12 @@
         "bulletPoint13": "i drosglwyddo, anfon neu uwchlwytho unrhyw ddata sy’n cynnwys firysau, ceffylau Trojan, mwydod, spyware neu unrhyw raglenni niweidiol eraill a gynlluniwyd i effeithio’n andwyol ar weithrediad meddalwedd neu galedwedd cyfrifiadurol",
         "bulletPoint14": "mewn cysylltiad ag unrhyw fath o ymosodiad gwadu gwasanaeth neu at unrhyw bwrpas maleisus",
         "bulletPoint15": "gyda manylion cofrestredig rhywun arall, oni bai bod gennych yr awdurdod i wneud hynny ganddynt hwy",
-        "paragraph4": "Os byddwch yn torri unrhyw un o’r telerau ac amodau hyn, gallwn eich atal rhag cael mynediad i’ch cyfrif GOV.UK a gallwn gymryd camau i orfodi’r telerau ac amodau hyn a chymryd camau eraill fel y bo’n briodol lle rydym wedi dioddef colled. Os, drwy wneud unrhyw un o’r gweithredoedd uchod, rydych hefyd yn cyflawni trosedd, gallwn roi gwybod i’r awdurdodau gorfodi’r gyfraith perthnasol. Efallai y byddwn yn cydweithredu â’r awdurdodau hynny drwy ddatgelu eich hunaniaeth iddynt hwy."
+        "paragraph4": "Os byddwch yn torri unrhyw un o’r telerau ac amodau hyn, gallwn eich atal rhag cael mynediad i’ch GOV.UK One Login a gallwn gymryd camau i orfodi’r telerau ac amodau hyn a chymryd camau eraill fel y bo’n briodol lle rydym wedi dioddef colled. Os, drwy wneud unrhyw un o’r gweithredoedd uchod, rydych hefyd yn cyflawni trosedd, gallwn roi gwybod i’r awdurdodau gorfodi’r gyfraith perthnasol. Efallai y byddwn yn cydweithredu â’r awdurdodau hynny drwy ddatgelu eich hunaniaeth iddynt hwy."
       },
       "section5": {
-        "header": "Dileu eich cyfrif",
+        "header": "Dileu eich GOV.UK One Login",
         "paragraph1": {
-          "text1": "Gallwch ddileu eich cyfrif a’r wybodaeth ynddo yn barhaol ar unrhyw adeg trwy fewngofnodi i’ch cyfrif neu ",
+          "text1": "Gallwch ddileu eich GOV.UK One Login a’r wybodaeth ynddo yn barhaol ar unrhyw adeg drwy fewngofnodi neu ",
           "linkText1": "gysylltu â ni",
           "text2": "Byddwn yn cadw cofnod o wybodaeth benodol, yn unol â’n ",
           "linkText2": "hysbysiad preifatrwydd",
@@ -881,7 +885,7 @@
       },
       "section6": {
         "header": "Newidiadau",
-        "paragraph1": "Gallwn wneud newidiadau a gwelliannau i’r cyfrif GOV.UK ar unrhyw adeg a heb rybudd i:",
+        "paragraph1": "Gallwn wneud newidiadau a gwelliannau i GOV.UK One Login ar unrhyw adeg a heb rybudd i:",
         "bulletPoint1": "gwneud gwelliannau technegol neu gywiriadau",
         "bulletPoint2": "gwella perfformiad y gwasanaeth",
         "bulletPoint3": "gwella ymarferoldeb",
@@ -891,30 +895,30 @@
       },
       "section7": {
         "header": "Gwasanaethau a thrafodion",
-        "paragraph1": "Gallwch ddefnyddio eich cyfrif GOV.UK i gael mynediad at wasanaethau’r llywodraeth ar-lein. Gall y gwasanaethau hyn gael eu rheoli gan GDS, Swyddfa’r Cabinet neu adran neu asiantaeth arall o’r llywodraeth.",
+        "paragraph1": "Gallwch ddefnyddio eich GOV.UK One Login i gael mynediad at wasanaethau ar-lein y llywodraeth. Gall y gwasanaethau hyn gael eu rheoli gan GDS, Swyddfa’r Cabinet neu adran neu asiantaeth arall o’r llywodraeth.",
         "paragraph2": "Bydd gan bob gwasanaeth ei delerau ac amodau hysbysiadau preifatrwydd a pholisïau cwcis ei hun, ar wahân, sy’n berthnasol i’r defnydd o’r gwasanaeth hwnnw. Dylech ddarllen rhain cyn defnyddio’r gwasanaeth.",
-        "paragraph3": "Os yw gwasanaeth sy’n cael ei redeg gan adran neu asiantaeth arall y llywodraeth yn stopio bod yn hygyrch gyda chyfrifon GOV.UK bydd y gwasanaeth yn cysylltu â chi i ddweud wrthych beth ddylech ei wneud."
+        "paragraph3": "Os yw gwasanaeth sy’n cael ei redeg gan adran neu asiantaeth arall y llywodraeth yn stopio bod yn hygyrch gyda GOV.UK One Login bydd y gwasanaeth yn cysylltu â chi i ddweud wrthych beth ddylech ei wneud."
       },
       "section8": {
         "header": "Ein cyfrifoldeb cyfreithiol i chi",
-        "paragraph1": "Mae’r cyfrif GOV.UK yn offeryn ac nid oes gennym unrhyw atebolrwydd i chi ar gyfer gwasanaethau’r llywodraeth ar-lein rydych yn cael mynediad atynt gan ddefnyddio’r cyfrif GOV.UK. Mae atebolrwydd i chi yn disgyn i ddarparwr gwasanaeth y llywodraeth.",
-        "paragraph2": "Er ein bod yn gwneud ymdrechion rhesymol i ddarparu, cynnal a diweddaru gwasanaeth cyfrif GOV.UK cadarn, fe’i darperir ’fel y mae’. Nid ydym yn gwneud unrhyw sylwadau mynegiannol neu ymhlyg neu warantau y bydd eich mynediad at, neu ddefnydd o, gyfrif GOV.UK, yn ddi-dor neu’n gwbl ddiogel.",
-        "paragraph3": "Ni fyddwn yn atebol nac yn gyfrifol am unrhyw golled neu ddifrod a achosir gan feirws, ymosodiad atal gwasanaeth neu unrhyw ddeunydd niweidiol arall a all heintio’ch dyfais, offer, rhaglenni, data neu ddeunydd perchnogol arall oherwydd eich defnydd o gyfrif GOV.UK.",
+        "paragraph1": "Mae’r GOV.UK One Login yn declyn ac nid oes gennym unrhyw atebolrwydd i chi ar gyfer gwasanaethau ar-lein y llywodraeth rydych yn cael mynediad atynt gan ddefnyddio GOV.UK One Login. Darparwr gwasanaeth y llywodraeth sy’n atebol i chi.",
+        "paragraph2": "Er ein bod yn gwneud ymdrechion rhesymol i ddarparu, cynnal a diweddaru gwasanaeth GOV.UK One Login cadarn, fe’i darperir ’fel y mae’. Nid ydym yn gwneud unrhyw sylwadau mynegiannol nac ymhlyg neu warantau y bydd eich mynediad at, neu ddefnydd o, GOV.UK One Login, yn ddi-dor neu’n gwbl ddiogel.",
+        "paragraph3": "Ni fyddwn yn atebol nac yn gyfrifol am unrhyw golled neu ddifrod a achosir gan feirws, ymosodiad atal gwasanaeth neu unrhyw ddeunydd niweidiol arall a all heintio’ch dyfais, offer, rhaglenni, data neu ddeunydd perchnogol arall oherwydd eich defnydd o GOV.UK One Login.",
         "subHeader1": "Colled a difrod",
         "paragraph4": "Nid oes dim byd yn y telerau ac amodau hyn yn eithrio neu’n cyfyngu ar ein rhwymedigaeth am:",
         "bulletPoint1": "marwolaeth neu anaf personol o ganlyniad i’n esgeulustod",
         "bulletPoint2": "twyll neu gamliwio twyllodrus",
         "bulletPoint3": "unrhyw atebolrwydd arall na ellir ei eithrio neu ei gyfyngu o dan gyfraith Lloegr",
         "paragraph5": "Nid ydym yn atebol am unrhyw:",
-        "bulletPoint4": "colled neu ddifrod a allai ddod o ddefnyddio’r cyfrif GOV.UK nad yw’n cael ei achosi oherwydd i ni dorri’r telerau ac amodau hyn",
+        "bulletPoint4": "colled neu ddifrod a allai ddod o ddefnyddio GOV.UK One Login nad yw’n cael ei achosi oherwydd i ni dorri’r telerau ac amodau hyn",
         "bulletPoint5": "colled neu ddifrod i ddyfais neu gynnwys digidol sy’n perthyn i chi",
-        "bulletPoint6": "colled neu ddifrod sy’n deillio o anallu i gael mynediad neu ddefnyddio eich cyfrif GOV.UK",
-        "bulletPoint7": "colledion anuniongyrchol neu ddilynol na ellid eu rhagweld i chi a ni pan ddechreuoch ddefnyddio eich cyfrif GOV.UK (mae colled neu iawndal yn ’rhagweladwy’ pan fyddant yn ganlyniad amlwg o  ni’n torri’r telerau ac amodau hyn neu os oeddent yn cael eu hystyried gennych chi a ni pan ddechreuoch ddefnyddio’r cyfrif GOV.UK)",
+        "bulletPoint6": "colled neu ddifrod sy’n deillio o anallu i gael mynediad neu ddefnyddio eich GOV.UK One Login",
+        "bulletPoint7": "colledion anuniongyrchol neu ddilynol nad oedd modd i chi a ni eu rhagweld pan ddechreuoch ddefnyddio GOV.UK One Login (mae colled neu iawndal yn ’rhagweladwy’ pan fyddant yn ganlyniad amlwg i ni dorri’r telerau ac amodau hyn neu os oeddent yn cael eu hystyried gennych chi a ni pan ddechreuoch ddefnyddio GOV.UK One Login)",
         "bulletPoint8": "colli elw, refeniw, contractau, cynilion, ewyllys da a gwariant wedi’i wastraffu",
         "paragraph6": "Nid yw GDS yn atebol am ei fethiant i gydymffurfio â’r telerau ac amodau oherwydd amgylchiadau sydd y tu hwnt i reolaeth GDS.",
         "paragraph7": "Nid yw hyn yn effeithio ar unrhyw hawliau cyfreithiol sydd gennych fel defnyddiwr mewn perthynas â gwasanaethau neu feddalwedd diffygiol. Ceir cyngor am eich hawliau cyfreithiol gan eich Cyngor ar Bopeth leol neu Swyddfa Safonau Masnach.",
-        "subHeader2": "Dolenni o’r cyfrif GOV.UK",
-        "paragraph8": "Nid ydym yn gyfrifol am unrhyw ddolenni o’ch cyfrif GOV.UK i wefannau sy’n cael eu rheoli gan adrannau ac asiantaethau eraill y llywodraeth, darparwyr gwasanaethau neu sefydliadau eraill. Nid oes gennym unrhyw reolaeth dros y cynnwys ar y gwefannau hyn.",
+        "subHeader2": "Dolenni o GOV.UK One Login",
+        "paragraph8": "Nid ydym yn gyfrifol am unrhyw ddolenni o’ch GOV.UK One Login i wefannau sy’n cael eu rheoli gan adrannau ac asiantaethau eraill y llywodraeth, darparwyr gwasanaethau neu sefydliadau eraill. Nid oes gennym unrhyw reolaeth dros y cynnwys ar y gwefannau hyn.",
         "paragraph9": "Nid ydym yn gyfrifol am:",
         "bulletPoint9": "ddiogelu unrhyw wybodaeth rydych yn ei roi i’r gwefannau hyn",
         "bulletPoint10": "unrhyw golled neu ddifrod a allai ddod o’ch defnydd o’r gwefannau hyn, neu unrhyw wefannau eraill y maent yn cysylltu â hwy",
@@ -928,7 +932,7 @@
       },
       "section10": {
         "header": "Cyfraith lywodraethol",
-        "paragraph1": "Mae cyfreithiau Lloegr yn berthnasol yn unig i’r telerau ac amodau hyn ac i’r holl faterion sy’n ymwneud â defnyddio cyfrifon GOV.UK. Bydd unrhyw achos gweithredu sy’n codi o dan neu mewn cysylltiad â’r telerau ac amodau hyn neu eich defnydd o gyfrifon GOV.UK yn ddarostyngedig i awdurdodaeth unigryw llysoedd Lloegr."
+        "paragraph1": "Mae cyfreithiau Lloegr yn berthnasol yn unig i’r telerau ac amodau hyn ac i’r holl faterion sy’n ymwneud â defnyddio GOV.UK One Login. Bydd unrhyw achos gweithredu sy’n codi o dan neu mewn cysylltiad â’r telerau ac amodau hyn neu eich defnydd o GOV.UK One Login yn ddarostyngedig i awdurdodaeth unigryw llysoedd Lloegr."
       },
       "section11": {
         "header": "Cysylltu â ni",
@@ -937,7 +941,7 @@
           "text1": " os oes gennych:"
         },
         "bulletPoint1": "cwestiynau am y telerau ac amodau hyn",
-        "bulletPoint2": "cwestiynau neu gŵyn am y cyfrif GOV.UK",
+        "bulletPoint2": "cwestiynau neu gŵyn am GOV.UK One Login",
         "paragraph2": {
           "text1": "Darganfyddwch fwy ",
           "linkText": "am GDS a’n rôl"
@@ -945,26 +949,26 @@
       }
     },
     "privacy": {
-      "title": "Hysbysiad preifatrwydd cyfrifon GOV.UK",
-      "header": "Hysbysiad preifatrwydd cyfrifon GOV.UK",
+      "title": "Hysbysiad preifatrwydd GOV.UK One Login",
+      "header": "Hysbysiad preifatrwydd GOV.UK One Login",
       "section1": {
         "header": "Pwy ydym ni",
         "paragraph1": {
-          "text1": "Mae cyfrifon GOV.UK yn cael eu darparu gan ",
+          "text1": "Mae GOV.UK One Login yn cael ei ddarparu gan ",
           "linkText": "Gwasanaeth Digidol y Llywodraeth (GDS)",
           "text2": ", rhan o Swyddfa’r Cabinet. Mae sôn am ’ni’ yn yr hysbysiad preifatrwydd hwn yn cyfeirio at GDS."
         },
         "paragraph2": {
-          "text1": "Mae’r hysbysiad preifatrwydd hwn ond yn cwmpasu cyfrifon GOV.UK. Darllenwch brif ",
+          "text1": "Mae’r hysbysiad preifatrwydd hwn ond yn cwmpasu GOV.UK One Login. Darllenwch brif ",
           "linkText": "hysbysiad preifatrwydd GOV.UK",
           "text2": " i ddarganfod sut mae eich gwybodaeth bersonol yn cael ei chasglu a’i phrosesu pan fyddwch yn defnyddio’r wefan GOV.UK."
         },
         "paragraph3": "Swyddfa’r Cabinet yw rheolydd data’r wybodaeth bersonol a ddarperir gennych i ni pan fyddwch yn:",
-        "bulletPoint1": "creu cyfrif GOV.UK",
-        "bulletPoint2": "defnyddio eich cyfrif GOV.UK i gael mynediad at wasanaeth ar-lein y llywodraeth",
+        "bulletPoint1": "creu GOV.UK One Login",
+        "bulletPoint2": "defnyddio eich GOV.UK One Login i gael mynediad at wasanaeth ar-lein y llywodraeth",
         "bulletPoint3": "cysylltu â ni",
-        "paragraph4": "Pan fyddwch yn darparu gwybodaeth i wasanaeth arall y llywodraeth tra rydych wedi mewngofnodi i’ch cyfrif, yr adran o’r llywodraeth sy’n rhedeg y gwasanaeth yw’r rheolwr data. Bydd ganddynt eu hysbysiad preifatrwydd eu hunain i egluro sut maent yn prosesu’ch gwybodaeth. Nid oes gennym fynediad i’r wybodaeth rydych yn ei darparu i wasanaethau sy’n cael eu rhedeg gan adrannau eraill y llywodraeth.",
-        "paragraph5": "Pan fyddwch yn profi eich hunaniaeth gyda chyfrif GOV.UK, byddwn yn:",
+        "paragraph4": "Pan fyddwch yn darparu gwybodaeth i wasanaeth arall y llywodraeth tra rydych wedi mewngofnodi i GOV.UK One Login, yr adran o’r llywodraeth sy’n rhedeg y gwasanaeth yw’r rheolwr data. Bydd ganddynt eu hysbysiad preifatrwydd eu hunain i egluro sut maent yn prosesu’ch gwybodaeth. Nid oes gennym fynediad i’r wybodaeth rydych yn ei darparu i wasanaethau sy’n cael eu rhedeg gan adrannau eraill y llywodraeth.",
+        "paragraph5": "Pan fyddwch yn profi eich hunaniaeth gyda GOV.UK One Login, byddwn yn:",
         "bulletPoint4": "gofyn i chi am fanylion eich pasbort - byddwn yn gwirio’r rhain gyda Swyddfa Pasbort EM (HMPO)",
         "bulletPoint5": {
           "text3": "gwirio eich gwybodaeth gyda",
@@ -977,32 +981,32 @@
       },
       "section2": {
         "header": "Pa wybodaeth rydym yn ei chasglu",
-        "paragraph1": "Pan fyddwch yn defnyddio gwasanaeth sydd angen cyfrif GOV.UK, byddwn yn derbyn gwybodaeth am y gwasanaeth pan fydd yn eich cyfeirio at:",
-        "bulletPoint1": "creu neu fewngofnodi i mewn i gyfrif",
+        "paragraph1": "Pan fyddwch yn defnyddio gwasanaeth sydd angen GOV.UK One Login, byddwn yn derbyn gwybodaeth am y gwasanaeth pan fydd yn eich cyfeirio at:",
+        "bulletPoint1": "creu GOV.UK One Login neu fewngofnodi",
         "bulletPoint2": "profi eich hunaniaeth",
-        "paragraph2": "Mae’r wybodaeth rydym yn ei chasglu pan fyddwch yn creu ac yn defnyddio cyfrif GOV.UK yn cynnwys:",
-        "bulletPoint3": "gwybodaeth bersonol sylfaenol sydd ei angen i sefydlu a dilysu eich cyfrif, gan gynnwys eich cyfeiriad e-bost a rhif ffôn symudol",
+        "paragraph2": "Mae’r wybodaeth rydym yn ei chasglu pan fyddwch yn creu ac yn defnyddio GOV.UK One Login yn cynnwys:",
+        "bulletPoint3": "gwybodaeth bersonol sylfaenol sydd ei hangen i sefydlu a dilysu eich GOV.UK One Login, gan gynnwys eich cyfeiriad e-bost a rhif ffôn symudol, os ydych yn dewis cael codau diogelwch ar gyfer mewngofnodi drwy neges destun",
         "bulletPoint4": "gwybodaeth arall sydd ei angen i brofi pwy ydych chi, fel eich enw, dyddiad geni, manylion pasbort a hanes cyfeiriad",
-        "bulletPoint5": "unrhyw wybodaeth rydych yn dewis ei arbed i’ch cyfrif, er enghraifft eich dewisiadau tanysgrifio e-bost GOV.UK",
+        "bulletPoint5": "unrhyw wybodaeth rydych yn dewis ei harbed i’ch GOV.UK One Login, er enghraifft eich dewisiadau tanysgrifio e-bost GOV.UK",
         "bulletPoint6": {
-          "text1": "gwybodaeth am sut rydych yn defnyddio eich cyfrif a gwefan GOV.UK, sy’n cael ei gasglu yng nghofnodion y system, a chan gwcis Google Analytics os ydych yn rhoi caniatâd - mae’r ",
+          "text1": "gwybodaeth am sut rydych yn defnyddio eich GOV.UK One Login a gwefan GOV.UK, sy’n cael ei gasglu yng nghofnodion y system, a chan gwcis Google Analytics os ydych yn rhoi caniatâd - mae’r ",
           "linkText1": "hysbysiad preifatrwydd GOV.UK",
-          "comma": " , ",
+          "comma": ", ",
           "linkText2": "pholisi cwcis GOV.UK",
           "and": " a ",
-          "linkText3": "Polisi cwcis cyfrifon GOV.UK",
+          "linkText3": "polisi cwcis GOV.UK One Login",
           "text2": " yn darparu mwy o wybodaeth am hyn"
         },
         "bulletPoint7": "dynodwyr ar-lein, fel eich cyfeiriad Protocol Rhyngrwyd (IP), a gwybodaeth dechnegol am y ddyfais rydych yn ei defnyddio gan gynnwys y model, porwr gwe a system weithredu, sy’n cael ei gasglu’n awtomatig mewn cofnodion system pan fyddwch yn defnyddio GOV.UK",
-        "bulletPoint8": "cwestiynau, ymholiadau neu adborth rydych yn eu gadael, gan gynnwys eich enw a’ch cyfeiriad e-bost, os byddwch yn eu darparu ar y ffurflen gyswllt cyfrifon GOV.UK",
-        "bulletPoint9": "os oeddech chi’n gallu profi eich hunaniaeth gyda’ch cyfrif GOV.UK",
+        "bulletPoint8": "cwestiynau, ymholiadau neu adborth rydych yn eu gadael, gan gynnwys eich enw a’ch cyfeiriad e-bost, os byddwch yn eu darparu ar y ffurflen gyswllt GOV.UK One Login",
+        "bulletPoint9": "os oeddech chi’n gallu profi eich hunaniaeth gyda’ch GOV.UK One Login",
         "bulletPoint10": "pa sefydliadau, gwasanaethau neu wybodaeth roeddem yn eu defnyddio i brofi pwy ydych chi",
-        "paragraph3": "Pan fyddwch yn creu cyfrif, bydd yn cynhyrchu dynodwr cyfrif unigryw yn awtomatig."
+        "paragraph3": "Pan fyddwch yn creu GOV.UK One Login, bydd yn cynhyrchu dynodwr cyfrif unigryw yn awtomatig."
       },
       "section3": {
         "header": "Pam rydym angen eich gwybodaeth",
         "paragraph1": "Rydym yn casglu eich gwybodaeth bersonol i:",
-        "bulletPoint1": "ddarparu cyfrif GOV.UK i chi fel y gallwch ei ddefnyddio i gael mynediad at wasanaethau ar-lein y llywodraeth",
+        "bulletPoint1": "ddarparu GOV.UK One Login i chi fel y gallwch ei ddefnyddio i gael mynediad at wasanaethau ar-lein y llywodraeth",
         "bulletPoint2": "profi eich hunaniaeth",
         "bulletPoint3": {
           "text1": "cadw eich dewisiadau, er enghraifft eich dewisiadau diweddaru tanysgrifiad e-bost ",
@@ -1012,25 +1016,25 @@
         "paragraph2": "Rydym hefyd yn defnyddio eich gwybodaeth i:",
         "bulletPoint4": "cadw eich cyfrif yn ddiogel (gan ddefnyddio eich cyfeiriad e-bost, rhif ffôn, cyfrinair a chofnodion system)",
         "bulletPoint5": "monitro, canfod ac ymchwilio i dwyll",
-        "bulletPoint6": "dweud wrth y gwasanaethau rydych yn eu cyrchu trwy eich cyfrif GOV.UK eich bod wedi mewngofnodi’n llwyddiannus",
-        "bulletPoint7": "rhoi i’r gwasanaethau’r llywodraeth rydych yn eu cyrchu trwy eich cyfrif a’r adrannau sy’n eu rhedeg y wybodaeth rydych yn cytuno’n benodol i ni rannu, er enghraifft eich e-bost a’ch rhif ffôn",
-        "bulletPoint8": "eich darparu gyda chofnod o sut mae eich cyfrif wedi cael ei ddefnyddio, er enghraifft, pryd y mewngofnodwyd ddiwethaf a pha wasanaethau y mae wedi cael ei ddefnyddio gyda nhw",
-        "bulletPoint9": "cysylltu â chi am unrhyw doriadau, problemau neu newidiadau arfaethedig a allai effeithio ar eich cyfrif (gan ddefnyddio eich cyfeiriad e-bost)",
-        "bulletPoint10": "cysylltu â chi i ofyn am adborth ar eich cyfrif, os ydych wedi rhoi caniatâd i ni (gan ddefnyddio eich cyfeiriad e-bost)",
+        "bulletPoint6": "dweud wrth y gwasanaethau rydych yn eu cyrchu trwy eich GOV.UK One Login eich bod wedi mewngofnodi’n llwyddiannus",
+        "bulletPoint7": "rhoi i’r gwasanaethau’r llywodraeth rydych yn eu cyrchu trwy eich GOV.UK One Login a’r adrannau sy’n eu rhedeg â gwybodaeth rydych yn cytuno’n benodol i ni ei rhannu, er enghraifft eich e-bost a’ch rhif ffôn",
+        "bulletPoint8": "eich darparu gyda chofnod o sut mae eich GOV.UK One Login wedi cael ei ddefnyddio, er enghraifft, pryd y’i mewngofnodwyd ddiwethaf a pha wasanaethau y mae wedi cael ei ddefnyddio gyda nhw",
+        "bulletPoint9": "cysylltu â chi am unrhyw doriadau, problemau neu newidiadau arfaethedig a allai effeithio ar eich GOV.UK One Login (gan ddefnyddio eich cyfeiriad e-bost)",
+        "bulletPoint10": "cysylltu â chi i ofyn am adborth ar eich GOV.UK One Login, os ydych wedi rhoi caniatâd i ni (gan ddefnyddio eich cyfeiriad e-bost)",
         "bulletPoint11": {
-          "text3": "gwella a deall sut rydych yn defnyddio eich cyfrif GOV.UK",
+          "text3": "gwella a deall sut rydych yn defnyddio eich GOV.UK One Login",
           "linkText": "defnyddio cwcis Google Analytics",
           "text4": "(gallwch ddewis peidio â derbyn y cwcis hyn)"
         },
         "bulletPoint12": "ymateb i unrhyw adborth rydych yn ei anfon atom, os ydych chi wedi gofyn i ni wneud",
-        "paragraph3": "Gallwn hefyd ddefnyddio eich gwybodaeth i gynhyrchu adroddiadau dienw am gyfrifon GOV.UK. Mae hyn yn ein helpu i ddeall lle y gallwn wneud gwelliannau i gyfrifon GOV.UK."
+        "paragraph3": "Gallwn hefyd ddefnyddio eich gwybodaeth i gynhyrchu adroddiadau dienw am GOV.UK One Login. Mae hyn yn ein helpu i ddeall lle y gallwn wneud gwelliannau i GOV.UK One Login."
       },
       "section4": {
         "header": "Ein sail gyfreithiol dros brosesu’ch gwybodaeth",
         "paragraph1": "Pan fyddwn yn prosesu gwybodaeth ar gyfer monitro diogelwch a thwyll, y sail gyfreithiol yw ein buddiannau cyfreithlon.",
-        "paragraph2": "Pan fyddwn yn prosesu gwybodaeth i wneud gwelliannau i gyfrifon GOV.UK, y sail gyfreithiol yw eich caniatâd penodol. Mae hyn yn cynnwys:",
-        "bulletPoint1": "casglu a dadansoddi gwybodaeth am sut rydych yn defnyddio eich cyfrif GOV.UK gan ddefnyddio cwcis Google Analytics",
-        "bulletPoint2": "anfon e-bost atoch i ofyn am adborth am eich cyfrif",
+        "paragraph2": "Pan fyddwn yn prosesu gwybodaeth i wneud gwelliannau i GOV.UK One Login, y sail gyfreithiol yw eich caniatâd penodol. Mae hyn yn cynnwys:",
+        "bulletPoint1": "casglu a dadansoddi gwybodaeth am sut rydych yn defnyddio eich GOV.UK One Login gan ddefnyddio cwcis Google Analytics",
+        "bulletPoint2": "anfon e-bost atoch i ofyn am adborth am GOV.UK One Login",
         "paragraph3": "Y sail gyfreithiol ar gyfer prosesu’r holl ddata personol arall yw ei fod yn angenrheidiol wrth arfer ein swyddogaethau fel adran o’r llywodraeth."
       },
       "section5": {
@@ -1039,15 +1043,15 @@
         "bulletPoint1": "gwerthu neu rentu eich gwybodaeth i drydydd partïon",
         "bulletPoint2": "rhannu eich gwybodaeth gyda thrydydd partïon at ddibenion marchnata",
         "subHeader1": "Rhannu eich gwybodaeth gyda gwasanaethau ar-lein y llywodraeth a’r adrannau sy’n eu rhedeg",
-        "paragraph2": "Byddwn yn dweud wrth y gwasanaethau y byddwch yn cyrchu trwy eich cyfrif pan fyddwch yn llwyddo i greu eich cyfrif neu’n mewngofnodi fel y gallant ganiatáu i chi ddefnyddio’r gwasanaeth.",
-        "paragraph3": "Efallai y bydd gwasanaethau rydych yn eu cyrchu trwy eich cyfrif yn gofyn i chi rannu gwybodaeth rydych wedi ei arbed yn eich cyfrif GOV.UK. Pan fyddant yn gwneud hyn, byddwn yn dweud wrthych pa wybodaeth maent wedi gofyn amdano, a byddwn ond yn rhannu’r wybodaeth os ydych yn cytuno.",
-        "paragraph4": "Os nad ydych yn dewis rhannu’r wybodaeth hon o’ch cyfrif GOV.UK, efallai y gofynnir i chi ddarparu’r un wybodaeth yn uniongyrchol i’r gwasanaeth yn nes ymlaen.",
-        "paragraph5": "Bydd gan bob gwasanaeth y byddwch yn cyrchu drwy eich cyfrif GOV.UK ei delerau ac amodau a’i hysbysiad preifatrwydd ei hun. Dylech ddarllen y rhain yn ogystal â thelerau ac amodau cyfrifon GOV.UK a’r hysbysiad preifatrwydd hwn, fel eich bod yn deall sut mae eich gwybodaeth bersonol yn cael ei rheoli.",
+        "paragraph2": "Byddwn yn dweud wrth y gwasanaethau y byddwch yn cyrchu trwy eich cyfrif pan fyddwch yn llwyddo i greu eich GOV.UK One Login neu’n mewngofnodi fel y gallant ganiatáu i chi ddefnyddio’r gwasanaeth.",
+        "paragraph3": "Efallai y bydd gwasanaethau rydych yn eu cyrchu trwy eich cyfrif yn gofyn i chi rannu gwybodaeth rydych wedi ei harbed yn eich GOV.UK One Login. Pan fyddant yn gwneud hyn, byddwn yn dweud wrthych pa wybodaeth maent wedi gofyn amdani, a byddwn ond yn rhannu’r wybodaeth os ydych yn cytuno.",
+        "paragraph4": "Os nad ydych yn dewis rhannu’r wybodaeth hon o’ch GOV.UK One Login, efallai y gofynnir i chi ddarparu’r un wybodaeth yn uniongyrchol i’r gwasanaeth yn nes ymlaen.",
+        "paragraph5": "Bydd gan bob gwasanaeth y byddwch yn cyrchu drwy eich GOV.UK One Login ei delerau ac amodau a’i hysbysiad preifatrwydd ei hun. Dylech ddarllen y rhain yn ogystal â thelerau ac amodau GOV.UK One Login a’r hysbysiad preifatrwydd hwn, fel eich bod yn deall sut mae eich gwybodaeth bersonol yn cael ei rheoli.",
         "subHeader2": "Rhannu eich gwybodaeth i brofi pwy ydych chi",
         "paragraph6": "Byddwn yn rhannu eich gwybodaeth gyda HMPO ac Experian pan fyddwn yn profi eich hunaniaeth. Byddwn ond yn rhoi’r wybodaeth maent ei hangen i wneud y gwiriad hwn. Byddant yn cadw eich manylion cyhyd ag y mae angen iddynt neu bod y gyfraith angen iddynt wneud hynny.",
         "subHeader3": "Rhannu eich gwybodaeth i amddiffyn rhag twyll",
         "paragraph7": "Er mwyn amddiffyn rhag trosedd a thwyll, efallai y byddwn weithiau’n rhannu gwybodaeth gyda:",
-        "bulletPoint3": "adrannau’r llywodraeth sy’n rhedeg y gwasanaethau rydych yn eu cyrchu drwy eich cyfrif",
+        "bulletPoint3": "adrannau’r llywodraeth sy’n rhedeg y gwasanaethau rydych yn eu cyrchu drwy eich GOV.UK One Login",
         "bulletPoint4": "sefydliadau eraill yn y sector cyhoeddus, megis y Swyddfa Gartref",
         "bulletPoint5": "asiantaethau gorfodi’r gyfraith",
         "bulletPoint6": "asiantaethau cyfeirio credyd",
@@ -1056,7 +1060,7 @@
         "bulletPoint8": "rhifau ffôn",
         "bulletPoint9": "cyfeiriadau e-bost",
         "bulletPoint10": "cyfeiriadau a lleoliadau IP",
-        "bulletPoint11": "dynodwyr cyfrif unigryw",
+        "bulletPoint11": "dynodwyr unigryw",
         "bulletPoint12": "gwybodaeth am y dyfeisiau sy’n cael eu defnyddio",
         "bulletPoint13": "manylion pasbort, gan gynnwys enw a dyddiad geni",
         "bulletPoint14": "hanes cyfeiriad",
@@ -1066,29 +1070,29 @@
       "section6": {
         "header": "Pa mor hir rydym yn cadw eich gwybodaeth",
         "paragraph1": "Rydym yn storio eich gwybodaeth bersonol cyhyd ag y bo’n rhesymol angenrheidiol a chyfiawn yn gyfreithiol.",
-        "paragraph2": "Byddwn yn cadw eich cyfrif ac unrhyw wybodaeth a arbedir ynddo cyhyd ag y byddwch yn ei ddefnyddio. Os ydych yn dileu eich cyfrif neu os na fyddwch yn mewngofnodi am 2 flynedd, byddwn yn dileu’r holl wybodaeth sy’n gysylltiedig ag ef. Bydd unrhyw wybodaeth rydych yn ei ddileu o’ch cyfrif yn cael ei dileu yn barhaol.",
+        "paragraph2": "Byddwn yn cadw eich GOV.UK One Login ac unrhyw wybodaeth a arbedir ynddo cyhyd ag y byddwch yn ei ddefnyddio. Os ydych yn dileu eich GOV.UK One Login neu os na fyddwch yn mewngofnodi am 2 flynedd, byddwn yn dileu’r holl wybodaeth sy’n gysylltiedig ag ef. Bydd unrhyw wybodaeth rydych yn ei dileu o’ch GOV.UK One Login yn cael ei dileu yn barhaol.",
         "paragraph3": "Byddwn yn cadw eich data adborth am 2 flynedd.",
         "paragraph4": "Byddwn yn dileu cofnod mynediad data ar ôl 365 diwrnod.",
-        "paragraph5": "Byddwn yn storio gwybodaeth am y camau rydych yn eu cymryd a sut rydych yn defnyddio’r cyfrif am 7 mlynedd, at ddibenion monitro twyll."
+        "paragraph5": "Byddwn yn storio gwybodaeth am y camau rydych yn eu cymryd a sut rydych yn defnyddio GOV.UK One Login am 7 mlynedd, at ddibenion monitro twyll."
       },
       "section7": {
         "header": "Amddiffyn preifatrwydd plant",
-        "paragraph1": "Nid yw cyfrifon GOV.UK wedi’u cynllunio, neu wedi’u targedu’n fwriadol, ar gyfer plant 13 oed neu iau. Nid ydym yn casglu na chadw gwybodaeth yn fwriadol am unrhyw un dan 13 oed."
+        "paragraph1": "Nid yw GOV.UK One Login wedi’i gynllunio, neu wedi’i dargedu’n fwriadol, ar gyfer plant 13 oed neu iau. Nid ydym yn casglu na chadw gwybodaeth yn fwriadol am unrhyw un dan 13 oed."
       },
       "section8": {
         "header": "Ble mae eich gwybodaeth yn cael ei brosesu a’i storio",
-        "paragraph1": "Mae’r holl ddata a gwybodaeth bersonol sy’n gysylltiedig â’ch cyfrif GOV.UK yn cael ei storio yn y DU neu yn yr Ardal Economaidd Ewropeaidd (AEE). Mae’r AEE wedi cael ei asesu gan Swyddfa’r Comisiynydd Gwybodaeth fel un sydd â amddiffyniadau cyfreithiol digonol ar gyfer preifatrwydd data yn unol â’r rhai yn y DU.",
+        "paragraph1": "Mae’r holl ddata a gwybodaeth bersonol sy’n gysylltiedig â’ch GOV.UK One Login yn cael ei storio yn y DU neu yn yr Ardal Economaidd Ewropeaidd (AEE). Mae’r AEE wedi cael ei asesu gan Swyddfa’r Comisiynydd Gwybodaeth fel un sydd â amddiffyniadau cyfreithiol digonol ar gyfer preifatrwydd data yn unol â’r rhai yn y DU.",
         "paragraph2": "Pan fydd ein cyflenwyr angen mynediad i’ch data, efallai y byddant yn gwneud hynny o’r tu allan i’r AEE. Gall data a gesglir gan Google Analytics gael ei drosglwyddo y tu allan i’r Ardal Economaidd Ewropeaidd (AEE) i’w brosesu. Pan fydd y naill neu’r llall o’r pethau hyn yn digwydd, byddwn yn sicrhau bod eich gwybodaeth yr un mor ddiogel, er enghraifft drwy gynnwys cymalau ychwanegol yn ein contractau gyda chyflenwyr."
       },
       "section9": {
         "header": "Sut rydym yn diogelu eich gwybodaeth bersonol a’i chadw’n ddiogel",
         "paragraph1": "Rydym wedi ymrwymo i wneud popeth o fewn ein gallu i gadw’ch gwybodaeth yn ddiogel. Rydym wedi sefydlu systemau a phrosesau i atal mynediad neu ddatgelu eich gwybodaeth heb awdurdod - er enghraifft, rydym yn defnyddio lefelau amrywiol o amgryptio. Rydym hefyd yn sicrhau bod unrhyw drydydd parti rydym yn delio yn cadw’r holl wybodaeth bersonol y maent yn ei phrosesu ar ein rhan yn ddiogel.",
-        "paragraph2": "Fel perchennog eich cyfrif GOV.UK, mae gennych chi hefyd rywfaint o gyfrifoldeb am ddiogelwch eich cyfrif. Er enghraifft, dylech:",
+        "paragraph2": "Fel perchennog eich GOV.UK One Login, mae gennych chi hefyd rywfaint o gyfrifoldeb am ei ddiogelwch. Er enghraifft, dylech:",
         "bulletPoint1": {
-          "text1": "dewis cyfrinair cryf ar gyfer eich cyfrif a sicrhewch eich bod yn ei gadw’n ddiogel - mae Canolfan Seiberddiogelwch Genedlaethol y DU (NCSC) yn darparu ",
-          "linkText": "cyngor ar gadw’ch cyfrifon ar-lein yn ddiogel"
+          "text1": "ddewis cyfrinair cryf a sicrhau eich bod yn ei gadw’n ddiogel - mae Canolfan Seiberddiogelwch Genedlaethol y DU (NCSC) yn darparu ",
+          "linkText": "cyngor ar ddiogelwch ar-lein"
         },
-        "bulletPoint2": "cysylltwch â ni ar unwaith os ydych yn amau bod eich cyfrif wedi cael ei gyfaddawdu"
+        "bulletPoint2": "cysylltwch â ni ar unwaith os ydych yn amau bod eich GOV.UK One Login wedi cael ei gyfaddawdu"
       },
       "section10": {
         "header": "Prosesu awtomataidd",
@@ -1099,12 +1103,12 @@
       },
       "section11": {
         "header": "Eich hawliau",
-        "paragraph1": "Pan fyddwch wedi mewngofnodi i’ch cyfrif gallwch:",
-        "bulletPoint1": "gyrchu yr holl wybodaeth bersonol sy’n gysylltiedig â’ch cyfrif GOV.UK",
+        "paragraph1": "Pan fyddwch wedi mewngofnodi i GOV.UK One Login gallwch:",
+        "bulletPoint1": "gyrchu yr holl wybodaeth bersonol sy’n gysylltiedig â’ch GOV.UK One Login",
         "bulletPoint2": "newid neu ddiweddaru eich gwybodaeth fel eich cyfeiriad e-bost, cyfrinair a dewisiadau tanysgrifio e-bost",
         "bulletPoint3": "newid eich caniatâd i gwcis nad ydynt yn hanfodol neu ddweud wrthym sut rydych am i ni gysylltu â chi",
-        "bulletPoint4": "dileu gwybodaeth o’ch cyfrif (ar wahân i’ch cyfeiriad e-bost, rhif ffôn symudol a chyfrinair oherwydd ni allwch gael mynediad i’ch cyfrif hebddynt)",
-        "bulletPoint5": "dileu eich cyfrif GOV.UK yn gyfan gwbl",
+        "bulletPoint4": "dileu gwybodaeth o’ch GOV.UK One Login (ar wahân i’ch cyfeiriad e-bost, cyfrinair a rhif ffôn symudol, os nad oes gennych ffordd arall i ddilysu eich GOV.UK One Login, oherwydd ni allwch gael mynediad i’ch GOV.UK One Login hebddynt)",
+        "bulletPoint5": "dileu eich GOV.UK One Login yn gyfan gwbl",
         "paragraph2": "Gallwch hefyd:",
         "bulletPoint6": "dynnu eich caniatâd yn ôl i’ch gwybodaeth bersonol gael ei brosesu gan ddefnyddio data neu adborth dadansoddi’r we",
         "bulletPoint7": "gwrthwynebu sut mae eich gwybodaeth bersonol yn cael ei phrosesu",
@@ -1165,7 +1169,7 @@
         "validationError": {
           "required": "Rhowch eich cyfrinair",
           "maxLength": "Mae’n rhaid i’ch cyfrinair fod yn llai na 256 nod",
-          "samePassword": "Mae eich cyfrif eisoes yn defnyddio’r cyfrinair hwnnw. Rhowch gyfrinair gwahanol",
+          "samePassword": "Rydych eisoes yn defnyddio’r cyfrinair hwnnw. Rhowch gyfrinair gwahanol",
           "alphaNumeric": "Mae’n rhaid i’ch cyfrinair fod yn o leiaf 8 nod o hyd a rhaid iddo gynnwys llythrennau a rhifau"
         }
       },
@@ -1229,7 +1233,7 @@
     "accountLocked": {
       "title": "Rydych wedi rhoi’r cyfrinair anghywir i mewn ormod o weithiau",
       "header": "Rydych wedi rhoi’r cyfrinair anghywir i mewn ormod o weithiau",
-      "paragraph": "Rydych chi wedi cael eich cloi allan o’ch cyfrif oherwydd eich bod wedi rhoi’r cyfrinair anghywir i mewn fwy na 5 gwaith. Mae hyn er mwyn cadw eich cyfrif yn ddiogel.",
+      "paragraph": "Rydych chi wedi cael eich cloi allan o’ch GOV.UK One Login oherwydd eich bod wedi rhoi’r cyfrinair anghywir i mewn fwy na 5 gwaith. Mae hyn er mwyn cadw eich cyfrif yn ddiogel.",
       "subHeader": "Beth nesaf",
       "bulletPointSection": {
         "title": "Gallwch:",
@@ -1241,8 +1245,8 @@
     "browserBackButtonError": {
       "title": "Mae’n ddrwg gennym, ni allwch fynd yn ôl o’r dudalen honno",
       "header": "Mae’n ddrwg gennym, ni allwch fynd yn ôl o’r dudalen honno",
-      "paragraph1": "Bydd angen i chi ddechrau eto i greu eich cyfrif neu fewngofnodi.",
-      "returnToAccountCreationButtonText": "Yn ôl i greu eich cyfrif neu mewngofnodi",
+      "paragraph1": "Bydd angen i chi ddechrau eto i greu eich GOV.UK One Login neu fewngofnodi.",
+      "returnToAccountCreationButtonText": "Yn ôl i greu eich GOV.UK One Login neu fewngofnodi.",
       "returnToAccountCreationButtonLink": "/sign-in-or-create"
     },
     "support": {
@@ -1285,21 +1289,21 @@
     },
     "contactUsPublic": {
       "title": "Contact us",
-      "header": "GOV.UK account: report a problem or give feedback",
+      "header": "GOV.UK One Login: rhoi gwybod am broblem neu roi adborth",
       "section1": {
         "paragraph1": "Use this form to:",
-        "bulletPoint1": "tell us about a problem you’re having with your GOV.UK account",
-        "bulletPoint2": "suggest improvements or give feedback about your experience using your GOV.UK account",
+        "bulletPoint1": "dywedwch wrthym am broblem rydych chi’n ei chael gyda’ch GOV.UK One Login",
+        "bulletPoint2": "awgrymu gwelliannau neu roi adborth am eich profiad o ddefnyddio eich GOV.UK One Login",
         "paragraph2": "Our office hours are 9:30am to 5:30pm, Monday to Friday. We’ll respond to you by email in 2 working days."
       },
       "section3": {
         "header": "What are you contacting us about?",
-        "accountCreation": "A problem creating a GOV.UK account",
-        "signingIn": "A problem signing in to your GOV.UK account",
+        "accountCreation": "Problem creu GOV.UK One Login",
+        "signingIn": "Problem mewngofnodi i’ch GOV.UK One Login",
         "provingIdentity": "A problem proving your identity",
-        "somethingElse": "Another problem using your GOV.UK account",
+        "somethingElse": "Problem arall wrth ddefnyddio eich GOV.UK One Login",
         "emailSubscriptions": "GOV.UK email subscriptions",
-        "suggestionsFeedback": "A suggestion or feedback about using your GOV.UK account",
+        "suggestionsFeedback": "Awgrym neu adborth am ddefnyddio eich GOV.UK One Login",
         "idCheckApp": "A problem proving your identity using the GOV.UK ID Check app",
         "errorMessage": "Select a reason for contacting us"
       },
@@ -1307,23 +1311,23 @@
     },
     "contactUsFurtherInformation": {
       "signingIn": {
-        "title": "A problem signing in to your GOV.UK account",
-        "header": "A problem signing in to your GOV.UK account",
+        "title": "Problem mewngofnodi i’ch GOV.UK One Login",
+        "header": "Problem mewngofnodi i’ch GOV.UK One Login",
         "section1": {
           "header": "Tell us what happened",
           "radio1": "You did not get a security code",
           "radio2": "The security code did not work",
           "radio3": "You’ve changed your phone number or lost your phone",
           "radio4": "You’ve forgotten your password",
-          "radio5": "You’ve been told your account ‘cannot be found’",
+          "radio5": "Rydych wedi cael gwybod nad oes modd ‘dod o hyd’ i’ch GOV.UK One Login",
           "radio6": "There was a technical problem (for example, the service was unavailable)",
           "radio7": "Something else",
-          "errorMessage": "Select the problem you had when signing in to your account"
+          "errorMessage": "Dewiswch y broblem a gawsoch wrth fewngofnodi i’ch GOV.UK One Login"
         }
       },
       "accountCreation": {
-        "title": "A problem creating a GOV.UK account",
-        "header": "A problem creating a GOV.UK account",
+        "title": "Problem creu GOV.UK One Login",
+        "header": "Problem creu GOV.UK One Login",
         "section1": {
           "header": "Tell us what happened",
           "radio1": "You did not get a security code",
@@ -1332,7 +1336,7 @@
           "radio4": "There was a technical problem (for example, the service was unavailable)",
           "radio5": "Something else",
           "radio6": "You had a problem with an authenticator app",
-          "errorMessage": "Select the problem you had when creating an account"
+          "errorMessage": "Dewis y broblem a gawsoch chi wrth greu eich GOV.UK One Login"
         }
       },
       "idCheckApp": {
@@ -1378,8 +1382,8 @@
         "privacyNote": "Read our <a href=\"/privacy-notice\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">privacy notice</a> for more information on how we use your personal information."
       },
       "anotherProblem": {
-        "title": "Another problem using your GOV.UK account",
-        "header": "Another problem using your GOV.UK account",
+        "title": "Problem arall wrth ddefnyddio eich GOV.UK One Login",
+        "header": "Problem arall wrth ddefnyddio eich GOV.UK One Login",
         "section1": {
           "header": "What were you trying to do?",
           "errorMessage": "Enter what you were trying to do"
@@ -1416,8 +1420,8 @@
         }
       },
       "suggestionOrFeedback": {
-        "title": "A suggestion or feedback about using your GOV.UK account",
-        "header": "A suggestion or feedback about using your GOV.UK account",
+        "title": "Awgrym neu adborth am ddefnyddio eich GOV.UK One Login",
+        "header": "Awgrym neu adborth am ddefnyddio eich GOV.UK One Login",
         "section1": {
           "header": "Your suggestion or feedback",
           "errorMessage": "Enter your suggestion or feedback"
@@ -1526,8 +1530,8 @@
         }
       },
       "accountCreationProblem": {
-        "title": "Another problem creating an account",
-        "header": "Another problem creating an account",
+        "title": "Problem arall wrth greu eich GOV.UK One Login",
+        "header": "Problem arall wrth greu eich GOV.UK One Login",
         "section1": {
           "header": "Anything else you want to tell us",
           "paragraph1": "For example, if you want to add more detail or give us feedback",
@@ -1535,8 +1539,8 @@
         }
       },
       "signignInProblem": {
-        "title": "Problem arall gyda mewngofnodi i’ch cyfrif",
-        "header": "Problem arall gyda mewngofnodi i’ch cyfrif",
+        "title": "Problem arall wrth fewngofnodi i’ch GOV.UK One Login",
+        "header": "Problem arall wrth fewngofnodi i’ch GOV.UK One Login",
         "section1": {
           "header": "Ydych chi eisiau dweud unrhyw beth arall wrthym",
           "paragraph1": "Er enghraifft, os ydych eisiau ychwanegu mwy o fanylion neu roi adborth i ni",
@@ -1544,8 +1548,8 @@
         }
       },
       "accountNotFound": {
-        "title": "Ni ellir dod o hyd i’ch cyfrif",
-        "header": "Ni ellir dod o hyd i’ch cyfrif",
+        "title": "Ni ellir dod o hyd i’ch GOV.UK One Login",
+        "header": "Ni ellir dod o hyd i’ch GOV.UK One Login",
         "section1": {
           "header": "Pa wasanaeth oeddech chi’n ceisio ei ddefnyddio?",
           "paragraph1": "Er enghraifft, eich tanysgrifiadau e-bost GOV.UK, eich cyfrif treth personol neu Gredyd Cynhwysol",
@@ -1611,8 +1615,8 @@
       "header": "placeholder"
     },
     "proveIdentityWelcome": {
-      "title": "Profi pwy ydych chi gyda chyfrif GOV.UK",
-      "header": "Profi pwy ydych chi gyda chyfrif GOV.UK",
+      "title": "Profi pwy ydych chi gyda GOV.UK One Login",
+      "header": "Profi pwy ydych chi gyda GOV.UK One Login",
       "section1": {
         "paragraph1": "Bydd yn cymryd tua 10 munud i chi brofi pwy ydych chi yn y ffordd hyn.",
         "insetAlternativeLanguage": {
@@ -1629,17 +1633,7 @@
       },
       "section2": {
         "paragraph1": "Byddwch angen:",
-        "listItem1_1": "cyfrif GOV.UK – byddwn yn gofyn i chi greu neu fewngofnodi i’ch cyfrif pan fyddwch yn parhau",
-        "listItem1_2": "eich ID gyda llun",
-        "listItem1_3": "eich cyfeiriad presennol (efallai y byddwch angen eich cyfeiriad blaenorol hefyd os ydych wedi symud yn ddiweddar)",
-        "paragraph2": "Byddwn ond yn defnyddio’r wybodaeth rydych yn ei rhoi i ni i wneud yn siwr mai chi yw pwy rydych yn ei ddweud ydych chi."
-      },
-      "existingSession": {
-        "section3": {
-          "radioOption1": "Continue with your GOV.UK account"
-        },
-        "paragraph1": "Byddwch angen:",
-        "listItem1_1": "cyfrif GOV.UK – byddwn yn gofyn i chi greu neu fewngofnodi i’ch cyfrif pan fyddwch yn parhau",
+        "listItem1_1": "GOV.UK One Login – byddwn yn gofyn i chi fewngofnodi neu greu un pan fyddwch yn parhau",
         "listItem1_2": "eich ID gyda llun",
         "listItem1_3": "eich cyfeiriad presennol (efallai y byddwch angen eich cyfeiriad blaenorol hefyd os ydych wedi symud yn ddiweddar)",
         "paragraph2": "Byddwn ond yn defnyddio’r wybodaeth rydych yn ei rhoi i ni i wneud yn siwr mai chi yw pwy rydych yn ei ddweud ydych chi."
@@ -1654,10 +1648,10 @@
     "getSecurityCodes": {
       "title": "Dewis sut i gael codau diogelwch",
       "header": "Dewis sut i gael codau diogelwch",
-      "summary": "I orffen creu eich cyfrif, mae angen i chi ddewis ffordd o brofi mai chi yw chi pan fyddwch yn mewngofnodi.",
-      "titleAccountPartCreated": "Gorffen creu eich cyfrif",
-      "headerAccountPartCreated": "Gorffen creu eich cyfrif",
-      "summaryAccountPartCreated": "Dewiswch ffordd o gael codau diogelwch pan fyddwch yn mewngofnodi. Mae hyn yn helpu i gadw eich cyfrif yn ddiogel.",
+      "summary": "I orffen creu eich GOV.UK One Login, mae angen i chi ddewis ffordd o brofi mai chi yw chi pan fyddwch yn mewngofnodi.",
+      "titleAccountPartCreated": "Gorffen creu eich GOV.UK One Login",
+      "headerAccountPartCreated": "Gorffen creu eich GOV.UK One Login",
+      "summaryAccountPartCreated": "Dewiswch ffordd o gael codau diogelwch pan fyddwch yn mewngofnodi. Mae hyn yn helpu i gadw eich GOV.UK One Login yn ddiogel.",
       "secondFactorRadios": {
         "textMessageText": "Neges destun",
         "authAppText": "Ap dilysydd ar gyfer ffôn clyfar, llechen neu gyfrifiadur",
@@ -1713,9 +1707,9 @@
       }
     },
     "photoId": {
-      "title": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych gyda chyfrif GOV.UK",
-      "header": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych gyda chyfrif GOV.UK",
-      "introParagraph": "Gallwch ond brofi pwy ydych chi gyda chyfrif GOV.UK os oes gennych un o’r mathau canlynol o ID llun.",
+      "title": "Mae’n rhaid i chi gael ID gyda llun i brofi pwy ydych chi gyda GOV.UK One Login",
+      "header": "Mae’n rhaid i chi gael ID gyda llun i brofi pwy ydych chi gyda GOV.UK One Login",
+      "introParagraph": "Gallwch ond profi pwy ydych chi gyda GOV.UK One Login os oes gennych un o’r mathau canlynol o ID gyda llun.",
       "section1": {
         "subHeading": "Trwydded yrru y DU gyda llun",
         "paragraph1": "Byddwch angen trwydded yrru lawn neu dros dro dilys gyda’ch llun arno."
@@ -1736,7 +1730,7 @@
       "title": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych chi fel hyn",
       "header": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych chi fel hyn",
       "section1": {
-        "paragraph1": "Ar hyn o bryd, dim ond os oes gennych ID llun y gallwch brofi pwy ydych chi gyda’ch cyfrif GOV.UK."
+        "paragraph1": "Ar hyn o bryd gallwch ond profi pwy ydych chi gyda GOV.UK One Login os oes gennych ID gyda llun."
       },
       "section2": {
         "subHeading": "Beth allwch chi ei wneud",
@@ -1764,9 +1758,9 @@
       }
     },
     "signInRetryBlocked": {
-      "title": "Mae eich cyfrif wedi’i gloi",
-      "header": "Mae eich cyfrif wedi’i gloi",
-      "paragraph": "Mae hyn oherwydd eich bod wedi rhoi’r cyfrinair anghywir i mewn fwy na 5 gwaith y tro diwethaf i chi geisio mewngofnodi. Mae hyn er mwyn cadw eich cyfrif yn ddiogel.",
+      "title": "Ni allwch fewngofnodi ar hyn o bryd",
+      "header": "Ni allwch fewngofnodi ar hyn o bryd",
+      "paragraph": "Mae hyn oherwydd eich bod wedi rhoi’r cyfrinair anghywir i mewn fwy na 5 gwaith y tro diwethaf i chi geisio mewngofnodi. Mae hyn er mwyn cadw eich GOV.UK One Login yn ddiogel.",
       "info": {
         "paragraph1Start": "Gallwch ",
         "firstLink": "geisio mewngofnodi eto",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2,8 +2,7 @@
   "general": {
     "provider": "GOV.UK",
     "pageTitle": "GOV.UK Sign in",
-    "serviceName": "Sign in to or create your GOV.UK account",
-    "serviceNameTitle": "GOV.UK account",
+    "serviceNameTitle": "GOV.UK One Login",
     "errorTitlePrefix": "Error",
     "back": "Back",
     "warning": "Warning",
@@ -13,13 +12,13 @@
       "tag": "beta",
       "content": "This is a new service – your <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">feedback (opens in new tab)</a> will help us to improve it."
     },
-    "authenticatorAppIssuer": "GOV.UK account",
+    "authenticatorAppIssuer": "GOV.UK One Login",
     "yes": "Yes",
     "no": "No",
     "cookie": {
       "cookieBanner": {
-        "title": "Cookies on GOV.UK account",
-        "heading": "Cookies on GOV.UK account",
+        "title": "Cookies on GOV.UK One Login",
+        "heading": "Cookies on GOV.UK One Login",
         "paragraph1": "We use some essential cookies to make this service work.",
         "paragraph2": "We’d also like to use analytics cookies so we can understand how you use the service and make improvements.",
         "buttonAcceptText": "Accept analytics cookies",
@@ -46,7 +45,7 @@
     },
     "contactAccounts": {
       "contactLinkHref": "https://signin.account.gov.uk/contact-us",
-      "contactLinkText": "Contact the GOV.UK account team (opens in a new tab)"
+      "contactLinkText": "Contact the GOV.UK One Login team (opens in a new tab)"
     },
     "header": {
       "homepageHref": "https://www.gov.uk/"
@@ -117,11 +116,11 @@
       }
     },
     "sessionRequiredMidJourneyError": {
-      "title": "Sorry, you cannot access your account from this page",
-      "header": "Sorry, you cannot access your account from this page",
+      "title": "Sorry, you cannot access GOV.UK One Login from this page",
+      "header": "Sorry, you cannot access GOV.UK One Login from this page",
       "content": {
         "paragraph1": {
-          "text1": "Go to your GOV.UK account",
+          "text1": "Go to GOV.UK One Login",
           "text2": ", or find the service you need from the ",
           "text3": "GOV.UK homepage"
         },
@@ -132,19 +131,19 @@
   "pages": {
     "signInOrCreate": {
       "mandatory": {
-        "title": "Create a GOV.UK account or sign in",
-        "header": "Create a GOV.UK account or sign in"
+        "title": "Create a GOV.UK One Login or sign in",
+        "header": "Create a GOV.UK One Login or sign in"
       },
       "optional": {
-        "title": "Create an account to save your progress",
-        "header": "Create an account to save your progress"
+        "title": "Create a GOV.UK One Login or sign in to save your progress",
+        "header": "Create a GOV.UK One Login or sign in to save your progress"
       },
       "paragraph": "You’ll need:",
       "bullet1": "an email address",
       "bullet2": "a way to get security codes - this can be a UK mobile phone number or an authenticator app",
       "bullet2IntNumbers": "a way to get security codes - this can be a mobile phone number or an authenticator app",
       "insetAlternativeLanguage": {
-        "paragraph1": "The GOV.UK account is also available ",
+        "paragraph1": "GOV.UK One Login is also available ",
         "linkText": {
           "inPageLanguage": "in Welsh",
           "inDestinationLanguage": "(Cymraeg)",
@@ -152,20 +151,20 @@
         },
         "linkHref": "?lng=cy"
       },
-      "paragraph2": "If you already have a GOV.UK account you can",
+      "paragraph2": "If you already have a GOV.UK One Login you can",
       "signInText": "sign in",
       "moreAbout": {
-        "header": "About GOV.UK accounts",
-        "paragraph1": "GOV.UK accounts are new. At the moment you can only use your GOV.UK account with:",
+        "header": "About GOV.UK One Login",
+        "paragraph1": "GOV.UK One Login is new. At the moment you can only use it with:",
         "listItem1": "Apply for a vehicle operator licence",
         "listItem2": "Apply to become a registered social worker in England",
         "listItem3": "GOV.UK email subscriptions ",
         "listItem4": "LITE (Licensing for International Trade and Enterprise)",
         "listItem5": "Request a basic DBS check",
-        "paragraph2": "GOV.UK accounts do not work with all government accounts and services yet (for example Government Gateway or Universal Credit).",
-        "paragraph3": "In the future, you’ll be able to use your GOV.UK account to access all services on GOV.UK."
+        "paragraph2": "GOV.UK One Login does not work with all government accounts or services yet (for example Government Gateway or Universal Credit).",
+        "paragraph3": "In the future, you‘ll be able to use your GOV.UK One Login to access all services on GOV.UK."
       },
-      "createButtonText": "Create a GOV.UK account"
+      "createButtonText": "Create a GOV.UK One Login"
     },
     "enterEmailCreateAccount": {
       "title": "Enter your email address",
@@ -179,8 +178,8 @@
       }
     },
     "enterEmailExistingAccount": {
-      "title": "Enter your email address to sign in to your GOV.UK account",
-      "header": "Enter your email address to sign in to your GOV.UK account",
+      "title": "Enter your email address to sign in to your GOV.UK One Login",
+      "header": "Enter your email address to sign in to your GOV.UK One Login",
       "email": {
         "label": "Email address",
         "validationError": {
@@ -191,34 +190,34 @@
       }
     },
     "accountNotFoundOneLogin": {
-      "title": "No GOV.UK account found",
-      "header": "No GOV.UK account found",
-      "paragraph1": "There is no GOV.UK account for ",
-      "insetText1": "GOV.UK accounts are new. At the moment, they are separate from other government accounts.",
+      "title": "No GOV.UK One Login found",
+      "header": "No GOV.UK One Login found",
+      "paragraph1": "There is no GOV.UK One Login for ",
+      "insetText1": "GOV.UK One Login is new. It does not work with all government accounts or services yet.",
       "paragraph2": "If you’re trying to access your account for a government service, such as Universal Credit or your personal tax account, sign in to your account for that service.",
       "signInToServiceButtonText": "Sign in to a service",
       "tryAnotherLinkText": "Try another email address",
       "tryAnotherLinkHref": "/enter-email-existing-account"
     },
     "accountNotFoundMandatory": {
-      "title": "No GOV.UK account found",
-      "header": "No GOV.UK account found",
-      "paragraph1": "There is no GOV.UK account for ",
-      "insetText1": "GOV.UK accounts are new. At the moment, they are separate from other government accounts, such as Government Gateway or Universal Credit.",
-      "paragraph2": "You need to create a GOV.UK account even if you already have another type of government account.",
-      "createAccountButtonText": "Create a GOV.UK account",
+      "title": "No GOV.UK One Login found",
+      "header": "No GOV.UK One Login found",
+      "paragraph1": "There is no GOV.UK One Login for ",
+      "insetText1": "GOV.UK One Login is new. It does not work with all government accounts or services yet, for example Government Gateway or Universal Credit.",
+      "paragraph2": "You need to create a GOV.UK One Login even if you already have an account for another government service.",
+      "createAccountButtonText": "Create a GOV.UK One Login",
       "createAccountButtonHref": "/enter-email",
       "tryAnotherLinkText": "Try another email address",
       "tryAnotherLinkHref": "/enter-email-existing-account"
     },
     "accountNotFoundOptional": {
-      "title": "No GOV.UK account found",
-      "header": "No GOV.UK account found",
+      "title": "No GOV.UK One Login found",
+      "header": "No GOV.UK One Login found",
       "paragraph1": "We could not find a GOV.UK account using this email address.",
       "insetText1": "You may have other government accounts such as Government Gateway or your personal tax account.",
       "insetText2": "The GOV.UK account is separate from these other government accounts.",
-      "insetText3": "You need to create a GOV.UK account, even if you have another government account.",
-      "createAccountButtonText": "Create a GOV.UK account",
+      "insetText3": "You need to create a GOV.UK One Login even if you already have an account for another government service.",
+      "createAccountButtonText": "Create a GOV.UK One Login",
       "createAccountButtonHref": "/enter-email",
       "tryAnotherLinkText": "Try another email address",
       "tryAnotherLinkHref": "/enter-email-existing-account"
@@ -239,9 +238,9 @@
       }
     },
     "enterPasswordAccountExists": {
-      "title": "You have a GOV.UK account",
-      "header": "You have a GOV.UK account",
-      "paragraph1": "There’s already a GOV.UK account using ",
+      "title": "You have a GOV.UK One Login",
+      "header": "You have a GOV.UK One Login",
+      "paragraph1": "There’s already a GOV.UK One Login using ",
       "info": "Enter your password to sign in.",
       "password": {
         "label": "Password",
@@ -354,8 +353,8 @@
       }
     },
     "accountCreated": {
-      "title": "You’ve created your GOV.UK account",
-      "header": "You’ve created your GOV.UK account",
+      "title": "You’ve created your GOV.UK One Login",
+      "header": "You’ve created your GOV.UK One Login",
       "text": "Now continue to use the service.",
       "inset": "Your progress on ",
       "insetContinued": " has been saved.",
@@ -459,18 +458,24 @@
       }
     },
     "enterMfa": {
-      "title": "Check your phone",
-      "header": "Check your phone",
+      "title": "You need to enter a security code",
+      "header": "You need to enter a security code",
       "info": {
-        "paragraph1": "We sent a code to the phone number linked to your account.",
-        "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes."
+        "paragraph1": "This helps your GOV.UK One Login secure.",
+        "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes.",
+        "paragraph3": "To get a security code, open the ",
+        "authenticatorApp": "authenticator app ",
+        "paragraph3End": "you used to create your GOV.UK One Login",
+        "paragraph4": "We sent a code to the phone number linked to your account."
       },
       "resend": {
         "link": "Request a new code",
         "paragraph1": "if the code does not work or has expired, or you did not receive one."
       },
       "code": {
-        "label": "Enter the 6 digit security code",
+        "label": "Enter the security code",
+        "label2": "Enter the 6 digit security code",
+        "labelSummary": "This is the 6-digit number shown in your authenticator app",
         "validationError": {
           "required": "Enter the security code",
           "maxLength": "Enter the security code using only 6 digits",
@@ -481,28 +486,10 @@
       },
       "details": {
         "summaryText": "Problems with the code?",
-        "text1": "We can ",
-        "sendCodeLinkText": "send the code again",
+        "sendTheCodeAgain": "Send the code again",
         "sendCodeLinkHref": "/resend-code",
         "text 2": " if the code is not working or you did not receive it."
       }
-    },
-    "youNeedToEnterASecurityCode": {
-      "title": "You need to enter a security code",
-      "header": "You need to enter a security code",
-      "paragraph1": "This helps your GOV.UK account secure.",
-      "paragraph2": "To get a security code, open the ",
-      "authenticatorApp": "authenticator app ",
-      "paragraph2End": "you used to create your GOV.UK account",
-      "paragraph3": "We sent a code to the phone number linked to your account.",
-      "paragraph4": "It might take a few minutes for the code to arrive. The code will expire after 15 minutes.",
-      "enterSecurityCode": "Enter the security code",
-      "enterSecurityCodeSummary": "This is the 6-digit number shown in your authenticator app",
-      "enter6DigitSecurityCode": "Enter the 6 digit security code",
-      "problemsWithTheCode": "Problems with the code?",
-      "sendTheCodeAgain": "Send the code again",
-      "sendTheCodeAgainEnd": " if the code is not working or you did not receive it.",
-      "continue": "Continue"
     },
     "resendMfaCode": {
       "title": "Get security code",
@@ -510,7 +497,7 @@
       "continue": "Get security code",
       "message": "Text messages can sometimes take a few minutes to arrive.",
       "phoneNumber": {
-        "default": "We will send a code to the phone number linked to your account",
+        "default": "We will send the code to the phone number linked to your GOV.UK One Login.",
         "isResendCodeRequest": "We will send a code to: [mobile]."
       },
       "email": {
@@ -525,19 +512,19 @@
       "govukLinkText": "Go to the GOV.UK homepage",
       "paragraph1": "or",
       "signInLinkText": "sign in",
-      "paragraph2": "to your GOV.UK account."
+      "paragraph2": "to your GOV.UK One Login."
     },
     "shareInfo": {
-      "title": "Share information from your GOV.UK account",
-      "header": "Share information from your GOV.UK account",
+      "title": "Share information from your GOV.UK One Login",
+      "header": "Share information from your GOV.UK One Login",
       "continue": "Continue",
       "bulletPointSectionHeader": "This service needs to use your:",
-      "paragraph1": "You added this information to your GOV.UK account when you created the account. You can choose to share it with the service instead of entering it again when you use the service.",
+      "paragraph1": "You added this information to your GOV.UK One Login when you created it. You can choose to share the information with the service instead of entering it again when you use the service.",
       "paragraph2": "The service will only use this information to contact you about the service. It won’t share your information with anyone else. It will keep your information for as long as it needs to or the law requires it to.",
-      "paragraph3": "If you choose not to share information from your GOV.UK account, you may still be asked for that information as you use the service. For example if you choose not to share your email address and phone number and the service needs a way to contact you.",
-      "essentialHeader": "Do you want to share information from your GOV.UK account? ",
+      "paragraph3": "If you choose not to share information from your GOV.UK One Login, you may still be asked for that information as you use the service. For example if you choose not to share your email address and phone number and the service needs a way to contact you.",
+      "essentialHeader": "Do you want to share information from your GOV.UK One Login? ",
       "radios": {
-        "shareMy": "Do you want to share information from your GOV.UK account?",
+        "shareMy": "Do you want to share information from your GOV.UK One Login?",
         "radioText": {
           "agree": "Share my email address and phone number",
           "doNotAgree": "Do not share my email address and phone number",
@@ -546,8 +533,8 @@
       }
     },
     "updatedTermsAndConds": {
-      "title": "GOV.UK account terms of use update",
-      "header": "GOV.UK account terms of use update",
+      "title": "GOV.UK One Login terms of use update",
+      "header": "GOV.UK One Login terms of use update",
       "paragraph1": {
         "text": "We’ve updated our ",
         "and": "and",
@@ -592,26 +579,26 @@
         "termsAndConditionsText": "terms and conditions",
         "privacyNoticeText": "privacy notice",
         "cookiesPolicyText": "cookies policy",
-        "end": "to keep using your account."
+        "end": "to keep using your GOV.UK One Login."
       },
       "section2": {
-        "paragraph1": "If you do not agree to the new terms, you cannot use your GOV.UK account.",
+        "paragraph1": "If you do not agree to the new terms, you cannot use your GOV.UK One Login.",
         "govUkHomePageText": "Go to the GOV.UK homepage.",
-        "paragraph2": "If you no longer need your account, or want to delete information saved in your account, you can ",
+        "paragraph2": "If you no longer need your GOV.UK One Login, or want to delete information saved in your GOV.UK One Login, you can ",
         "contactUsText": "contact us."
       },
       "agreeAndContinue": "Agree and continue"
     },
     "cookiePolicy": {
-      "title": "GOV.UK accounts cookies policy",
-      "header": "GOV.UK accounts cookies policy",
+      "title": "GOV.UK One Login cookies policy",
+      "header": "GOV.UK One Login cookies policy",
       "info": {
-        "paragraph1": "This cookies policy only covers GOV.UK accounts. Read the main ",
+        "paragraph1": "This cookies policy only covers GOV.UK One Login. Read the main ",
         "govUkCookiesLinkHref": "https://www.gov.uk/help/cookies",
         "govUkCookiesLinkText": "GOV.UK cookies policy",
         "paragraph2": " to find out about cookies that are used on GOV.UK.",
-        "paragraph3": "Cookies are files saved on to your phone, tablet or computer when you visit a website. We use cookies to make the GOV.UK account work.",
-        "paragraph4": "We may also use analytics cookies to learn about how you use the account and help us improve it. We’ll ask for your permission before we do this.",
+        "paragraph3": "Cookies are files saved on to your phone, tablet or computer when you visit a website. We use cookies to make GOV.UK One Login work.",
+        "paragraph4": "We may also use analytics cookies to learn about how you use GOV.UK One Login and help us improve it. We’ll ask for your permission before we do this.",
         "paragraph5": "Cookies are not used to identify you personally.",
         "paragraph6": "Find out more about",
         "linkHref": "https://ico.org.uk/your-data-matters/online/cookies/",
@@ -622,7 +609,7 @@
         "header": "Strictly necessary cookies",
         "info": {
           "paragraph1": "We use essential cookies to:",
-          "bulletPoint1": "make the account work",
+          "bulletPoint1": "make GOV.UK One Login work",
           "bulletPoint2": "keep your information secure",
           "bulletPoint3": "detect fraudulent or malicious activity and breaches of our terms and conditions",
           "table": {
@@ -673,7 +660,7 @@
       },
       "cookiesMessage": {
         "header": "Cookies message",
-        "paragraph1": "You may see a banner when you use your GOV.UK account inviting you to accept cookies or review your settings. We’ll set cookies to: ",
+        "paragraph1": "You may see a banner when you use GOV.UK One Login inviting you to accept cookies or review your settings. We’ll set cookies to: ",
         "bulletPoint1": "let your computer know you’ve seen this message so you do not get shown it again",
         "bulletPoint2": "store your settings",
         "table": {
@@ -692,8 +679,8 @@
       },
       "settingsCookies": {
         "header": "Cookies that remember your settings",
-        "paragraph1": "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using your GOV.UK account.",
-        "paragraph2": "We set a cookie when you use your GOV.UK account to save your language preference. At the moment, this defaults to English.",
+        "paragraph1": "These cookies do things like remember your preferences and the choices you make, to personalise your experience of using GOV.UK One Login.",
+        "paragraph2": "We set a cookie when you use GOV.UK One Login to save your language preference. At the moment, this defaults to English.",
         "table": {
           "headers": {
             "col1": "Name",
@@ -702,17 +689,17 @@
           },
           "rows": {
             "row1": {
-              "col2": "Remembers the language you use the account in",
+              "col2": "Remembers the language you use in GOV.UK One Login",
               "col3": "1 year"
             }
           }
         }
       },
       "analytics": {
-        "header": "Cookies that measure how you use your GOV.UK account",
+        "header": "Cookies that measure how you use GOV.UK One Login",
         "info": {
-          "paragraph1": "We use Google Analytics cookies to collect anonymised information about how you use your GOV.UK account, for example what pages you visit and what you click on.",
-          "paragraph2": "This helps us understand how we can improve the account."
+          "paragraph1": "We use Google Analytics cookies to collect anonymised information about how you use your GOV.UK One Login, for example what pages you visit and what you click on.",
+          "paragraph2": "This helps us understand how we can improve GOV.UK One Login"
         },
         "table": {
           "headers": {
@@ -722,23 +709,23 @@
           },
           "rows": {
             "row1": {
-              "col2": "Helps us count how many people visit GOV.UK account by checking if you’ve visited before",
+              "col2": "Helps us count how many people visit GOV.UK One Login by checking if you’ve visited before",
               "col3": "2 years"
             },
             "row2": {
-              "col2": "Helps us count how many people visit GOV.UK account by checking if you’ve visited before",
+              "col2": "Helps us count how many people visit GOV.UK One Login by checking if you’ve visited before",
               "col3": "24 hours"
             },
             "row3": {
-              "col2": "Helps us count how many people visit GOV.UK accounts by checking if you’ve visited before",
+              "col2": "Helps us count how many people visit GOV.UK One Login by checking if you’ve visited before",
               "col3": "When you close your web browser"
             }
           }
         }
       },
       "settings": {
-        "yesRadioButton": "Use cookies that measure how I use my GOV.UK account",
-        "noRadioButton": "Do not use cookies that measure how I use my GOV.UK account",
+        "yesRadioButton": "Use cookies that measure how I use GOV.UK One Login",
+        "noRadioButton": "Do not use cookies that measure how I use GOV.UK One Login",
         "saveButton": "Save cookie settings"
       },
       "successBanner": {
@@ -748,46 +735,46 @@
       }
     },
     "accessibilityStatement": {
-      "title": "Accessibility statement for GOV.UK accounts",
-      "header": "Accessibility statement for GOV.UK accounts",
+      "title": "Accessibility statement for GOV.UK One Login",
+      "header": "Accessibility statement for GOV.UK One Login",
       "content": {
-        "paragraph1": "GOV.UK accounts are part of the wider GOV.UK website. There’s a separate ",
+        "paragraph1": "GOV.UK One Login is part of the wider GOV.UK website. There’s a separate ",
         "linkText": "accessibility statement for the main GOV.UK website",
-        "paragraph2": "This page only contains information about GOV.UK accounts, available at www.signin.account.gov.uk."
+        "paragraph2": "This page only contains information about GOV.UK One Login, available at www.signin.account.gov.uk."
       },
       "section1": {
-        "header": "Using GOV.UK accounts",
+        "header": "Using GOV.UK One Login",
         "paragraph1": {
-          "text1": "GOV.UK accounts are run by the ",
+          "text1": "GOV.UK One Login is run by the ",
           "linkText": "Government Digital Service (GDS)",
-          "text2": ", part of the Cabinet Office. We want as many people as possible to be able to use GOV.UK accounts. This means you should be able to:"
+          "text2": ", part of the Cabinet Office. We want as many people as possible to be able to use GOV.UK One Login. This means you should be able to:"
         },
         "bulletPoint1": "change colours, contrast levels and fonts",
         "bulletPoint2": "zoom in up to 300% without the text spilling off the screen",
-        "bulletPoint3": "navigate most of the account using just a keyboard",
-        "bulletPoint4": "navigate most of the account using speech recognition software",
-        "bulletPoint5": "listen to most of the account content using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)",
-        "paragraph2": "We’ve also made the text in the account as simple as possible to understand.",
+        "bulletPoint3": "navigate most GOV.UK One Login using just a keyboard",
+        "bulletPoint4": "navigate most of GOV.UK One Login using speech recognition software",
+        "bulletPoint5": "listen to most of the content in GOV.UK One Login using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)",
+        "paragraph2": "We’ve also made the text in GOV.UK One Login as simple as possible to understand.",
         "linkText": "AbilityNet",
         "linkHref": "https://mcmw.abilitynet.org.uk/",
         "paragraph3": "has advice on making your device easier to use if you have a disability."
       },
       "section2": {
-        "header": "How accessible GOV.UK accounts are",
-        "paragraph1": "The following parts of GOV.UK accounts are not fully accessible:",
-        "bulletPoint1": "it’s not possible to stop or change the length of the time-out when you use, sign in to or create an account",
+        "header": "How accessible GOV.UK One Login is",
+        "paragraph1": "The following parts of GOV.UK One Login are not fully accessible:",
+        "bulletPoint1": "it’s not possible to stop or change the length of the time-out when you use, sign in to or create a GOV.UK One Login",
         "bulletPoint2": "it’s not possible for a screen reader to know when the emails we send are in a language other than English",
         "bulletPoint3": "one page reloads automatically after a set time limit, and it’s not possible to stop or delay this",
         "paragraph2": "We’ll update this page when issues are fixed or with information about when we plan to fix them."
       },
       "section3": {
-        "header": "What to do if you have difficulty using GOV.UK accounts",
-        "paragraph1": "If you have difficulty using GOV.UK accounts, ",
+        "header": "What to do if you have difficulty using GOV.UK One Login",
+        "paragraph1": "If you have difficulty using GOV.UK One Login, ",
         "linkText": "contact us"
       },
       "section4": {
-        "header": "Report accessibility problems with GOV.UK accounts",
-        "paragraph1": "We’re always looking to improve the accessibility of GOV.UK accounts. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, ",
+        "header": "Report accessibility problems with GOV.UK One Login",
+        "paragraph1": "We’re always looking to improve the accessibility of GOV.UK One Login. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, ",
         "linkText": "contact us"
       },
       "section5": {
@@ -797,11 +784,11 @@
         "linkText": "contact the Equality Advisory and Support Service (EASS)"
       },
       "section6": {
-        "header": "Technical information about GOV.UK accounts’ accessibility",
-        "paragraph1": "The Government Digital Service is committed to making GOV.UK accounts accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.",
+        "header": "Technical information about GOV.UK One Login’s accessibility",
+        "paragraph1": "The Government Digital Service is committed to making GOV.UK One Login accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.",
         "subHeader": "Compliance status",
         "paragraph2": {
-          "text1": "GOV.UK accounts are partially compliant with the",
+          "text1": "GOV.UK One Login is partially compliant with the",
           "linkText": "Web Content Accessibility Guidelines version 2.1",
           "text2": " AA standard, due to the non-compliances listed below."
         }
@@ -810,7 +797,7 @@
         "header": "Non-accessible content",
         "paragraph1": "The content listed below is non-accessible for the following reasons.",
         "subHeader": "Non compliance with the accessibility regulations",
-        "paragraph2": "When you create an account or sign in, if you do not do anything for 2 hours, the process will stop (time out) or you’ll be signed out. It’s not possible to adjust, extend or turn off the time out. This fails WCAG 2.1 success criterion 2.2.1 (Timing Adjustable)."
+        "paragraph2": "When you create a GOV.UK One Login or sign in, if you do not do anything for 2 hours, the process will stop (time out) or you’ll be signed out. It’s not possible to adjust, extend or turn off the time out. This fails WCAG 2.1 success criterion 2.2.1 (Timing Adjustable)."
       },
       "section8": {
         "header": "What we’re doing to improve accessibility",
@@ -819,63 +806,63 @@
       "section9": {
         "header": "Preparation of this accessibility statement",
         "paragraph1": "This statement was prepared on 4 November 2020. It was last reviewed on 29 June 2022.",
-        "paragraph2": "GOV.UK accounts were last tested on 13 June 2022. The test was carried out by the Digital Accessibility Centre (DAC), who produced an accessibility audit report on 17 June 2022. DAC assessed GOV.UK accounts against the Web Content Accessibility Guidelines WCAG 2.1."
+        "paragraph2": "GOV.UK One Login was last tested on 13 June 2022. The test was carried out by the Digital Accessibility Centre (DAC), who produced an accessibility audit report on 17 June 2022. DAC assessed GOV.UK One Login against the Web Content Accessibility Guidelines WCAG 2.1."
       }
     },
     "termsAndConditions": {
-      "title": "GOV.UK account terms and conditions",
-      "header": "GOV.UK account terms and conditions",
+      "title": "GOV.UK One Login terms and conditions",
+      "header": "GOV.UK One Login terms and conditions",
       "section1": {
         "paragraph1": {
-          "text1": "These terms and conditions specifically cover GOV.UK accounts. You can use a GOV.UK account to access and use some government services and features. Pages that are part of the GOV.UK account have urls containing account.gov.uk. If you are using other parts of GOV.UK you should also read the ",
+          "text1": "These terms and conditions specifically cover GOV.UK One Login. You can use GOV.UK One Login to access and use some government services and features. Pages that are part of GOV.UK One Login have urls containing account.gov.uk. If you are using other parts of GOV.UK you should also read the ",
           "linkText": "terms and conditions for GOV.UK"
         },
         "paragraph2": {
-          "text1": "The GOV.UK account is managed by ",
+          "text1": "GOV.UK One Login is managed by ",
           "linkText": "Government Digital Service",
           "text2": " (GDS) on behalf of the Crown. GDS is part of the Cabinet Office and will be referred to as ‘we’ from now on."
         },
         "paragraph3": {
           "text1": "Please read these terms and conditions, the ",
-          "linkText1": "GOV.UK accounts privacy notice",
+          "linkText1": "GOV.UK One Login privacy notice",
           "text2": " and the ",
-          "linkText2": "GOV.UK accounts cookies policy",
-          "text3": "before using the GOV.UK account. The privacy notice explains the terms on which we process any personal data we collect from you or that you provide to us. The cookie policy gives information about the cookies we use and how we use them when you use GOV.UK or your GOV.UK account."
+          "linkText2": "GOV.UK One Login cookies policy",
+          "text3": "before using GOV.UK One Login. The privacy notice explains the terms on which we process any personal data we collect from you or that you provide to us. The cookie policy gives information about the cookies we use and how we use them when you use GOV.UK One Login."
         },
-        "paragraph4": "By registering for and continuing to use a GOV.UK account, you agree to these terms and conditions, the privacy notice and cookies policy.",
+        "paragraph4": "By registering for and continuing to use GOV.UK One Login, you agree to these terms and conditions, the privacy notice and cookies policy.",
         "subHeader": "Changes to these terms and conditions",
         "paragraph5": "We can update these terms, as well as the cookies policy and privacy notice, at any time without notice.",
-        "paragraph6": "If we change the terms and conditions, we’ll ask you to accept them the next time you sign in to your account."
+        "paragraph6": "If we change the terms and conditions, we’ll ask you to accept them the next time you sign in to GOV.UK One Login."
       },
       "section2": {
-        "header": "Accessing your GOV.UK account",
-        "paragraph1": "You are responsible for making all arrangements for you to access your GOV.UK account. This includes providing your own device, operating system, browser and internet connection. \nYou should use a device that uses a Windows, OS, iOS or Android operating system. We recommend you use one of the following browsers:",
+        "header": "Accessing GOV.UK One Login",
+        "paragraph1": "You are responsible for making all arrangements for you to access GOV.UK One Login. This includes providing your own device, operating system, browser and internet connection. You should use a device that uses a Windows, OS, iOS or Android operating system. We recommend you use one of the following browsers:",
         "bulletPoint1": "The latest version of Google Chrome, Microsoft Edge, Mozilla Firefox, Samsung Internet or Internet Explorer",
         "bulletPoint2": "Safari 12 or later",
         "bulletPoint3": "Safari for iOS 12.1 or later",
-        "paragraph2": "We do not guarantee that your GOV.UK account will always be available, or that access to it will be error free. We will provide a way for you to report problems with your account.",
-        "paragraph3": "We may suspend, stop, remove, update or change the GOV.UK account without notice at any time."
+        "paragraph2": "We do not guarantee that GOV.UK One Login will always be available, or that access to it will be error free. We will provide a way for you to report problems with GOV.UK One Login.",
+        "paragraph3": "We may suspend, stop, remove, update or change GOV.UK One Login without notice at any time."
       },
       "section3": {
-        "header": "Keeping your account secure",
+        "header": "Keeping your GOV.UK One Login secure",
         "paragraph1": {
-          "text1": "We have many measures in place to keep your information safe, but as the owner of your GOV.UK account, you also have some responsibility for the security of your account. For example you should choose a strong password for your account and ensure you keep it secure. The UK’s National Cyber Security Centre (NCSC) provides ",
-          "linkText": "advice on keeping your online accounts secure"
+          "text1": "We have many measures in place to keep your information safe, but as the owner of your GOV.UK One Login, you also have some responsibility for its security. For example you should choose a strong password and ensure you keep it secure. The UK’s National Cyber Security Centre (NCSC) provides ",
+          "linkText": "advice on online security"
         },
-        "paragraph2": "If you think that someone knows the username and password to your GOV.UK account, you must reset your password as soon as possible."
+        "paragraph2": "If you think that someone knows the username and password to your GOV.UK One Login, you must reset your password as soon as possible."
       },
       "section4": {
-        "header": "Using your GOV.UK account",
-        "paragraph1": "You will use your account to access government services and for no other purpose.",
+        "header": "Using GOV.UK One Login",
+        "paragraph1": "You will use your GOV.UK One Login to access government services and for no other purpose.",
         "paragraph2": "Unless permitted by law or under these terms and conditions, you must:",
-        "bulletPoint1": "not copy the GOV.UK account except where copying is incidental to normal use",
-        "bulletPoint2": "not rent, lease, sub-license, loan, translate, merge, adapt, vary or modify the GOV.UK account",
-        "bulletPoint3": "not combine or incorporate the GOV.UK account with any other programs or services",
-        "bulletPoint4": "not disassemble, decompile, reverse-engineer or create derivative works based on any part of the GOV.UK account",
-        "bulletPoint5": "comply with all technology control or export laws that apply to the technology used by the GOV.UK account",
-        "paragraph3": "You must not use your GOV.UK account:",
+        "bulletPoint1": "not copy GOV.UK One Login except where copying is incidental to normal use",
+        "bulletPoint2": "not rent, lease, sub-license, loan, translate, merge, adapt, vary or modify GOV.UK One Login",
+        "bulletPoint3": "not combine or incorporate GOV.UK One Login with any other programs or services",
+        "bulletPoint4": "not disassemble, decompile, reverse-engineer or create derivative works based on any part of GOV.UK One Login",
+        "bulletPoint5": "comply with all technology control or export laws that apply to the technology used by GOV.UK One Login",
+        "paragraph3": "You must not use GOV.UK One Login:",
         "bulletPoint6": "to transmit any material that is insulting or offensive",
-        "bulletPoint7": "to collect any data or attempt to decipher any transmissions to or from the servers running GOV.UK account",
+        "bulletPoint7": "to collect any data or attempt to decipher any transmissions to or from the servers running GOV.UK One Login",
         "bulletPoint8": "in a way that could damage, disable, overburden, impair or compromise our systems or security",
         "bulletPoint9": "in a way that interferes with other users",
         "bulletPoint10": "in any unlawful or fraudulent manner or for any unlawful or fraudulent purpose",
@@ -884,12 +871,12 @@
         "bulletPoint13": "to transmit, send or upload any data that contains viruses, Trojan horses, worms, spyware or any other harmful programs designed to adversely affect the operation of computer software or hardware",
         "bulletPoint14": "in connection with any kind of denial of service attack or for any malicious purpose",
         "bulletPoint15": "with someone else’s registered details, unless you have the authority to do so from them",
-        "paragraph4": "If you breach any of these terms and conditions, we may stop you from accessing your GOV.UK account and may take action to enforce these terms and conditions and take other action as appropriate where we have suffered loss. If, by doing any of the above acts, you are also committing a criminal offence, we may report it to the relevant law enforcement authorities. We may cooperate with those authorities by disclosing your identity to them."
+        "paragraph4": "If you breach any of these terms and conditions, we may stop you from accessing your GOV.UK One Login and may take action to enforce these terms and conditions and take other action as appropriate where we have suffered loss. If, by doing any of the above acts, you are also committing a criminal offence, we may report it to the relevant law enforcement authorities. We may cooperate with those authorities by disclosing your identity to them."
       },
       "section5": {
-        "header": "Deleting your account",
+        "header": "Deleting your GOV.UK One Login",
         "paragraph1": {
-          "text1": "You can permanently delete your account and the information in it at any time by signing in to your account or ",
+          "text1": "You can permanently delete your GOV.UK One Login and the information in it at any time by signing in or ",
           "linkText1": "contacting us",
           "text2": "We’ll keep a record of certain information, in line with our ",
           "linkText2": "privacy notice",
@@ -898,7 +885,7 @@
       },
       "section6": {
         "header": "Changes",
-        "paragraph1": "We can make changes and improvements to the GOV.UK account at any time and without notice to:",
+        "paragraph1": "We can make changes and improvements to GOV.UK One Login at any time and without notice to:",
         "bulletPoint1": "make technical improvements or corrections",
         "bulletPoint2": "improve the performance of the service",
         "bulletPoint3": "enhance functionality",
@@ -908,30 +895,30 @@
       },
       "section7": {
         "header": "Services and transactions",
-        "paragraph1": "You can use your GOV.UK account to access online government services. These services can be managed by GDS, the Cabinet Office or another government department or agency.",
+        "paragraph1": "You can use GOV.UK One Login to access online government services. These services can be managed by GDS, the Cabinet Office or another government department or agency.",
         "paragraph2": "Each service will have their own, separate terms and conditions, privacy notices and cookies policies, which apply to the use of that service. You should read these before you use the service.",
-        "paragraph3": "If a service run by another government department or agency stops being accessible with GOV.UK accounts the service will contact you to tell you what you should do."
+        "paragraph3": "If a service run by another government department or agency stops being accessible with GOV.UK One Login the service will contact you to tell you what you should do."
       },
       "section8": {
         "header": "Our legal responsibility to you",
-        "paragraph1": "The GOV.UK account is a tool and we have no liability to you for the online government services that you access using the GOV.UK account. Liability to you rests with the government service provider.",
-        "paragraph2": "Although we make reasonable efforts to provide, maintain and update a robust GOV.UK account service, it is provided ’as is’. We make no express or implied representations, warranties or guarantees that your access to, or use of, GOV.UK account will be unbroken or completely secure.",
-        "paragraph3": "We will not be liable or responsible for any loss or damage caused by a virus, denial of service attack or any other harmful material that may infect your device, equipment, programs, data or other proprietary material due to your use of a GOV.UK account.",
+        "paragraph1": "GOV.UK One Login is a tool and we have no liability to you for the online government services that you access using GOV.UK One Login. Liability to you rests with the government service provider.",
+        "paragraph2": "Although we make reasonable efforts to provide, maintain and update a robust GOV.UK One Login service, it is provided ’as is’. We make no express or implied representations, warranties or guarantees that your access to, or use of, GOV.UK One Login will be unbroken or completely secure.",
+        "paragraph3": "We will not be liable or responsible for any loss or damage caused by a virus, denial of service attack or any other harmful material that may infect your device, equipment, programs, data or other proprietary material due to your use of GOV.UK One Login.",
         "subHeader1": "Loss and damages",
         "paragraph4": "Nothing in these terms and conditions excludes or limits our liability for:",
         "bulletPoint1": "death or personal injury as a result of our negligence",
         "bulletPoint2": "fraud or fraudulent misrepresentation",
         "bulletPoint3": "any other liability which cannot be excluded or limited under English law",
         "paragraph5": "We’re not liable for any:",
-        "bulletPoint4": "loss or damage that may come from using the GOV.UK account that is not caused by our breach of these terms and conditions",
+        "bulletPoint4": "loss or damage that may come from using GOV.UK One Login that is not caused by our breach of these terms and conditions",
         "bulletPoint5": "loss or damage to a device or digital content belonging to you",
-        "bulletPoint6": "loss or damage arising from an inability to access or use your GOV.UK account",
-        "bulletPoint7": "indirect or subsequent losses that were not foreseeable to both you and us when you started using your GOV.UK account (loss or damages are ‘foreseeable’ when they are an obvious result of our breach of these terms and conditions or if they were considered by you and us when you began using the GOV.UK account)",
+        "bulletPoint6": "loss or damage arising from an inability to access or use GOV.UK One Login",
+        "bulletPoint7": "indirect or subsequent losses that were not foreseeable to both you and us when you started using GOV.UK One Login (loss or damages are ‘foreseeable’ when they are an obvious result of our breach of these terms and conditions or if they were considered by you and us when you began using GOV.UK One Login)",
         "bulletPoint8": "loss of profits, revenue, contracts, savings, goodwill and wasted expenditure",
         "paragraph6": "GDS is not liable for its failure to comply with the terms and conditions due to circumstances which are beyond GDS’ control.",
         "paragraph7": "This does not affect any legal rights you may have as a consumer in relation to faulty services or software. Advice about your legal rights is available from your local Citizen’s Advice or Trading Standards Office.",
-        "subHeader2": "Links from the GOV.UK account",
-        "paragraph8": "We are not responsible for any links from your GOV.UK account links to websites that are managed by other government departments and agencies, service providers or other organisations. We do not have any control over the content on these websites.",
+        "subHeader2": "Links from GOV.UK One Login",
+        "paragraph8": "We are not responsible for any links from GOV.UK One Login to websites that are managed by other government departments and agencies, service providers or other organisations. We do not have any control over the content on these websites.",
         "paragraph9": "We’re not responsible for:",
         "bulletPoint9": "the protection of any information you give to these websites",
         "bulletPoint10": "any loss or damage that may come from your use of these websites, or any other websites they link to",
@@ -945,7 +932,7 @@
       },
       "section10": {
         "header": "Governing law",
-        "paragraph1": "The laws of England apply exclusively to these terms and conditions and to all matters relating to use of GOV.UK accounts. Any cause of action arising under or in connection with these terms and conditions or your use of GOV.UK accounts will be subject to the exclusive jurisdiction of the courts of England."
+        "paragraph1": "The laws of England apply exclusively to these terms and conditions and to all matters relating to use of GOV.UK One Login. Any cause of action arising under or in connection with these terms and conditions or your use of GOV.UK One Login will be subject to the exclusive jurisdiction of the courts of England."
       },
       "section11": {
         "header": "Contacting us",
@@ -954,7 +941,7 @@
           "text1": " if you have:"
         },
         "bulletPoint1": "questions about these terms and conditions",
-        "bulletPoint2": "questions or a complaint about the GOV.UK account",
+        "bulletPoint2": "questions or a complaint about GOV.UK One Login",
         "paragraph2": {
           "text1": "Find out more ",
           "linkText": "about GDS and our role"
@@ -962,26 +949,26 @@
       }
     },
     "privacy": {
-      "title": "GOV.UK accounts privacy notice",
-      "header": "GOV.UK accounts privacy notice",
+      "title": "GOV.UK One Login privacy notice",
+      "header": "GOV.UK One Login privacy notice",
       "section1": {
         "header": "Who we are",
         "paragraph1": {
-          "text1": "GOV.UK accounts are provided by the ",
+          "text1": "GOV.UK One Login is provided by the ",
           "linkText": "Government Digital Service (GDS)",
           "text2": ", part of the Cabinet Office. Mentions of ‘us’ and ‘we’ in this privacy notice refer to GDS."
         },
         "paragraph2": {
-          "text1": "This privacy notice only covers GOV.UK accounts. Read the main ",
+          "text1": "This privacy notice only covers GOV.UK One Login. Read the main ",
           "linkText": "GOV.UK privacy notice",
           "text2": " to find out how your personal information is collected and processed when you use the GOV.UK website."
         },
         "paragraph3": "The Cabinet Office is the data controller of the personal information you provide to us when you:",
-        "bulletPoint1": "create a GOV.UK account",
-        "bulletPoint2": "use your GOV.UK account to access an online government service",
+        "bulletPoint1": "create a GOV.UK One Login",
+        "bulletPoint2": "use your GOV.UK One Login to access an online government service",
         "bulletPoint3": "contact us",
-        "paragraph4": "When you provide information to another government service while signed into your account, the government department that runs the service is the data controller. They will have their own privacy notice to explain how they process your information. We do not have access to the information you provide to services run by other government departments.",
-        "paragraph5": "When you prove your identity with a GOV.UK account, we will:",
+        "paragraph4": "When you provide information to another government service while signed into GOV.UK One Login, the government department that runs the service is the data controller. They will have their own privacy notice to explain how they process your information. We do not have access to the information you provide to services run by other government departments.",
+        "paragraph5": "When you prove your identity with GOV.UK One Login, we will:",
         "bulletPoint4": "ask you for your passport details - we’ll check these with HM Passport Office (HMPO)",
         "bulletPoint5": {
           "text3": "check your information with",
@@ -994,32 +981,32 @@
       },
       "section2": {
         "header": "What information we collect",
-        "paragraph1": "When you use a service that requires a GOV.UK account, we’ll receive information about the service when it directs you to:",
-        "bulletPoint1": "create or sign in to an account",
+        "paragraph1": "When you use a service that requires a GOV.UK One Login, we’ll receive information about the service when it directs you to:",
+        "bulletPoint1": "create a GOV.UK One Login or sign in",
         "bulletPoint2": "prove your identity",
-        "paragraph2": "The information we collect when you create and use a GOV.UK account includes:",
-        "bulletPoint3": "basic personal information needed to set up and authenticate your account, including your email address and mobile phone number",
+        "paragraph2": "The information we collect when you create and use a GOV.UK One Login includes:",
+        "bulletPoint3": "basic personal information needed to set up and authenticate your GOV.UK One Login, including your email address and mobile phone number, if you choose to get security codes for signing in by text message",
         "bulletPoint4": "other information needed to prove your identity, such as your name, date of birth, passport details and address history",
-        "bulletPoint5": "any information that you choose to save to your account, for example your GOV.UK email subscription preferences",
+        "bulletPoint5": "any information that you choose to save to your GOV.UK One Login, for example your GOV.UK email subscription preferences",
         "bulletPoint6": {
-          "text1": "information on how you use your account and the GOV.UK website, which is collected in the system logs, and by Google Analytics cookies if you give consent - the ",
+          "text1": "information on how you use your GOV.UK One Login and the GOV.UK website, which is collected in the system logs, and by Google Analytics cookies if you give consent - the ",
           "linkText1": "GOV.UK privacy notice",
-          "comma": " , ",
+          "comma": ", ",
           "linkText2": "GOV.UK cookies policy",
           "and": " and ",
-          "linkText3": "GOV.UK accounts cookies policy",
+          "linkText3": "GOV.UK One Login cookies policy",
           "text2": " provide more information about this"
         },
         "bulletPoint7": "online identifiers, such as your Internet Protocol (IP) address, and technical information about the device you use including the model, web browser and operating system, which is automatically collected in system logs when you use GOV.UK",
-        "bulletPoint8": "questions, queries or feedback you leave, including your name and email address, if you provide them on the GOV.UK accounts contact form",
-        "bulletPoint9": "if you were able to prove your identity with your GOV.UK account",
+        "bulletPoint8": "questions, queries or feedback you leave, including your name and email address, if you provide them on the GOV.UK One Login contact form",
+        "bulletPoint9": "if you were able to prove your identity with your GOV.UK One Login",
         "bulletPoint10": "what organisations, services or information we used to prove your identity",
-        "paragraph3": "When you create an account, it will automatically generate a unique account identifier."
+        "paragraph3": "When you create a GOV.UK One Login, it will automatically generate a unique identifier."
       },
       "section3": {
         "header": "Why we need your information",
         "paragraph1": "We collect your personal information to:",
-        "bulletPoint1": "provide you with a GOV.UK account so that you can use it to access online government services",
+        "bulletPoint1": "provide you with a GOV.UK One Login so that you can use it to access online government services",
         "bulletPoint2": "prove your identity",
         "bulletPoint3": {
           "text1": "store your preferences, for example your ",
@@ -1027,27 +1014,27 @@
           "text2": "email subscription update preferences"
         },
         "paragraph2": "We also use your information to:",
-        "bulletPoint4": "keep your account secure (using your email address, phone number, password and system logs)",
+        "bulletPoint4": "keep your GOV.UK One Login secure (using your email address, phone number if provided, password and system logs)",
         "bulletPoint5": "monitor, detect and investigate fraud",
-        "bulletPoint6": "tell the services you access through your GOV.UK account that you have successfully signed in",
-        "bulletPoint7": "provide government services that you access through your account and the departments that run them with information you explicitly agree to us sharing, for example your email and telephone number",
-        "bulletPoint8": "provide you with a record of how your account has been used, for example, when it was last signed in to and what services it has been used with",
-        "bulletPoint9": "contact you about any planned interruptions, problems or changes that may affect your account (using your email address)",
-        "bulletPoint10": "contact you to ask for feedback on your account, if you have given us permission to (using your email address)",
+        "bulletPoint6": "tell the services you access through your GOV.UK One Login that you have successfully signed in",
+        "bulletPoint7": "provide government services that you access through your GOV.UK One Login and the departments that run them with information you explicitly agree to us sharing, for example your email and telephone number",
+        "bulletPoint8": "provide you with a record of how your GOV.UK One Login has been used, for example, when it was last signed in to and what services it has been used with",
+        "bulletPoint9": "contact you about any planned interruptions, problems or changes that may affect your GOV.UK One Login (using your email address)",
+        "bulletPoint10": "contact you to ask for feedback on GOV.UK One Login, if you have given us permission to (using your email address)",
         "bulletPoint11": {
-          "text3": "improve and understand how you use your GOV.UK account",
+          "text3": "improve and understand how you use your GOV.UK One Login",
           "linkText": "using Google Analytics cookies",
           "text4": "(you can choose not to accept these cookies)"
         },
         "bulletPoint12": "respond to any feedback you send us, if you’ve asked us to",
-        "paragraph3": "We may also use your information to produce anonymised reports about GOV.UK accounts. This helps us understand where we can make improvements to GOV.UK accounts."
+        "paragraph3": "We may also use your information to produce anonymised reports about GOV.UK One Login. This helps us understand where we can make improvements to GOV.UK One Login."
       },
       "section4": {
         "header": "Our legal basis for processing your information",
         "paragraph1": "When we process information for security and fraud monitoring, the legal basis is our legitimate interests.",
-        "paragraph2": "When we process information to make improvements to GOV.UK accounts, the legal basis is your explicit consent. This includes:",
-        "bulletPoint1": "collecting and analysing information about how you use your GOV.UK account using Google Analytics cookies",
-        "bulletPoint2": "emailing you to ask for feedback about your account",
+        "paragraph2": "When we process information to make improvements to GOV.UK One Login, the legal basis is your explicit consent. This includes:",
+        "bulletPoint1": "collecting and analysing information about how you use your GOV.UK One Login using Google Analytics cookies",
+        "bulletPoint2": "emailing you to ask for feedback about GOV.UK One Login",
         "paragraph3": "The legal basis for processing all other personal data is that it’s necessary in the exercise of our functions as a government department."
       },
       "section5": {
@@ -1056,15 +1043,15 @@
         "bulletPoint1": "sell or rent your information to third parties",
         "bulletPoint2": "share your information with third parties for marketing purposes",
         "subHeader1": "Sharing your information with online government services and the departments that run them",
-        "paragraph2": "We’ll tell the services that you access through your account when you successfully create your account or sign in so that they can allow you to use the service.",
-        "paragraph3": "Services you access through your account may ask you to share information you have saved in your GOV.UK account. When they do this, we’ll tell you which information they have asked for, and will only share the information if you agree.",
-        "paragraph4": "If you do not choose to share this information from your GOV.UK account, you might be asked to provide the same information directly to the service later on.",
-        "paragraph5": "Each service you access through your GOV.UK account will have its own terms and conditions and privacy notice. You should read these as well as the GOV.UK accounts terms and conditions and this privacy notice, so that you understand how your personal information is managed.",
+        "paragraph2": "We’ll tell the services that you access through your account when you successfully create your GOV.UK One Login or sign in so that they can allow you to use the service.",
+        "paragraph3": "Services you access through your account may ask you to share information you have saved in your GOV.UK One Login. When they do this, we’ll tell you which information they have asked for, and will only share the information if you agree.",
+        "paragraph4": "If you do not choose to share this information from your GOV.UK One Login, you might be asked to provide the same information directly to the service later on.",
+        "paragraph5": "Each service you access through your GOV.UK One Login will have its own terms and conditions and privacy notice. You should read these as well as the GOV.UK One Login terms and conditions and this privacy notice, so that you understand how your personal information is managed.",
         "subHeader2": "Sharing your information to prove your identity",
         "paragraph6": "We’ll share your information with HMPO and Experian when we prove your identity. We’ll only give them the information they need to do this check. They will keep your details for as long as they need to or the law requires them to do so.",
         "subHeader3": "Sharing your information to protect against fraud",
         "paragraph7": "To protect against crime and fraud, we might sometimes share information with:",
-        "bulletPoint3": "government departments that run the services you access though your account",
+        "bulletPoint3": "government departments that run the services you access though your GOV.UK One Login",
         "bulletPoint4": "other public sector organisations, such as the Home Office",
         "bulletPoint5": "law enforcement agencies",
         "bulletPoint6": "credit reference agencies",
@@ -1073,7 +1060,7 @@
         "bulletPoint8": "phone numbers",
         "bulletPoint9": "email addresses",
         "bulletPoint10": "IP addresses and geolocations",
-        "bulletPoint11": "unique account identifiers",
+        "bulletPoint11": "unique identifiers",
         "bulletPoint12": "information about the devices being used",
         "bulletPoint13": "passport details, including name and date of birth",
         "bulletPoint14": "address history",
@@ -1083,29 +1070,29 @@
       "section6": {
         "header": "How long we keep your information",
         "paragraph1": "We store your personal information for as long as is reasonably necessary and legally justifiable.",
-        "paragraph2": "We will keep your account and any information saved in it for as long as you use it. If you delete your account or if you don’t sign in for 2 years, we’ll delete all the information associated with it. Any information you delete from your account will be permanently deleted.",
+        "paragraph2": "We will keep your GOV.UK One Login and any information saved in it for as long as you use it. If you delete your GOV.UK One Login or if you don’t sign in for 2 years, we’ll delete all the information associated with it. Any information you delete from your GOV.UK One Login will be permanently deleted.",
         "paragraph3": "We will keep your feedback data for 2 years.",
         "paragraph4": "We will delete access log data after 365 days.",
-        "paragraph5": "We will store information about the actions you take and how you use the account for 7 years, for fraud monitoring purposes."
+        "paragraph5": "We will store information about the actions you take and how you use your GOV.UK One Login for 7 years, for fraud monitoring purposes."
       },
       "section7": {
         "header": "Children’s privacy protection",
-        "paragraph1": "GOV.UK accounts are not designed for, or intentionally targeted at, children 13 years of age or younger. We do not intentionally collect or maintain information about anyone under the age of 13."
+        "paragraph1": "GOV.UK One Login is not designed for, or intentionally targeted at, children 13 years of age or younger. We do not intentionally collect or maintain information about anyone under the age of 13."
       },
       "section8": {
         "header": "Where your information is processed and stored",
-        "paragraph1": "All personal data and information associated with your GOV.UK account is stored in the UK or in the European Economic Area (EEA). The EEA has been assessed by the Information Commissioner’s Office as having adequate legal protections for data privacy in line with those in the UK.",
+        "paragraph1": "All personal data and information associated with your GOV.UK One Login is stored in the UK or in the European Economic Area (EEA). The EEA has been assessed by the Information Commissioner’s Office as having adequate legal protections for data privacy in line with those in the UK.",
         "paragraph2": "Where our suppliers require access to your data, they may do so from outside of the EEA. Data collected by Google Analytics may be transferred outside the European Economic Area (EEA) for processing. When either of these things happen, we will make sure your information is just as well protected, for example by including extra clauses in our contracts with suppliers."
       },
       "section9": {
         "header": "How we protect your personal information and keep it secure",
         "paragraph1": "We are committed to doing all that we can to keep your information secure. We have set up systems and processes to prevent unauthorised access or disclosure of your information - for example, we use varying levels of encryption. We also make sure that any third parties that we deal with keep all personal information they process on our behalf secure.",
-        "paragraph2": "As the owner of your GOV.UK account, you also have some responsibility for the security of your account. For example, you should:",
+        "paragraph2": "As the owner of your GOV.UK One Login, you also have some responsibility for its security. For example, you should:",
         "bulletPoint1": {
-          "text1": "choose a strong password for your account and ensure you keep it secure - the UK’s National Cyber Security Centre (NCSC) provides ",
-          "linkText": "advice on keeping your online accounts secure"
+          "text1": "choose a strong password and ensure you keep it secure - the UK’s National Cyber Security Centre (NCSC) provides ",
+          "linkText": "advice on online security"
         },
-        "bulletPoint2": "contact us immediately if you suspect that your account has been compromised"
+        "bulletPoint2": "contact us immediately if you suspect that your GOV.UK One Login has been compromised"
       },
       "section10": {
         "header": "Automated processing",
@@ -1116,12 +1103,12 @@
       },
       "section11": {
         "header": "Your rights",
-        "paragraph1": "When you are signed in to your account you can:",
-        "bulletPoint1": "access all personal information associated with your GOV.UK account",
+        "paragraph1": "When you are signed in to GOV.UK One Login you can:",
+        "bulletPoint1": "access all personal information associated with your GOV.UK One Login",
         "bulletPoint2": "change or update your information such as your email address, password and email subscription preferences",
         "bulletPoint3": "change your consent to non-essential cookies or tell us how you want us to contact you",
-        "bulletPoint4": "delete information from your account (apart from your email address, mobile phone number and password because you can’t access your account without them)",
-        "bulletPoint5": "delete your GOV.UK account entirely",
+        "bulletPoint4": "delete information from your GOV.UK One Login (apart from your email address, password, and mobile phone number, if you do not have another way to authenticate your GOV.UK One Login, because you can’t access your GOV.UK One Login without them)",
+        "bulletPoint5": "delete your GOV.UK One Login entirely",
         "paragraph2": "You can also:",
         "bulletPoint6": "withdraw your consent for your personal information to be processed using web analytics data or feedback",
         "bulletPoint7": "object to how your personal information is processed",
@@ -1182,7 +1169,7 @@
         "validationError": {
           "required": "Enter your password",
           "maxLength": "Your password must be less than 256 characters",
-          "samePassword": "Your account is already using that password. Enter a different password",
+          "samePassword": "You are already using that password. Enter a different password",
           "alphaNumeric": "Your password must be at least 8 characters long and must include letters and numbers"
         }
       },
@@ -1246,7 +1233,7 @@
     "accountLocked": {
       "title": "You entered the wrong password too many times",
       "header": "You entered the wrong password too many times",
-      "paragraph": "You’ve been locked out of your account because you entered the wrong password more than 5 times. This is to keep your account secure.",
+      "paragraph": "You’ve been locked out of your GOV.UK One Login because you entered the wrong password more than 5 times. This is to keep your GOV.UK One Login secure.",
       "subHeader": "What next",
       "bulletPointSection": {
         "title": "You can:",
@@ -1258,8 +1245,8 @@
     "browserBackButtonError": {
       "title": "Sorry, you cannot go back from that page",
       "header": "Sorry, you cannot go back from that page",
-      "paragraph1": "You’ll need to start again to create your account or sign in.",
-      "returnToAccountCreationButtonText": "Back to create your account or sign in",
+      "paragraph1": "You’ll need to start again to create your GOV.UK One Login or sign in.",
+      "returnToAccountCreationButtonText": "Back to create your GOV.UK One Login or sign in.",
       "returnToAccountCreationButtonLink": "/sign-in-or-create"
     },
     "support": {
@@ -1302,21 +1289,21 @@
     },
     "contactUsPublic": {
       "title": "Contact us",
-      "header": "GOV.UK account: report a problem or give feedback",
+      "header": "GOV.UK One Login: report a problem or give feedback",
       "section1": {
         "paragraph1": "Use this form to:",
-        "bulletPoint1": "tell us about a problem you’re having with your GOV.UK account",
-        "bulletPoint2": "suggest improvements or give feedback about your experience using your GOV.UK account",
+        "bulletPoint1": "tell us about a problem you’re having with your GOV.UK One Login",
+        "bulletPoint2": "suggest improvements or give feedback about your experience using your GOV.UK One Login",
         "paragraph2": "Our office hours are 9:30am to 5:30pm, Monday to Friday. We’ll respond to you by email in 2 working days."
       },
       "section3": {
         "header": "What are you contacting us about?",
-        "accountCreation": "A problem creating a GOV.UK account",
-        "signingIn": "A problem signing in to your GOV.UK account",
+        "accountCreation": "A problem creating a GOV.UK One Login",
+        "signingIn": "A problem signing in to your GOV.UK One Login",
         "provingIdentity": "A problem proving your identity",
-        "somethingElse": "Another problem using your GOV.UK account",
+        "somethingElse": "Another problem using your GOV.UK One Login",
         "emailSubscriptions": "GOV.UK email subscriptions",
-        "suggestionsFeedback": "A suggestion or feedback about using your GOV.UK account",
+        "suggestionsFeedback": "A suggestion or feedback about using your GOV.UK One Login",
         "idCheckApp": "A problem proving your identity using the GOV.UK ID Check app",
         "errorMessage": "Select a reason for contacting us"
       },
@@ -1324,23 +1311,23 @@
     },
     "contactUsFurtherInformation": {
       "signingIn": {
-        "title": "A problem signing in to your GOV.UK account",
-        "header": "A problem signing in to your GOV.UK account",
+        "title": "A problem signing in to your GOV.UK One Login",
+        "header": "A problem signing in to your GOV.UK One Login",
         "section1": {
           "header": "Tell us what happened",
           "radio1": "You did not get a security code",
           "radio2": "The security code did not work",
           "radio3": "You’ve changed your phone number or lost your phone",
           "radio4": "You’ve forgotten your password",
-          "radio5": "You’ve been told your account ‘cannot be found’",
+          "radio5": "You’ve been told your GOV.UK One Login ‘cannot be found’",
           "radio6": "There was a technical problem (for example, the service was unavailable)",
           "radio7": "Something else",
-          "errorMessage": "Select the problem you had when signing in to your account"
+          "errorMessage": "Select the problem you had when signing in to your GOV.UK One Login"
         }
       },
       "accountCreation": {
-        "title": "A problem creating a GOV.UK account",
-        "header": "A problem creating a GOV.UK account",
+        "title": "A problem creating a GOV.UK One Login",
+        "header": "A problem creating a GOV.UK One Login",
         "section1": {
           "header": "Tell us what happened",
           "radio1": "You did not get a security code",
@@ -1349,7 +1336,7 @@
           "radio4": "There was a technical problem (for example, the service was unavailable)",
           "radio5": "Something else",
           "radio6": "You had a problem with an authenticator app",
-          "errorMessage": "Select the problem you had when creating an account"
+          "errorMessage": "Select the problem you had when creating your GOV.UK One Login"
         }
       },
       "idCheckApp": {
@@ -1395,8 +1382,8 @@
         "privacyNote": "Read our <a href=\"/privacy-notice\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">privacy notice</a> for more information on how we use your personal information."
       },
       "anotherProblem": {
-        "title": "Another problem using your GOV.UK account",
-        "header": "Another problem using your GOV.UK account",
+        "title": "Another problem using your GOV.UK One Login",
+        "header": "Another problem using your GOV.UK One Login",
         "section1": {
           "header": "What were you trying to do?",
           "errorMessage": "Enter what you were trying to do"
@@ -1433,8 +1420,8 @@
         }
       },
       "suggestionOrFeedback": {
-        "title": "A suggestion or feedback about using your GOV.UK account",
-        "header": "A suggestion or feedback about using your GOV.UK account",
+        "title": "A suggestion or feedback about using your GOV.UK One Login",
+        "header": "A suggestion or feedback about using your GOV.UK One Login",
         "section1": {
           "header": "Your suggestion or feedback",
           "errorMessage": "Enter your suggestion or feedback"
@@ -1543,8 +1530,8 @@
         }
       },
       "accountCreationProblem": {
-        "title": "Another problem creating an account",
-        "header": "Another problem creating an account",
+        "title": "Another problem creating your GOV.UK One Login",
+        "header": "Another problem creating your GOV.UK One Login",
         "section1": {
           "header": "Anything else you want to tell us",
           "paragraph1": "For example, if you want to add more detail or give us feedback",
@@ -1552,8 +1539,8 @@
         }
       },
       "signignInProblem": {
-        "title": "Another problem signing in to your account",
-        "header": "Another problem signing in to your account",
+        "title": "Another problem signing in to your GOV.UK One Login",
+        "header": "Another problem signing in to your GOV.UK One Login",
         "section1": {
           "header": "Anything else you want to tell us",
           "paragraph1": "For example, if you want to add more detail or give us feedback",
@@ -1561,8 +1548,8 @@
         }
       },
       "accountNotFound": {
-        "title": "Your account cannot be found",
-        "header": "Your account cannot be found",
+        "title": "Your GOV.UK One Login cannot be found",
+        "header": "Your GOV.UK One Login cannot be found",
         "section1": {
           "header": "What service were you trying to use?",
           "paragraph1": "For example, your GOV.UK email subscriptions, your personal tax account or Universal Credit",
@@ -1628,8 +1615,8 @@
       "header": "placeholder"
     },
     "proveIdentityWelcome": {
-      "title": "Prove your identity with a GOV.UK account",
-      "header": "Prove your identity with a GOV.UK account",
+      "title": "Prove your identity with GOV.UK One Login",
+      "header": "Prove your identity with GOV.UK One Login",
       "section1": {
         "paragraph1": "It will take you about 10 minutes to prove your identity this way.",
         "insetAlternativeLanguage": {
@@ -1646,17 +1633,7 @@
       },
       "section2": {
         "paragraph1": "You’ll need:",
-        "listItem1_1": "a GOV.UK account – we’ll ask you to create or sign in to your account when you continue",
-        "listItem1_2": "your photo ID",
-        "listItem1_3": "your current home address (you might also need your previous address if you’ve recently moved)",
-        "paragraph2": "We’ll only use the information you give us to make sure that you are who you say you are."
-      },
-      "existingSession": {
-        "section3": {
-          "radioOption1": "Continue with your GOV.UK account"
-        },
-        "paragraph1": "You’ll need:",
-        "listItem1_1": "a GOV.UK account – we’ll ask you to create or sign in to your account when you continue",
+        "listItem1_1": "a GOV.UK One Login – we’ll ask you to sign in or create one when you continue",
         "listItem1_2": "your photo ID",
         "listItem1_3": "your current home address (you might also need your previous address if you’ve recently moved)",
         "paragraph2": "We’ll only use the information you give us to make sure that you are who you say you are."
@@ -1671,10 +1648,10 @@
     "getSecurityCodes": {
       "title": "Choose how to get security codes",
       "header": "Choose how to get security codes",
-      "summary": "To finish creating your account, you need to choose a way to prove it’s you when you sign in.",
-      "titleAccountPartCreated": "Finish creating your account",
-      "headerAccountPartCreated": "Finish creating your account",
-      "summaryAccountPartCreated": "Choose a way to get security codes when you sign in. This helps keep your account secure.",
+      "summary": "To finish creating your GOV.UK One Login, choose a way to prove it’s you when you sign in. ",
+      "titleAccountPartCreated": "Finish creating your GOV.UK One Login",
+      "headerAccountPartCreated": "Finish creating your GOV.UK One Login",
+      "summaryAccountPartCreated": "Choose a way to get security codes when you sign in. This helps keep your GOV.UK One Login secure.",
       "secondFactorRadios": {
         "textMessageText": "Text message",
         "authAppText": "Authenticator app for smartphone, tablet or computer",
@@ -1730,9 +1707,9 @@
       }
     },
     "photoId": {
-      "title": "You must have a photo ID to prove your identity with a GOV.UK account",
-      "header": "You must have a photo ID to prove your identity with a GOV.UK account",
-      "introParagraph": "You can only prove your identity with a GOV.UK account if you have one of the following types of photo ID.",
+      "title": "You must have a photo ID to prove your identity with GOV.UK One Login",
+      "header": "You must have a photo ID to prove your identity with GOV.UK One Login",
+      "introParagraph": "You can only prove your identity with GOV.UK One Login if you have one of the following types of photo ID.",
       "section1": {
         "subHeading": "UK photocard driving licence",
         "paragraph1": "You’ll need a valid full or provisional driving licence with your photo on it."
@@ -1753,7 +1730,7 @@
       "title": "You must have a photo ID to prove your identity this way",
       "header": "You must have a photo ID to prove your identity this way",
       "section1": {
-        "paragraph1": "You can currently only prove your identity with your GOV.UK account if you have a photo ID."
+        "paragraph1": "You can currently only prove your identity with GOV.UK One Login if you have a photo ID."
       },
       "section2": {
         "subHeading": "What you can do",
@@ -1781,9 +1758,9 @@
       }
     },
     "signInRetryBlocked": {
-      "title": "Your account is locked",
-      "header": "Your account is locked",
-      "paragraph": "This is because you entered the wrong password more than 5 times the last time you tried to sign in. This is to keep your account secure.",
+      "title": "You cannot sign in at the moment",
+      "header": "You cannot sign in at the moment",
+      "paragraph": "This is because you entered the wrong password more than 5 times the last time you tried to sign in. This is to keep your GOV.UK One Login secure.",
       "info": {
         "paragraph1Start": "You can ",
         "firstLink": "try to sign in again",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -487,6 +487,23 @@
         "text 2": " if the code is not working or you did not receive it."
       }
     },
+    "youNeedToEnterASecurityCode": {
+      "title": "You need to enter a security code",
+      "header": "You need to enter a security code",
+      "paragraph1": "This helps your GOV.UK account secure.",
+      "paragraph2": "To get a security code, open the ",
+      "authenticatorApp": "authenticator app ",
+      "paragraph2End": "you used to create your GOV.UK account",
+      "paragraph3": "We sent a code to the phone number linked to your account.",
+      "paragraph4": "It might take a few minutes for the code to arrive. The code will expire after 15 minutes.",
+      "enterSecurityCode": "Enter the security code",
+      "enterSecurityCodeSummary": "This is the 6-digit number shown in your authenticator app",
+      "enter6DigitSecurityCode": "Enter the 6 digit security code",
+      "problemsWithTheCode": "Problems with the code?",
+      "sendTheCodeAgain": "Send the code again",
+      "sendTheCodeAgainEnd": " if the code is not working or you did not receive it.",
+      "continue": "Continue"
+    },
     "resendMfaCode": {
       "title": "Get security code",
       "header": "Get security code",

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export interface UserSession {
   featureFlags?: any;
   wrongCodeEnteredLock?: string;
   codeRequestLock?: string;
+  mfaMethodType?: string;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What?

When a user signs in with `1FA` tries to access another service like account management, they are required to go through `2FA` regardless of their authentication level.

- Implement content for users with verified by `authenticator app`
- Implement content for users verified by `Phone/SMS`

## Why?

So that a user signed in with 1FA understands why they are required to go through 2FA process in order to access the RP's service.
 
## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated
