### PR TITLE
AUT-1061: Revise messages on error pages, for 400, 500 error codes

### DIFF
--- a/src/components/common/errors/404.njk
+++ b/src/components/common/errors/404.njk
@@ -7,7 +7,10 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">{{'error.error404.header' | translate }}</h1>
     <p class="govuk-body">{{'error.error404.content.paragraph1' | translate }}</p>
+    <p class="govuk-heading-m">{{'error.error404.content.whatYouCanDo' | translate }}</p>
     <p class="govuk-body">{{'error.error404.content.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{'error.error404.content.paragraph3' | translate }}</p>
+    <p class="govuk-body">{{'error.error404.content.paragraph4' | translate }}</p>
 
     {{ govukButton({
     "text": "error.error404.content.govUKHomepageButtonText" | translate,

--- a/src/components/common/errors/session-expired.njk
+++ b/src/components/common/errors/session-expired.njk
@@ -7,6 +7,7 @@
 
 <h1 class="govuk-heading-l">{{ 'error.timeoutError.header' | translate }}</h1>
 <p class="govuk-body">{{ 'error.timeoutError.content.paragraph1' | translate }}</p>
+<p class="govuk-heading-m">{{'error.timeoutError.content.whatYouCanDo' | translate }}</p>
 <p class="govuk-body">{{ 'error.timeoutError.content.paragraph2' | translate }}</p>
 
 {{ govukButton({

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -92,15 +92,18 @@
       "title": "Tudalen heb ei darganfod",
       "header": "Tudalen heb ei darganfod",
       "content": {
-        "paragraph1": "Os ydych wedi teipio’r cyfeiriad gwe, edrychwch i weld ei fod yn gywir.",
-        "paragraph2": "Os ydych wedi gludo’r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo’r cyfeiriad cyfan.",
+        "paragraph1": "Ni allwn ddod o hyd i’r dudalen rydych chi’n chwilio amdani.",
+        "whatYouCanDo": "Beth allwch chi ei wneud",
+        "paragraph2": "Os ydych wedi teipio’r cyfeiriad gwe, edrychwch i weld ei fod yn gywir.",
+        "paragraph3": "Os ydych wedi gludo’r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo’r cyfeiriad cyfan.",
+        "paragraph4": "Gallwch hefyd fynd i hafan GOV.UK i ddod o hyd i’r gwasanaeth roeddech yn ceisio ei ddefnyddio, neu edrych amdano drwy ddefnyddio eich peiriant chwilio.",
         "govUKHomepageButtonHref": "https://www.gov.uk/",
         "govUKHomepageButtonText": "Ewch i hafan GOV.UK"
       }
     },
     "error500": {
       "title": "Mae problem gyda’r gwasanaeth hwn",
-      "header": "Mae’n ddrwg gennym, mae problem gyda’r gwasanaeth hwn",
+      "header": "Mae’n ddrwg gennym, mae problem",
       "content": {
         "paragraph1": "Rhowch gynnig arall yn nes ymlaen."
       }
@@ -110,7 +113,8 @@
       "header": "Mae’n ddrwg gennym, mae’r dudalen wedi dod i ben",
       "content": {
         "paragraph1": "Mae hyn oherwydd na wnaethoch unrhyw beth am fwy na 2 awr. ",
-        "paragraph2": "Bydd angen i chi ddechrau’r hyn roeddech yn ei wneud eto.",
+        "whatYouCanDo": "Beth allwch chi ei wneud",
+        "paragraph2": "Ewch yn ôl i’r gwasanaeth roeddech chi’n ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio eich peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.",
         "govUKHomepageButtonHref": "https://www.gov.uk/",
         "govUKHomepageButtonText": "Ewch i hafan GOV.UK"
       }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -92,15 +92,18 @@
       "title": "Page not found",
       "header": "Page not found",
       "content": {
-        "paragraph1": "If you typed the web address, check it is correct.",
-        "paragraph2": "If you pasted the web address, check you copied the entire address.",
+        "paragraph1": "We cannot find the page you’re looking for.",
+        "whatYouCanDo": "What you can do",
+        "paragraph2": "If you typed the web address, check it is correct.",
+        "paragraph3": "If you pasted the web address, check you copied the entire address.",
+        "paragraph4": "You can also go to the GOV.UK homepage to find the service you were trying to use, or look for it using your search engine.",
         "govUKHomepageButtonHref": "https://www.gov.uk/",
         "govUKHomepageButtonText": "Go to the GOV.UK homepage"
       }
     },
     "error500": {
       "title": "There’s a problem with this service",
-      "header": "Sorry, there’s a problem with this service",
+      "header": "Sorry, there is a problem",
       "content": {
         "paragraph1": "Try again later."
       }
@@ -110,7 +113,8 @@
       "header": "Sorry, the page has expired",
       "content": {
         "paragraph1": "This is because you did not do anything for more than 2 hours. ",
-        "paragraph2": "You’ll need to start what you were doing again.",
+        "whatYouCanDo": "What you can do",
+        "paragraph2": "Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.",
         "govUKHomepageButtonHref": "https://www.gov.uk/",
         "govUKHomepageButtonText": "Go to the GOV.UK homepage"
       }


### PR DESCRIPTION
## What?

Revise error message for the following pages:

- 404/page not found
<img width="1039" alt="Screenshot 2023-02-20 at 13 51 32" src="https://user-images.githubusercontent.com/110528805/220134756-8fa0e79d-3a43-46b5-ae87-5f2ecb39a550.png">

- Session timeout 
<img width="1038" alt="Screenshot 2023-02-20 at 13 56 11" src="https://user-images.githubusercontent.com/110528805/220134795-bee9be9e-98b3-421d-902a-25c3fff00ed6.png">

- 500/Internal service error
<img width="1016" alt="Screenshot 2023-02-20 at 14 32 45" src="https://user-images.githubusercontent.com/110528805/220134819-7b01d6a3-55ad-4c67-9f91-af5d5c9f6719.png">

## Why?

So that users have a better understanding of why there's an error

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Related PRs
[Service Unavailable](https://github.com/alphagov/di-infrastructure/pull/468)
