### PR TITLE
BAU - Enable International Numbers in Integration

### DIFF
--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -5,7 +5,7 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
-support_international_numbers = "0"
+support_international_numbers = "1"
 support_language_cy           = "1"
 
 logging_endpoint_arns = [


### PR DESCRIPTION
## What?

 - Enable International Numbers in Integration

## Why?

- We are close to going live and need to enable them in all non prod environments first

