### PR TITLE
AUT-1075: Move secondary CTAs below primary CTAs

### DIFF
--- a/src/components/check-your-email/index.njk
+++ b/src/components/check-your-email/index.njk
@@ -49,16 +49,16 @@
     </p>
     {% endset %}
 
-    {{ govukDetails({
-  summaryText: 'pages.checkYourEmail.details.summaryText' | translate,
-  html: detailsHTML
-}) }}
-
     {{ govukButton({
-    "text": "general.continue.label" | translate,
-    "type": "Submit",
-    "preventDoubleClick": true
-}) }}
+      "text": "general.continue.label" | translate,
+      "type": "Submit",
+      "preventDoubleClick": true
+    }) }}
+
+    {{ govukDetails({
+      summaryText: 'pages.checkYourEmail.details.summaryText' | translate,
+      html: detailsHTML
+    }) }}
 
   </form>
 

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -57,18 +57,18 @@
         <a href="{{'pages.checkYourPhone.details.changeMfaChoiceLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.changeMfaChoiceLinkText'| translate}}</a>.
       </p>
 
-      {% endset %}
+    {% endset %}
+
+    {{ govukButton({
+      "text": "general.continue.label" | translate,
+      "type": "Submit",
+      "preventDoubleClick": true
+    }) }}
 
     {{ govukDetails({
       summaryText: 'pages.checkYourPhone.details.summaryText' | translate,
       html: detailsHTML
     }) }}
-
-    {{ govukButton({
-  "text": "general.continue.label" | translate,
-  "type": "Submit",
-  "preventDoubleClick": true
-  }) }}
 
   </form>
 

--- a/src/components/enter-password/index-account-exists.njk
+++ b/src/components/enter-password/index-account-exists.njk
@@ -38,15 +38,16 @@
         },
         "off"
     ) }}
+
+    {{ govukButton({
+        "text": "general.continue.label" | translate,
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
+
 <p class="govuk-body">
     <a href="/reset-password-request" class="govuk-link" rel="noreferrer noopener">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>
 </p>
-
-{{ govukButton({
-    "text": "general.continue.label" | translate,
-    "type": "Submit",
-    "preventDoubleClick": true
-}) }}
 
 </form>
 

--- a/src/components/enter-password/index.njk
+++ b/src/components/enter-password/index.njk
@@ -30,15 +30,15 @@
     "off"
 ) }}
 
-<p class="govuk-body">
-    <a href="/reset-password-request" class="govuk-link" rel="noreferrer noopener">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>
-</p>
-
 {{ govukButton({
     "text": "general.continue.label" | translate,
     "type": "Submit",
     "preventDoubleClick": true
 }) }}
+
+<p class="govuk-body">
+    <a href="/reset-password-request" class="govuk-link" rel="noreferrer noopener">{{'pages.enterPassword.forgottenPassword.text' | translate }}</a>
+</p>
 
 </form>
 


### PR DESCRIPTION
## What?

Moves secondary call to action (CTA) links below primary CTAs.

## Why?

Design have identified that we are not applying these consistently. In some instances they are placed above the button CTA while in other instances they are placed below. It has been decided that secondary CTAs should be below.

## Changes
This changes four pages: "You have a GOV.UK One Login"; "Enter your password"; "Check your phone", and; "Check your email". Screenshots after the change are shown below. 

![You-have-a-GOV-UK-One-Login-GOV-UK-One-Login](https://user-images.githubusercontent.com/16000203/220372163-d318efd4-9f05-482c-a661-d2a52eab20c8.png)

![Enter-your-password-GOV-UK-One-Login](https://user-images.githubusercontent.com/16000203/220371517-c2655dbb-e3bb-4e03-8f88-4ebf5551c3a5.png)

![Check-your-phone-GOV-UK-One-Login](https://user-images.githubusercontent.com/16000203/220371564-2cf6395a-3d04-402d-ad83-e990899baa9e.png)

![Check-your-email-GOV-UK-One-Login](https://user-images.githubusercontent.com/16000203/220372284-946e574b-338c-4867-98b7-97aacefad7a6.png)


## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [ ] Changes to the user interface have been demonstrated
