### PR TITLE
AUT-1094: Change hidden telephone number presentation

### DIFF
--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -14,8 +14,12 @@
 
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.checkYourPhone.header' | translate }}</h1>
 
+  {% set insetText %}
+    {{ 'pages.checkYourPhone.info.paragraph1' | translate }} <span class='govuk-!-font-weight-bold'>{{ phoneNumber }}</span>
+  {% endset %}
+
   {{ govukInsetText({
-    text: 'pages.checkYourPhone.info.paragraph1' | translate | replace("[mobile]", phoneNumber )
+    text: insetText | safe
   }) }}
 
   <p class="govuk-body">{{'pages.checkYourPhone.info.paragraph2' | translate }}</p>

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -22,7 +22,7 @@ describe("Integration:: contact us - public user", () => {
       .callsFake(function (req: any, res: any, next: any): void {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
         req.session.user.email = "test@test.com";
-        req.session.user.phoneNumber = "******7867";
+        req.session.user.phoneNumber = "7867";
 
         next();
       });

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -29,7 +29,7 @@ describe("Integration:: enter mfa", () => {
 
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "******7867",
+          phoneNumber: "7867",
           journey: {
             nextPath: PATH_NAMES.ENTER_MFA,
           },

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -51,7 +51,7 @@ describe("enter password controller", () => {
       const fakeService: EnterPasswordServiceInterface = {
         loginUser: sinon.fake.returns({
           data: {
-            redactedPhoneNumber: "******3456",
+            redactedPhoneNumber: "3456",
             mfaRequired: true,
             consentRequired: false,
             latestTermsAndConditionsAccepted: true,
@@ -91,7 +91,7 @@ describe("enter password controller", () => {
         loginUser: sinon.fake.returns({
           success: true,
           data: {
-            redactedPhoneNumber: "******3456",
+            redactedPhoneNumber: "3456",
             mfaRequired: false,
             mfaMethodVerified: true,
             mfaMethodType: "SMS",
@@ -121,7 +121,7 @@ describe("enter password controller", () => {
         loginUser: sinon.fake.returns({
           success: true,
           data: {
-            redactedPhoneNumber: "******3456",
+            redactedPhoneNumber: "3456",
             mfaMethodVerified: false,
             mfaMethodType: "SMS",
           },
@@ -149,7 +149,7 @@ describe("enter password controller", () => {
       const fakeService: EnterPasswordServiceInterface = {
         loginUser: sinon.fake.returns({
           data: {
-            redactedPhoneNumber: "******3456",
+            redactedPhoneNumber: "3456",
             latestTermsAndConditionsAccepted: false,
             mfaMethodVerified: true,
             mfaMethodType: "SMS",
@@ -181,7 +181,7 @@ describe("enter password controller", () => {
       const fakeService: EnterPasswordServiceInterface = {
         loginUser: sinon.fake.returns({
           data: {
-            redactedPhoneNumber: "******3456",
+            redactedPhoneNumber: "3456",
             mfaRequired: true,
             consentRequired: false,
             latestTermsAndConditionsAccepted: true,

--- a/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-controller.test.ts
@@ -92,7 +92,7 @@ describe("enter phone number controller", () => {
       expect(fakeProfileService.updateProfile).to.have.been.calledOnce;
       expect(fakeNotificationService.sendNotification).to.have.been.calledOnce;
       expect(res.redirect).to.have.calledWith(PATH_NAMES.CHECK_YOUR_PHONE);
-      expect(req.session.user.phoneNumber).to.be.eq("*******3990");
+      expect(req.session.user.phoneNumber).to.be.eq("3990");
     });
 
     it("should redirect to /check-your-phone when success with valid international number", async () => {
@@ -120,7 +120,7 @@ describe("enter phone number controller", () => {
       expect(fakeProfileService.updateProfile).to.have.been.calledOnce;
       expect(fakeNotificationService.sendNotification).to.have.been.calledOnce;
       expect(res.redirect).to.have.calledWith(PATH_NAMES.CHECK_YOUR_PHONE);
-      expect(req.session.user.phoneNumber).to.be.eq("********3322");
+      expect(req.session.user.phoneNumber).to.be.eq("3322");
     });
 
     it("should throw error when API call to /update-profile throws error", async () => {

--- a/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
+++ b/src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts
@@ -28,7 +28,7 @@ describe("Integration::enter phone number", () => {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "******7867",
+          phoneNumber: "7867",
           journey: {
             nextPath: PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
           },

--- a/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
@@ -28,7 +28,7 @@ describe("Integration:: resend email code", () => {
 
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "******7867",
+          phoneNumber: "7867",
           journey: {
             nextPath: PATH_NAMES.CREATE_ACCOUNT_CHECK_EMAIL,
             optionalPaths: [PATH_NAMES.RESEND_EMAIL_CODE],

--- a/src/components/resend-mfa-code/index.njk
+++ b/src/components/resend-mfa-code/index.njk
@@ -7,7 +7,9 @@
 {% set hrefBack = 'enter-code' %}
 
 {% if isResendCodeRequest %}
-    {% set phoneNumberMessage = 'pages.resendMfaCode.phoneNumber.isResendCodeRequest' | translate | replace("[mobile]", phoneNumber) %}
+    {% set phoneNumberMessage %}
+       {{ 'pages.resendMfaCode.phoneNumber.isResendCodeRequest' | translate }} <span class='govuk-!-font-weight-bold'>{{ phoneNumber }}</span>
+    {% endset %}
 {% else %}
     {% set phoneNumberMessage = 'pages.resendMfaCode.phoneNumber.default' | translate | replace("[mobile]", phoneNumber) %}
 {% endif %}
@@ -20,7 +22,7 @@
         <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resendMfaCode.header' | translate}}</h1>
 
         {{ govukInsetText({
-            text: phoneNumberMessage
+            text: phoneNumberMessage | safe
         }) }}
 
         <p class="govuk-body">{{'pages.resendMfaCode.message' | translate}}</p>

--- a/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -28,7 +28,7 @@ describe("Integration:: resend mfa code", () => {
 
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "******7867",
+          phoneNumber: "7867",
           journey: {
             nextPath: PATH_NAMES.ENTER_MFA,
             optionalPaths: [PATH_NAMES.RESEND_MFA_CODE],

--- a/src/components/reset-password/tests/reset-password-controller.test.ts
+++ b/src/components/reset-password/tests/reset-password-controller.test.ts
@@ -106,7 +106,7 @@ describe("reset password controller (in 6 digit code flow)", () => {
             loginUser: sinon.fake.returns({
               success: true,
               data: {
-                redactedPhoneNumber: "******1234",
+                redactedPhoneNumber: "1234",
                 consentRequired: false,
                 latestTermsAndConditionsAccepted: true,
                 mfaMethodVerified: true,
@@ -155,7 +155,7 @@ describe("reset password controller (in 6 digit code flow)", () => {
             loginUser: sinon.fake.returns({
               success: true,
               data: {
-                redactedPhoneNumber: "******1234",
+                redactedPhoneNumber: "1234",
                 consentRequired: false,
                 latestTermsAndConditionsAccepted: true,
                 mfaMethodVerified: false,
@@ -199,7 +199,7 @@ describe("reset password controller (in 6 digit code flow)", () => {
         loginUser: sinon.fake.returns({
           success: true,
           data: {
-            redactedPhoneNumber: "******1234",
+            redactedPhoneNumber: "1234",
             consentRequired: false,
             latestTermsAndConditionsAccepted: true,
             mfaMethodVerified: true,

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -25,7 +25,7 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
         res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "******7867",
+          phoneNumber: "7867",
           journey: {
             nextPath: PATH_NAMES.RESET_PASSWORD,
           },

--- a/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
+++ b/src/components/updated-terms-conditions/tests/updated-terms-conditions-integration.test.ts
@@ -30,7 +30,7 @@ describe("Integration:: updated-terms-code", () => {
 
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "******7867",
+          phoneNumber: "7867",
           journey: {
             nextPath: PATH_NAMES.UPDATED_TERMS_AND_CONDITIONS,
           },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -402,7 +402,7 @@
       "title": "Gwiriwch eich ffôn",
       "header": "Gwiriwch eich ffôn",
       "info": {
-        "paragraph1": "Rydym wedi anfon cod i [mobile].",
+        "paragraph1": "Rydym wedi anfon cod i’ch rhif ffôn sy’n gorffen gyda ",
         "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud."
       },
       "code": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -502,7 +502,7 @@
       "message": "Gall negeseuon testun weithiau gymryd ychydig funudau i gyrraedd.",
       "phoneNumber": {
         "default": "Byddwn yn anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login",
-        "isResendCodeRequest": "Byddwn yn anfon cod i: [mobile]."
+        "isResendCodeRequest": "Byddwn yn anfon cod i’ch rhif ffôn sy’n gorffen gyda "
       },
       "email": {
         "recipientMessage": "Byddwn yn anfon cod i: ",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -502,7 +502,7 @@
       "message": "Text messages can sometimes take a few minutes to arrive.",
       "phoneNumber": {
         "default": "We will send the code to the phone number linked to your GOV.UK One Login.",
-        "isResendCodeRequest": "We will send a code to: [mobile]."
+        "isResendCodeRequest": "We will send a code to your phone number ending with "
       },
       "email": {
         "recipientMessage": "We will send a code to: ",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -402,7 +402,7 @@
       "title": "Check your phone",
       "header": "Check your phone",
       "info": {
-        "paragraph1": "We have sent a code to [mobile].",
+        "paragraph1": "We have sent a code to your phone number ending with ",
         "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes."
       },
       "code": {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -10,9 +10,7 @@ export function containsNumbersOnly(value: string): boolean {
 }
 
 export function redactPhoneNumber(value: string): string | undefined {
-  return value
-    ? "*".repeat(value.length - 4) + value.trim().slice(value.length - 4)
-    : undefined;
+  return value ? value.trim().slice(value.length - 4) : undefined;
 }
 
 export function generateNonce(): string {

--- a/test/unit/utils/strings.test.ts
+++ b/test/unit/utils/strings.test.ts
@@ -47,11 +47,11 @@ describe("string-helpers", () => {
 
   describe("obfuscatePhoneNumber", () => {
     it("should return obfuscated phone number when valid uk phone number", () => {
-      expect(redactPhoneNumber("07700900796")).to.equal("*******0796");
+      expect(redactPhoneNumber("07700900796")).to.equal("0796");
     });
 
     it("should return obfuscated phone number when valid international phone number", () => {
-      expect(redactPhoneNumber("+330645453322")).to.equal("*********3322");
+      expect(redactPhoneNumber("+330645453322")).to.equal("3322");
     });
 
     it("should return undefined when phone number is is empty", () => {


### PR DESCRIPTION
## What?

Simple change to the way hidden telephone numbers are described/presented on two screens: 

- [x] Check your phone
- [x] Get security code 

## Why?

The new presentation uses words to convey that the presented digits are the end of the user's telephone number and, in doing so, addresses an issue where screen readers were reading "Star star star 0 4 0 6" that may have been confusing for some users. 

## Screen changes

### Check your phone
<img width="313" alt="Screenshot 2023-03-27 at 15 28 57" src="https://user-images.githubusercontent.com/16000203/227970335-c0259713-2eb3-4b72-a9fe-bd2a1d6eaebd.png">
<img width="312" alt="Screenshot 2023-03-27 at 15 28 39" src="https://user-images.githubusercontent.com/16000203/227970343-28ebc207-f60b-499f-9efa-c58f8ae9ecf4.png">

### Get security code
<img width="313" alt="Screenshot 2023-04-06 at 12 12 26" src="https://user-images.githubusercontent.com/16000203/230361183-95d3dd34-17ce-40a3-a04a-ab81c786a0b7.png">

<img width="312" alt="Screenshot 2023-04-06 at 12 12 57" src="https://user-images.githubusercontent.com/16000203/230361201-12620beb-d705-41fd-87c5-c6f8355e8698.png">

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
