### PR TITLE
AUT-1119: Support form changes for ID Check App

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -91,6 +91,47 @@ export function contactUsGet(req: Request, res: Response): void {
   });
 }
 
+export function validateAppErrorCode(appErrorCode: string): boolean {
+  const testResult = /^(\d|[a-f]){4}$/.test(appErrorCode);
+
+  if (!testResult) {
+    logger.warn(`App error code ${appErrorCode} did not meet validation rules`);
+  }
+
+  return testResult;
+}
+
+export function getAppErrorCode(appErrorCode: string | undefined): string {
+  if (!appErrorCode) {
+    logger.info(`Error code ${appErrorCode} was falsy`);
+    return "";
+  }
+
+  return validateAppErrorCode(appErrorCode) ? appErrorCode : "";
+}
+
+export function getAppSessionId(appSessionId: string | undefined): string {
+  if (!appSessionId) {
+    logger.info(`appSessionId ${appSessionId} was falsy`);
+    return "";
+  }
+
+  return validateAppId(appSessionId) ? appSessionId : "";
+}
+
+export function validateAppId(appSessionId: string): boolean {
+  const testResult =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(
+      appSessionId
+    );
+
+  if (!testResult) {
+    logger.warn(`appSessionId ${appSessionId} did not meet validation rules`);
+  }
+
+  return testResult;
+}
+
 function validateReferer(referer: string): string {
   let valid = false;
   let url;
@@ -134,6 +175,16 @@ export function furtherInformationGet(req: Request, res: Response): void {
   if (!req.query.theme) {
     return res.redirect(PATH_NAMES.CONTACT_US);
   }
+
+  if (req.query.appErrorCode && req.query.appSessionId) {
+    return res.render("contact-us/further-information/index.njk", {
+      theme: req.query.theme,
+      referer: validateReferer(req.query.referer as string),
+      appErrorCode: getAppErrorCode(req.query.appErrorCode as string),
+      appSessionId: getAppSessionId(req.query.appSessionId as string),
+    });
+  }
+
   return res.render("contact-us/further-information/index.njk", {
     theme: req.query.theme,
     referer: validateReferer(req.query.referer as string),
@@ -146,9 +197,14 @@ export function furtherInformationPost(req: Request, res: Response): void {
     theme: req.body.theme,
     subtheme: req.body.subtheme,
     referer: validateReferer(req.body.referer),
-  }).toString();
+  });
 
-  res.redirect(url + "?" + queryParams);
+  if (req.body.appErrorCode && req.body.appSessionId) {
+    queryParams.append("appErrorCode", getAppErrorCode(req.body.appErrorCode));
+    queryParams.append("appSessionId", getAppSessionId(req.body.appSessionId));
+  }
+
+  res.redirect(url + "?" + queryParams.toString());
 }
 
 export function contactUsQuestionsGet(req: Request, res: Response): void {
@@ -172,7 +228,17 @@ export function contactUsQuestionsGet(req: Request, res: Response): void {
     pageTitleHeading: pageTitle,
     zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
     ipnSupport: res.locals.ipnSupport,
+    appErrorCode: getAppErrorCode(req.query.appErrorCode as string),
+    appSessionId: getAppSessionId(req.query.appSessionId as string),
   });
