### PR TITLE
AUT-1116: Change One Login Sign In link to secondary button

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -68,15 +68,19 @@
     text: 'pages.signInOrCreate.createButtonText' | translate,
     value: "create",
     name: "optionSelected",
+    classes: "govuk-!-margin-right-3",
     attributes: {
       "id": "create-account-link"
     }
   }) }}
 
-    <p class="govuk-body">
-      {{ 'pages.signInOrCreate.paragraph2' | translate }}
-      <a href="/sign-in-or-create?redirectPost=true" class="govuk-link" id="sign-in-link">{{ 'pages.signInOrCreate.signInText' | translate }}</a>.
-    </p>
+    {{ govukButton({
+      text: 'pages.signInOrCreate.signInText' | translate,
+      classes: "govuk-button--secondary",
+      attributes: {
+        "id": "sign-in-button"
+      }
+    }) }}
 
   </form>
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -155,8 +155,7 @@
         },
         "linkHref": "?lng=en"
       },
-      "paragraph2": "Os oes gennych GOV.UK One Login yn barod gallwch",
-      "signInText": "fewngofnodi",
+      "signInText": "Fewngofnodi",
       "moreAbout": {
         "header": "Am GOV.UK One Login",
         "paragraph1": "Mae GOV.UK One Login yn newydd. Ar hyn o bryd gallwch ond defnyddio eich GOV.UK One Login gyda:",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -155,8 +155,7 @@
         },
         "linkHref": "?lng=cy"
       },
-      "paragraph2": "If you already have a GOV.UK One Login you can",
-      "signInText": "sign in",
+      "signInText": "Sign in",
       "moreAbout": {
         "header": "About GOV.UK One Login",
         "paragraph1": "GOV.UK One Login is new. At the moment you can only use it with:",


### PR DESCRIPTION
## What?

Change current ‘Sign in’ link on the ‘Create a [GOV.UK](http://gov.uk/) One Login or sign in’ page to a secondary button.

## Why?

After seeing an increase in the number of users landing on the `You already have an account` page which was a sign of users mistakenly choosing to create account rather than sign in. To avoid confusion, a secondary button is used as supposed to a text with a link attached.

![image](https://user-images.githubusercontent.com/110528805/223779909-9a765441-9de7-4330-aeb6-df1131df52de.png)

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated