### PR TITLE
Fix: Replace English text in Welsh Accessibility Statement

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -759,7 +759,7 @@
         "paragraph1": "Nid yw’r rhannau canlynol o GOV.UK One Login yn gwbl hygyrch:",
         "bulletPoint1": "nid yw’n bosib stopio na newid hyd yr amseru allan pan fyddwch yn defnyddio, mewngofnodi i neu greu GOV.UK One Login",
         "bulletPoint2": "nid yw’n bosib i ddarllenydd sgrin wybod pryd mae’r e-byst rydym yn eu hanfon mewn iaith ar wahân i’r Saesneg",
-        "bulletPoint3": "one page reloads automatically after a set time limit, and it’s not possible to stop or delay this",
+        "bulletPoint3": "mae un dudalen yn ail-lwytho yn awtomatig ar ôl terfyn amser penodol, ac nid yw’n bosibl i stopio neu oedi hyn",
         "paragraph2": "Byddwn yn diweddaru’r dudalen hon pan fydd y materion wedi cael eu datrys neu gyda gwybodaeth ynghylch pryd rydym yn bwriadu eu datrys."
       },
       "section3": {


### PR DESCRIPTION
## What?

Replaces an English sentence that was found in the Accessibility Statement with the Welsh language equivalent.

## Why?

There should not be English text in the Welsh language page.

## Change have been demonstrated

- [x] Changes to the user interface have been demonstrated