+}
+
+export function createTicketIdentifier(appSessionId: string): string {
+  if (appSessionId) {
+    return appSessionId;
+  } else {
+    return crypto.randomBytes(20).toString("base64url");
+  }
 }
 
 export function contactUsQuestionsFormPost(
@@ -185,7 +251,10 @@ export function contactUsQuestionsFormPost(
       req.body.theme,
       req.body.subtheme
     );
-    const ticketIdentifier = crypto.randomBytes(20).toString("base64url");
+
+    const ticketIdentifier = createTicketIdentifier(
+      getAppSessionId(req.body.appSessionId)
+    );
 
     await service.contactUsSubmitForm({
       descriptions: {
@@ -202,6 +271,7 @@ export function contactUsQuestionsFormPost(
       optionalData: {
         ticketIdentifier: ticketIdentifier,
         userAgent: req.get("User-Agent"),
+        appErrorCode: getAppErrorCode(req.body.appErrorCode),
       },
       feedbackContact: req.body.contact === "true",
       questions: questions,

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -130,6 +130,11 @@ export function contactUsService(
       htmlBody.push(`<p>Unable to capture ticket identifier</p>`);
     }
 
+    if (optionalData.appErrorCode) {
+      htmlBody.push(`<span>[ID Check App error code]</span>`);
+      htmlBody.push(`<p>${optionalData.appErrorCode}</p>`);
+    }
+
     htmlBody.push(`<span>[From page]</span>`);
     if (referer) {
       htmlBody.push(`<p>${referer}</p>`);

--- a/src/components/contact-us/further-information/_id-check-app-further-information.njk
+++ b/src/components/contact-us/further-information/_id-check-app-further-information.njk
@@ -7,6 +7,7 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
+{% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
         {% set items = [
                 {

--- a/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
@@ -10,6 +10,7 @@
     <input type="hidden" name="backurl" value="{{backurl}}"/>
     <input type="hidden" name="formType" value="idCheckApp"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
+    {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
     {% include 'contact-us/questions/_what_happened.njk' %}
 

--- a/src/components/contact-us/questions/_id-check-app-hidden-fields.njk
+++ b/src/components/contact-us/questions/_id-check-app-hidden-fields.njk
@@ -1,0 +1,4 @@
+{% if appErrorCode and appSessionId %}
+    <input type="hidden" name="appErrorCode" value="{{appErrorCode}}"/>
+    <input type="hidden" name="appSessionId" value="{{appSessionId}}"/>
+{% endif %}

--- a/src/components/contact-us/questions/_id-check-app-linking-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-linking-problem.njk
@@ -10,6 +10,7 @@
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="formType" value="idCheckApp"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
+{% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
 {% include 'contact-us/questions/_what_happened.njk' %}
 

--- a/src/components/contact-us/questions/_id-check-app-something-else.njk
+++ b/src/components/contact-us/questions/_id-check-app-something-else.njk
@@ -10,6 +10,7 @@
     <input type="hidden" name="backurl" value="{{backurl}}"/>
     <input type="hidden" name="formType" value="idCheckAppSomethingElse"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
+    {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
     {{ govukCharacterCount({
         label: {

--- a/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
@@ -10,6 +10,7 @@
     <input type="hidden" name="backurl" value="{{backurl}}"/>
     <input type="hidden" name="formType" value="idCheckApp"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
+    {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
     {% include 'contact-us/questions/_what_happened.njk' %}
 

--- a/src/components/contact-us/questions/_id-check-app-technical-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-technical-problem.njk
@@ -10,6 +10,7 @@
     <input type="hidden" name="backurl" value="{{backurl}}"/>
     <input type="hidden" name="formType" value="idCheckAppTechnicalProblem"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
+    {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
     {{ govukCharacterCount({
         label: {

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -3,7 +3,15 @@ import { describe } from "mocha";
 
 import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
-import { contactUsFormPost, contactUsGet } from "../contact-us-controller";
+import {
+  contactUsFormPost,
+  contactUsGet,
+  validateAppErrorCode,
+  getAppErrorCode,
+  getAppSessionId,
+  validateAppId,
+  createTicketIdentifier,
+} from "../contact-us-controller";
 import { SUPPORT_TYPE, ZENDESK_THEMES } from "../../../app.constants";
 
 describe("contact us controller", () => {
@@ -103,6 +111,97 @@ describe("contact us controller", () => {
       expect(res.redirect).to.have.calledWith(
         "/contact-us-questions?theme=proving_identity&referer=http%3A%2F%2Flocalhost%3A3000%2Fenter-email"
       );
+    });
+  });
+});
+
+describe("appErrorCode and appSessionId query parameters", () => {
+  const validAppErrorCodes = ["abcd", "1234", "ab12", "12ab"];
+  const invalidAppErrorCodes = ["abcde", "12345", "zb12", "12ag"];
+  const validAppSessionIds = [
+    "1234abcd-12ab-11aa-90aa-04938abc12ab",
+    "abc5678a-ab12-1c56-88ed-facc89109aee",
+  ];
+  const invalidAppSessionIds = [
+    "1234zbcd-12zb-11zz-90zz-04938zc12zb",
+    "zbc5678z-zb12-1c56-88ed-fzcc89109ee",
+  ];
+
+  describe("validateAppErrorCode", () => {
+    validAppErrorCodes.forEach((i) => {
+      it(`should return true when passed a valid string like ${i}`, () => {
+        expect(validateAppErrorCode(i)).to.be.true;
+      });
+    });
+
+    invalidAppErrorCodes.forEach((i) => {
+      it(`should return false when passed an invalid string like ${i}`, () => {
+        expect(validateAppErrorCode(i)).to.be.false;
+      });
+    });
+  });
+
+  describe("getAppErrorCode", () => {
+    it(`It should return "" if passed an empty string`, () => {
+      expect(getAppErrorCode("")).to.equal("");
+    });
+
+    validAppErrorCodes.forEach((i) => {
+      it(`should return the original string when passed a valid string like ${i}`, () => {
+        expect(getAppErrorCode(i)).to.equal(i);
+      });
+    });
+
+    invalidAppErrorCodes.forEach((i) => {
+      it(`should return "" when passed an invalid string like ${i}`, () => {
+        expect(getAppErrorCode(i)).to.be.equal("");
+      });
+    });
+  });
+
+  describe("validateAppId", () => {
+    validAppSessionIds.forEach((i) => {
+      it(`should return true when passed a valid string like ${i}`, () => {
+        expect(validateAppId(i)).to.be.true;
+      });
+    });
+  });
+
+  describe("getAppSessionId", () => {
+    it(`It should return "" if passed an empty string`, () => {
+      expect(getAppSessionId("")).to.be.equal("");
+    });
+
+    [
+      "1234abcd-12ab-11aa-90aa-04938abc12ab",
+      "abc5678a-ab12-1c56-88ed-facc89109aee",
+    ].forEach((i) => {
+      it(`should return the original string when passed a valid string like ${i}`, () => {
+        expect(getAppSessionId(i)).to.equal(i);
+      });
+    });
+
+    [
+      "1234zbcd-12zb-11zz-90zz-04938zc12zb",
+      "zbc5678z-zb12-1c56-88ed-fzcc89109ee",
+    ].forEach((i) => {
+      it(`should return "" when passed an invalid string like ${i}`, () => {
+        expect(getAppErrorCode(i)).to.equal("");
+      });
+    });
+  });
+
+  describe("createTicketIdentifier", () => {
+    validAppSessionIds.forEach((i) => {
+      it(`should return the original string when passed a valid appSessionId like ${i}`, () => {
+        expect(createTicketIdentifier(i)).to.equal(i);
+      });
+    });
+
+    invalidAppSessionIds.forEach((i) => {
+      it(`should return not return the original string when passed an invalid string like ${i}`, () => {
+        expect(getAppErrorCode(i)).to.not.equal(i);
+      });
     });
   });
 });

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -53,6 +53,8 @@ describe("contact us questions controller", () => {
         referer: REFERER,
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'GOV.UK email subscriptions' radio option was chosen", () => {
@@ -69,6 +71,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.emailSubscriptions.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'A suggestion or feedback' radio option was chosen", () => {
@@ -85,6 +89,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.suggestionOrFeedback.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
 
@@ -102,6 +108,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.provingIdentity.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
 
@@ -128,6 +136,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -145,6 +155,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'You do not have access to the phone number' radio option was chosen", () => {
@@ -162,6 +174,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.noPhoneNumberAccess.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'You've forgotten your password' radio option was chosen", () => {
@@ -179,6 +193,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.forgottenPassword.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'Your account cannot be found' radio option was chosen", () => {
@@ -196,6 +212,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.accountNotFound.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -213,6 +231,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -230,6 +250,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.anotherProblem.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
   });
@@ -250,6 +272,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.noSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'the security code did not work' radio option was chosen", () => {
@@ -267,6 +291,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.invalidSecurityCode.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'You do not have a UK number' radio option was chosen", () => {
@@ -284,6 +310,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.noUKMobile.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'technical problem' radio option was chosen", () => {
@@ -301,6 +329,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.technicalError.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'something else' radio option was chosen", () => {
@@ -318,6 +348,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.accountCreation.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
     it("should render contact-us-questions if a 'problem with authenticator app' radio option was chosen", () => {
@@ -335,6 +367,8 @@ describe("contact us questions controller", () => {
         pageTitleHeading: "pages.contactUsQuestions.authenticatorApp.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
+        appErrorCode: "",
+        appSessionId: "",
       });
     });
 

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -15,6 +15,8 @@ export interface ContactForm {
 export interface OptionalData {
   userAgent: string;
   ticketIdentifier?: string;
+  appSessionId?: string;
+  appErrorCode?: string;
 }
 
 export interface Questions {


### PR DESCRIPTION
## What?

Allows for two new query string parameters to be provided to the `/contact-us-further-information` route representing an `appSessionId` and `appErrorCode`. These will be included in GET requests coming from the ID Check App. 

An example request URL would be: 

`https://signin.account.gov.uk/contact-us-further-information?theme=id_check_app&appErrorCode=aed1&appSessionId=1234abcd-12ab-11aa-90aa-04938abc12ab`

Where these parameters are included and meet expectations, they will persist through to ID Check App forms (as hidden fields where possible, or query strings where not) and be sent to Zendesk as:

* The `appSessionId` will be the "Ticket identifier" (replacing the Base64 string)
* The `appErrorCode` will be a new field called "ID Check App error code"

## Why?

The inclusion of an error code and app session ID will make it easier for the ID Check App team to investigate problems encountered by users. By making these parameters optional it is still possible for a user to provide information directly through the web form.

## Notes on the implementation

### Overview

![aut-1119 drawio (1)](https://user-images.githubusercontent.com/16000203/225645813-577204f0-fa60-470e-a541-186b73f96aef.png)


### Regular expressions
Two regular expressions are used, one to match the pattern for error codes which I have written (they are 4-digit hexadecimals) and one to match session IDs which has been provided by the ID Check app team.

### Filtering values
Filtering of the `appSessionId` and `appErrorCode` is approached through two types of methods: 

* `getAppErrorCode()` and `getAppSessionId()` will return either valid strings or empty strings
* `validateAppErrorCode()` and `validateAppSessionId()` will return a boolean

### Changing the Ticket Identifier
When passed a valid `appSessionId` the `createTicketIdentifier()` will return this. In other cases it will return a Base64 encoded string

## Zendesk tickets from testing
These are screenshots of tickets created in Zendesk from my local machine where `appErrorCode` is `aed1` and `appSessionId` is `1234abcd-12ab-11aa-90aa-04938abc12ab` 

### You had a problem linking the app to your web browse
<img width="886" alt="You had a problem linking the app to your web browser" src="https://user-images.githubusercontent.com/16000203/225387496-adb57434-0a95-4d6a-8a2f-66d7ec4d481a.png">

### You had a problem taking a photo of your identity document using the GOV UK ID Check app
<img width="911" alt="You had a problem taking a photo of your identity document using the GOV UK ID Check app" src="https://user-images.githubusercontent.com/16000203/225387547-2f5e77c8-360c-4b0d-9726-36fc1da41294.png">

### You had a problem scanning your face
<img width="904" alt="You had a problem scanning your face" src="https://user-images.githubusercontent.com/16000203/225387614-67e9530f-1101-45fa-a96d-2decf60370c6.png">

### You had a technical problem
<img width="881" alt="You had a technical problem" src="https://user-images.githubusercontent.com/16000203/225387667-bccc5901-0b6a-49d8-b656-6eefa70aa530.png">

### Another problem
<img width="887" alt="Another problem" src="https://user-images.githubusercontent.com/16000203/225387749-f544df60-fb02-4060-ad0b-774a36f51b9a.png">

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
