### PR TITLE
BAU - Remove useCodeFlow boolean from reset password request

### DIFF
--- a/src/components/reset-password-check-email/reset-password-check-email-service.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-service.ts
@@ -23,7 +23,6 @@ export function resetPasswordCheckEmailService(
       API_ENDPOINTS.RESET_PASSWORD_REQUEST,
       {
         email: email,
-        useCodeFlow: true,
       },
       getRequestConfig({
         sessionId: sessionId,


### PR DESCRIPTION
## What?

 - Remove useCodeFlow boolean from reset password request

## Why?

- The boolean is never used so we can stop sending it to the api
