### PR TITLE
AUT-1080: check-email-change-security-codes navigation changes, Welsh translation

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -61,6 +61,11 @@ export const PATH_NAMES = {
   CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES: "/check-email-change-security-codes",
 };
 
+export const HREF_BACK = {
+  CHECK_YOUR_PHONE: "check-your-phone",
+  ENTER_AUTHENTICATOR_APP_CODE: "enter-authenticator-app-code",
+};
+
 export const HTTP_STATUS_CODES = {
   NOT_FOUND: 404,
   INTERNAL_SERVER_ERROR: 500,

--- a/src/components/check-your-email-security-codes/check-your-email-security-codes-controller.ts
+++ b/src/components/check-your-email-security-codes/check-your-email-security-codes-controller.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from "express";
-import { NOTIFICATION_TYPE } from "../../app.constants";
+import {
+  HREF_BACK,
+  MFA_METHOD_TYPE,
+  NOTIFICATION_TYPE,
+} from "../../app.constants";
 import { VerifyCodeInterface } from "../common/verify-code/types";
 import { codeService } from "../common/verify-code/verify-code-service";
 import { verifyCodePost } from "../common/verify-code/verify-code-controller";
@@ -12,8 +16,15 @@ export function checkYourEmailSecurityCodesGet(
   req: Request,
   res: Response
 ): void {
+  let backUrl = "";
+  if (req.query.type === MFA_METHOD_TYPE.AUTH_APP) {
+    backUrl = HREF_BACK.ENTER_AUTHENTICATOR_APP_CODE;
+  } else if (req.query.type === MFA_METHOD_TYPE.SMS) {
+    backUrl = HREF_BACK.CHECK_YOUR_PHONE;
+  }
   res.render(TEMPLATE_NAME, {
     email: req.session.user.email,
+    backUrl: backUrl,
   });
 }
 

--- a/src/components/check-your-email-security-codes/index.njk
+++ b/src/components/check-your-email-security-codes/index.njk
@@ -5,7 +5,7 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set showBack = true %}
-{% set hrefBack = 'enter-email-create' %}
+{% set hrefBack = backUrl %}
 {% set pageTitleName = 'pages.checkYourEmailSecurityCodes.title' | translate %}
 
 {% block content %}
@@ -23,7 +23,7 @@
   <p class="govuk-body">{{'pages.checkYourEmailSecurityCodes.code.paragraph2' | translate}}</p>
   <p class="govuk-body">{{'pages.checkYourEmailSecurityCodes.code.paragraph3' | translate}}</p>
 
-  <form action="/check-your-email" method="post" novalidate="novalidate">
+  <form action="/check-email-change-security-codes" method="post" novalidate="novalidate">
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="email" value="{{email}}"/>

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -529,7 +529,7 @@
       },
       "text": "Rydym wedi anfon e-bost at: ",
       "code": {
-        "paragraph1": "Mae'r e-bost yn cynnwys cod diogelwch 6 digid. Ar ôl i chi roi eich cod, byddwch yn gallu newid sut i gael codau diogelwch pan fyddwch yn mewngofnodi.",
+        "paragraph1": "Mae’r e-bost yn cynnwys cod diogelwch 6 digid. Ar ôl i chi roi eich cod, byddwch yn gallu newid sut i gael codau diogelwch pan fyddwch yn mewngofnodi.",
         "paragraph2": "Efallai y bydd eich e-bost yn cymryd ychydig funudau i gyrraedd. Os na chewch e-bost, edrychwch ar eich ffolder spam.",
         "paragraph3": "Bydd y cod yn dod i ben ar ôl 2 awr.",
         "label": "Rhowch y cod diogelwch 6 digid",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -522,31 +522,31 @@
       }
     },
     "checkYourEmailSecurityCodes": {
-      "title": "Check your email",
-      "header": "Check your email",
+      "title": "Gwiriwch eich e-bost",
+      "header": "Gwiriwch eich e-bost",
       "info": {
-        "paragraph1": "We need to make sure this is your GOV.UK One Login before you can change how you get security codes."
+        "paragraph1": "Mae angen i ni sicrhau mae eich GOV.UK One Login chi yw hwn cyn y gallwch newid sut i gael codau diogelwch."
       },
-      "text": "We have sent an email to: ",
+      "text": "Rydym wedi anfon e-bost at: ",
       "code": {
-        "paragraph1": "The email contains a 6 digit security code. After you enter the code, you’ll be able to change how you get security codes when you sign in.",
-        "paragraph2": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
-        "paragraph3": "The code will expire after 2 hours.",
-        "label": "Enter the 6 digit security code",
+        "paragraph1": "Mae'r e-bost yn cynnwys cod diogelwch 6 digid. Ar ôl i chi roi eich cod, byddwch yn gallu newid sut i gael codau diogelwch pan fyddwch yn mewngofnodi.",
+        "paragraph2": "Efallai y bydd eich e-bost yn cymryd ychydig funudau i gyrraedd. Os na chewch e-bost, edrychwch ar eich ffolder spam.",
+        "paragraph3": "Bydd y cod yn dod i ben ar ôl 2 awr.",
+        "label": "Rhowch y cod diogelwch 6 digid",
         "validationError": {
-          "required": "Enter the security code",
-          "maxLength": "Enter the security code using only 6 digits",
-          "minLength": "Enter the security code using only 6 digits",
-          "invalidFormat": "Enter the security code using only 6 digits",
-          "invalidCode": "The security code you entered is not correct, or may have expired, try entering it again or request a new code"
+          "required": "Rhowch y cod diogelwch",
+          "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
+          "minLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
+          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
+          "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi yn gywir, neu efallai ei fod wedi dod i ben, ceisiwch ei roi i mewn eto neu ofyn am god newydd"
         }
       },
       "details": {
-        "summaryText": "Problems with the code?",
-        "text1": "We can ",
-        "sendCodeLinkText": "send the code again",
+        "summaryText": "Problemau gyda’r cod?",
+        "text1": "Gallwn ",
+        "sendCodeLinkText": "anfon y cod eto",
         "sendCodeLinkHref": "/resend-email-code",
-        "text2": " if the code is not working or you did not receive it."
+        "text2": " neu gallwch "
       }
     },
     "signedOut": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
             "/node_modules/@types"
         ]
     },
+    "include": ["src/**/*.ts"],
     "exclude": [
       "test",
         "coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
             "/node_modules/@types"
         ]
     },
-    "include": ["src/**/*.ts"],
     "exclude": [
       "test",
         "coverage",


### PR DESCRIPTION
## What?

'check-email-change-security-codes' navigation changes, Welsh translation

- Make the back url dynamic so it can go back to either 'check-your-phone' or 'enter-authenticator-app-code' as required.
- POST form to 'check-email-change-security-codes'.

## Why?

The back url needs to be dynamic as this page is the target for two different previous pages.
The form POST url was incorrect.

## Change have been demonstrated

Changes are dormant and not visible to users.  To be demonstrated when the account recovery flow is in place.

## Related PRs

#960 