### PR TITLE
AUT-1061: Remove wrapping around paragraphs on the Page not found screen

### DIFF
--- a/src/components/common/errors/404.njk
+++ b/src/components/common/errors/404.njk
@@ -3,20 +3,16 @@
 {% set pageTitleName = 'error.error404.title' | translate %}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">{{'error.error404.header' | translate }}</h1>
-    <p class="govuk-body">{{'error.error404.content.paragraph1' | translate }}</p>
-    <p class="govuk-heading-m">{{'error.error404.content.whatYouCanDo' | translate }}</p>
-    <p class="govuk-body">{{'error.error404.content.paragraph2' | translate }}</p>
-    <p class="govuk-body">{{'error.error404.content.paragraph3' | translate }}</p>
-    <p class="govuk-body">{{'error.error404.content.paragraph4' | translate }}</p>
+    <h1 class="govuk-heading-l">{{ 'error.error404.header' | translate }}</h1>
+    <p class="govuk-body">{{ 'error.error404.content.paragraph1' | translate }}</p>
+    <p class="govuk-heading-m">{{ 'error.error404.content.whatYouCanDo' | translate }}</p>
+    <p class="govuk-body">{{ 'error.error404.content.paragraph2' | translate }}</p>
+    <p class="govuk-body">{{ 'error.error404.content.paragraph3' | translate }}</p>
+    <p class="govuk-body">{{ 'error.error404.content.paragraph4' | translate }}</p>
 
     {{ govukButton({
-    "text": "error.error404.content.govUKHomepageButtonText" | translate,
-    "type": "Submit",
-    "href": "error.error404.content.govUKHomepageButtonHref" | translate
+        "text": "error.error404.content.govUKHomepageButtonText" | translate,
+        "type": "Submit",
+        "href": "error.error404.content.govUKHomepageButtonHref" | translate
     }) }}
-  </div>
-</div>
 {% endblock %}


### PR DESCRIPTION
## What?

Response to bug raised to fix styling on `Page not found` error screen 

## Why?

To ensure the paragraphs run the full width of the page

From:
![image](https://user-images.githubusercontent.com/110528805/224015086-28214fa6-de00-42d6-9089-3094d9b207ef.png)

To:
![image](https://user-images.githubusercontent.com/110528805/224015209-0c797484-f59e-4abe-86ee-049ef0c55015.png)

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

## Related PRs

[Origial PR](939)