### PR TITLE
AUT-1051: Add no session middleware

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -99,7 +99,10 @@ export const API_ENDPOINTS = {
 export const ERROR_MESSAGES = {
   FAILED_HTTP_REQUEST: "Failed HTTP request",
   INVALID_CSRF_TOKEN: "Invalid CSRF token",
-  INVALID_SESSION: "Invalid session",
+  INVALID_SESSION_GOV_UK_INTERNAL_REQUEST:
+    "Invalid session and referrer has gov.uk domain",
+  INVALID_SESSION_NON_GOV_UK_EXTERNAL_REQUEST:
+    "Invalid session and referrer does not have gov.uk domain",
   INVALID_HTTP_REQUEST: "Invalid HTTP request",
   FORBIDDEN: "Unauthorized HTTP request",
   INTERNAL_SERVER_ERROR: "Internal server error",

--- a/src/components/common/errors/mid-journey-direct-navigation-without-session.njk
+++ b/src/components/common/errors/mid-journey-direct-navigation-without-session.njk
@@ -1,0 +1,15 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitleName = 'error.sessionRequiredMidJourneyError.title' | translate %}
+
+{% block content %}
+
+<h1 class="govuk-heading-l">{{ 'error.sessionRequiredMidJourneyError.header' | translate }}</h1>
+
+<p class="govuk-body">
+    <a href={{accountManagementUrl}} class="govuk-link govuk-body" id="oneLoginAcctMgmtHomeLink">{{ 'error.sessionRequiredMidJourneyError.content.paragraph1.text1' | translate }}</a>{{ 'error.sessionRequiredMidJourneyError.content.paragraph1.text2' | translate }}
+    <a href="{{'error.sessionRequiredMidJourneyError.content.govUKHomepageButtonHref' | translate}}" class="govuk-link govuk-body" id="govUkHomeLink">{{ 'error.sessionRequiredMidJourneyError.content.paragraph1.text3' | translate }}</a>.
+</p>
+
+{% endblock %}

--- a/src/handlers/internal-server-error-handler.ts
+++ b/src/handlers/internal-server-error-handler.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express";
-import { HTTP_STATUS_CODES } from "../app.constants";
+import { getAccountManagementUrl } from "../config";
+import { ERROR_MESSAGES, HTTP_STATUS_CODES } from "../app.constants";
 
 export function serverErrorHandler(
   err: any,
@@ -9,6 +10,16 @@ export function serverErrorHandler(
 ): void {
   if (res.headersSent) {
     return next(err);
+  }
+
+  if (
+    res.statusCode == HTTP_STATUS_CODES.UNAUTHORIZED &&
+    err.message === ERROR_MESSAGES.INVALID_SESSION_NON_GOV_UK_EXTERNAL_REQUEST
+  ) {
+    return res.render(
+      "common/errors/mid-journey-direct-navigation-without-session.njk",
+      { accountManagementUrl: getAccountManagementUrl() }
+    );
   }
 
   if (res.statusCode == HTTP_STATUS_CODES.UNAUTHORIZED) {

--- a/src/handlers/tests/internal-server-error-handler.test.ts
+++ b/src/handlers/tests/internal-server-error-handler.test.ts
@@ -1,0 +1,81 @@
+import { expect } from "chai";
+import { NextFunction, Request, Response } from "express";
+import sinon from "sinon";
+import { ERROR_MESSAGES, HTTP_STATUS_CODES } from "../../app.constants";
+import { serverErrorHandler } from "../internal-server-error-handler";
+
+describe("serverErrorHandler", () => {
+  let req: Request;
+  let res: Response;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    req = {} as Request;
+    res = {
+      headersSent: false,
+      statusCode: 200,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      render: () => {},
+      status: function (newStatus: number) {
+        this.statusCode = newStatus;
+      },
+    } as unknown as Response;
+    next = sinon.spy();
+  });
+
+  it("should call next if headers have already been sent", () => {
+    res.headersSent = true;
+    const err = new Error("Test error");
+
+    serverErrorHandler(err, req, res, next);
+
+    expect(next).to.have.been.calledOnceWith(err);
+    expect(res.statusCode).to.equal(200);
+  });
+
+  it("should render mid-journey-direct-navigation-without-session template if session is invalid and not a GOV.UK request", () => {
+    res.statusCode = HTTP_STATUS_CODES.UNAUTHORIZED;
+    const err = new Error(
+      ERROR_MESSAGES.INVALID_SESSION_NON_GOV_UK_EXTERNAL_REQUEST
+    );
+    const renderSpy = sinon.spy(res, "render");
+    const expectedTemplate =
+      "common/errors/mid-journey-direct-navigation-without-session.njk";
+    const expectedData = {
+      accountManagementUrl: "http://localhost:6001",
+    };
+
+    serverErrorHandler(err, req, res, next);
+
+    expect(renderSpy).to.have.been.calledOnceWith(
+      expectedTemplate,
+      expectedData
+    );
+    expect(res.statusCode).to.equal(HTTP_STATUS_CODES.UNAUTHORIZED);
+  });
+
+  it("should render session-expired template if session is invalid and it is a GOV.UK request", () => {
+    res.statusCode = HTTP_STATUS_CODES.UNAUTHORIZED;
+    const err = new Error(
+      ERROR_MESSAGES.INVALID_SESSION_GOV_UK_INTERNAL_REQUEST
+    );
+    const renderSpy = sinon.spy(res, "render");
+    const expectedTemplate = "common/errors/session-expired.njk";
+
+    serverErrorHandler(err, req, res, next);
+
+    expect(renderSpy).to.have.been.calledOnceWith(expectedTemplate);
+    expect(res.statusCode).to.equal(HTTP_STATUS_CODES.UNAUTHORIZED);
+  });
+
+  it("should render 500 template if error is not unauthorized and headers have not been sent", () => {
+    const err = new Error("Test error");
+    const renderSpy = sinon.spy(res, "render");
+    const expectedTemplate = "common/errors/500.njk";
+
+    serverErrorHandler(err, req, res, next);
+
+    expect(renderSpy).to.have.been.calledOnceWith(expectedTemplate);
+    expect(res.statusCode).to.equal(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+  });
+});

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -125,8 +125,8 @@
       "content": {
         "paragraph1": {
           "text1": "Ewch i’ch GOV.UK One Login",
-          "text2": ", or find the service you need from the ",
-          "text3": "GOV.UK homepage"
+          "text2": ", neu dewch o hyd i’r gwasanaeth rydych ei angen o ",
+          "text3": "hafan GOV.UK "
         },
         "govUKHomepageButtonHref": "https://www.gov.uk/"
       }

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -65,6 +65,9 @@ export function validateSessionMiddleware(
 
   res.status(401);
   next(
-    new ErrorWithLevel(ERROR_MESSAGES.INVALID_SESSION, ERROR_LOG_LEVEL.INFO)
+    new ErrorWithLevel(
+      ERROR_MESSAGES.INVALID_SESSION_NON_GOV_UK_EXTERNAL_REQUEST,
+      ERROR_LOG_LEVEL.INFO
+    )
   );
 }

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -1,7 +1,8 @@
 import { NextFunction, Request, Response } from "express";
-import { ERROR_LOG_LEVEL, ERROR_MESSAGES, PATH_NAMES } from "../app.constants";
 import xss from "xss";
 import { ErrorWithLevel } from "../utils/error";
+import { getAppEnv } from "../config";
+import { ERROR_LOG_LEVEL, ERROR_MESSAGES, PATH_NAMES } from "../app.constants";
 
 export function initialiseSessionMiddleware(
   req: Request,
@@ -64,6 +65,23 @@ export function validateSessionMiddleware(
   });
 
   res.status(401);
+
+  const referrer = req.get("Referrer");
+  const isReferrerInternal =
+    getAppEnv() === "local"
+      ? referrer?.includes("localhost")
+      : referrer?.includes("gov.uk");
+
+  if (isReferrerInternal) {
+    req.log.info("request from gov.uk domain");
+    next(
+      new ErrorWithLevel(
+        ERROR_MESSAGES.INVALID_SESSION_GOV_UK_INTERNAL_REQUEST,
+        ERROR_LOG_LEVEL.INFO
+      )
+    );
+  }
+
   next(
     new ErrorWithLevel(
       ERROR_MESSAGES.INVALID_SESSION_NON_GOV_UK_EXTERNAL_REQUEST,

--- a/src/middleware/tests/session-middleware.test.ts
+++ b/src/middleware/tests/session-middleware.test.ts
@@ -1,0 +1,109 @@
+import chai, { expect } from "chai";
+import { Request, Response } from "express";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+import { validateSessionMiddleware } from "../session-middleware";
+import { ERROR_MESSAGES } from "../../app.constants";
+
+chai.use(sinonChai);
+
+describe("Middleware", () => {
+  describe("validateSessionMiddleware", () => {
+    let req: Request;
+    let res: Response;
+    let next: sinon.SinonSpy;
+
+    beforeEach(() => {
+      req = {
+        cookies: {},
+        headers: {},
+        session: {
+          id: "session-id",
+          destroy: sinon.stub().callsArg(0),
+        },
+        log: {
+          error: sinon.stub(),
+          info: sinon.stub(),
+        },
+        get: function (headerName: string) {
+          if (headerName === "Referrer") {
+            return this.headers["referer"] || this.headers["referrer"];
+          }
+        },
+      } as any;
+      res = {
+        locals: {},
+        status: sinon.stub().returns({
+          json: sinon.stub(),
+        }),
+      } as any;
+      next = sinon.spy();
+    });
+
+    it("should call next if all required session properties are present", () => {
+      req.cookies.gs = "gs-cookie";
+      req.cookies.aps = "aps-cookie";
+
+      validateSessionMiddleware(req, res, next);
+
+      expect(req.session.destroy).to.not.have.been.called;
+      expect(res.status).to.not.have.been.called;
+      expect(next).to.have.been.calledOnce;
+    });
+
+    it("should destroy session and call next with error if gs cookie is missing", () => {
+      req.cookies.aps = "aps-cookie";
+
+      validateSessionMiddleware(req, res, next);
+
+      expect(req.session.destroy).to.have.been.calledOnce;
+      expect(res.status).to.have.been.calledOnceWith(401);
+      expect(next).to.have.been.calledOnce;
+      expect(next.args[0][0]).to.be.an("error");
+    });
+
+    it("should destroy session and call next with error if aps cookie is missing", () => {
+      req.cookies.gs = "gs-cookie";
+
+      validateSessionMiddleware(req, res, next);
+
+      expect(req.session.destroy).to.have.been.calledOnce;
+      expect(res.status).to.have.been.calledOnceWith(401);
+      expect(next).to.have.been.calledOnce;
+      expect(next.args[0][0]).to.be.an("error");
+    });
+
+    it("should recognise non gov.uk referer", () => {
+      req.headers.referer = "test.external.bookmark.com";
+
+      validateSessionMiddleware(req, res, next);
+
+      expect(next.getCalls()[0].args[0].message).to.eq(
+        ERROR_MESSAGES.INVALID_SESSION_NON_GOV_UK_EXTERNAL_REQUEST
+      );
+    });
+
+    it("should recognise internal (gov.uk) referer", () => {
+      req.headers.referer = "localhost.test.gov.uk";
+
+      validateSessionMiddleware(req, res, next);
+
+      expect(next.getCalls()[0].args[0].message).to.eq(
+        ERROR_MESSAGES.INVALID_SESSION_GOV_UK_INTERNAL_REQUEST
+      );
+    });
+
+    it("should destroy session and call next with error if session id is missing", () => {
+      req.cookies.gs = "gs-cookie";
+      req.cookies.aps = "aps-cookie";
+      req.session.id = null;
+
+      validateSessionMiddleware(req, res, next);
+
+      expect(req.session.destroy).to.have.been.calledOnce;
+      expect(res.status).to.have.been.calledOnceWith(401);
+      expect(next).to.have.been.calledOnce;
+      expect(next.args[0][0]).to.be.an("error");
+    });
+  });
+});


### PR DESCRIPTION
## What?

- Add no session middleware
- This will distinguish vs situations where a session is lacking because it has timed out (currently after 2 hours)
- It applies when there is no session because the user has e.g. bookmarked a session-required page and is trying to navigate directly

For example, `/enter-email` is a session-required route. Now, if we try to navigate to it directly, we will see (English):
<img width="967" alt="image" src="https://user-images.githubusercontent.com/106964077/225275014-b8ca4769-92ea-4497-9e48-ad756c0501d9.png">

or the equivalent page in Welsh:
<img width="964" alt="image" src="https://user-images.githubusercontent.com/106964077/225274920-25c1c947-b7d6-46bd-bff8-2820724da3a3.png">

## Why?

- To improve accuracy of error messages for users


## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [X] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [X] Performance Analysis have been informed of the change
