### PR TITLE
PYIC-2431 Update unhappy path page title

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1724,8 +1724,8 @@
       }
     },
     "noPhotoId": {
-      "title": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych chi fel hyn",
-      "header": "Mae’n rhaid i chi gael ID llun er mwyn profi pwy ydych chi fel hyn",
+      "title": "Mae angen i chi brofi pwy ydych chi mewn ffordd arall",
+      "header": "Mae angen i chi brofi pwy ydych chi mewn ffordd arall",
       "section1": {
         "paragraph1": "Ar hyn o bryd gallwch ond profi pwy ydych chi gyda GOV.UK One Login os oes gennych ID gyda llun."
       },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1724,8 +1724,8 @@
       }
     },
     "noPhotoId": {
-      "title": "You must have a photo ID to prove your identity this way",
-      "header": "You must have a photo ID to prove your identity this way",
+      "title": "You need to prove your identity another way",
+      "header": "You need to prove your identity another way",
       "section1": {
         "paragraph1": "You can currently only prove your identity with GOV.UK One Login if you have a photo ID."
       },


### PR DESCRIPTION
## What?

A content change to reassure users they can still continue their journey, but will need to prove their identity in a different way.

## Why?

This change was proposed by the content designer on the core team because the current `title` and `H1` makes this sound like more of a dead end for users than it actually is.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [ ] Changes to the user interface can be viewed in the [JIRA ticket](https://govukverify.atlassian.net/browse/PYIC-2431)

## Related PRs

Please include links to PRs in other repositories relevant to this PR.

* [Related change in core-front repository](https://github.com/alphagov/di-ipv-core-front/pull/690)
