### PR TITLE
AUT-995: Change content on the /enter-mfa screen accordingly to mfa method type

### DIFF
--- a/src/components/enter-mfa/enter-mfa-auth-app.njk
+++ b/src/components/enter-mfa/enter-mfa-auth-app.njk
@@ -1,0 +1,14 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% macro enterMfaAuthApp(paragraph3, authenticatorApp, paragraph3End) %}
+    {% set insetTextHtml %}
+        <p class="govuk-body">
+            {{ paragraph3 }}
+            <span class="govuk-!-font-weight-bold">{{ authenticatorApp }}</span>
+            <span>{{ paragraph3End }}</span>
+        </p>
+    {% endset %}
+    {{ govukInsetText({
+        html: insetTextHtml
+    }) }}
+{% endmacro %}

--- a/src/components/enter-mfa/enter-mfa-controller.ts
+++ b/src/components/enter-mfa/enter-mfa-controller.ts
@@ -25,6 +25,7 @@ export function enterMfaGet(
     if (!isAccountRecoveryEnabledForEnvironment) {
       return res.render(TEMPLATE_NAME, {
         phoneNumber: req.session.user.phoneNumber,
+        isAuthApp: req.session.user.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP,
         supportAccountRecovery: false,
       });
     }
@@ -58,6 +59,7 @@ export function enterMfaGet(
 
     res.render(TEMPLATE_NAME, {
       phoneNumber: req.session.user.phoneNumber,
+      isAuthApp: req.session.user.mfaMethodType === MFA_METHOD_TYPE.AUTH_APP,
       supportAccountRecovery: isAccountRecoveryEnabledForEnvironment,
       checkEmailLink,
     });

--- a/src/components/enter-mfa/enter-mfa-mobile.njk
+++ b/src/components/enter-mfa/enter-mfa-mobile.njk
@@ -1,0 +1,11 @@
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% macro enterMfaMobile(paragraph4, paragraph2) %}
+    {% set insetTextHtml %}
+        <p class="govuk-body">{{ paragraph4 }}</p>
+    {% endset %}
+    {{ govukInsetText({
+        html: insetTextHtml
+    }) }}
+    <p class="govuk-body">{{ paragraph2 }} </p>
+{% endmacro %}

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -3,61 +3,102 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.enterMfa.title' | translate %}
+{% set paragraph2 = 'pages.enterMfa.info.paragraph2' | translate %}
+{% set paragraph3 = 'pages.enterMfa.info.paragraph3' | translate %}
+{% set authenticatorApp = 'pages.enterMfa.info.authenticatorApp' | translate %}
+{% set paragraph3End = 'pages.enterMfa.info.paragraph3End' | translate %}
+{% set paragraph4 = 'pages.enterMfa.info.paragraph4' | translate %}
+{% from "./enter-mfa-auth-app.njk" import enterMfaAuthApp %}
+{% from "./enter-mfa-mobile.njk" import enterMfaMobile %}
 
 {% block content %}
 
-  {% include "common/errors/errorSummary.njk" %}
+    {% include "common/errors/errorSummary.njk" %}
 
-  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterMfa.header' | translate }}</h1>
+    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{ 'pages.enterMfa.header' | translate }}</h1>
+    <p class="govuk-body">{{ 'pages.enterMfa.info.paragraph1' | translate }} </p>
 
-  <p class="govuk-body">{{'pages.enterMfa.info.paragraph1' | translate }}</p>
-  <p class="govuk-body">{{'pages.enterMfa.info.paragraph2' | translate }}</p>
+    {% if isAuthApp %}
+        {{ enterMfaAuthApp(paragraph3, authenticatorApp, paragraph3End) }}
+        <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">
+            <input type="hidden" name="phoneNumber" value="{{ phoneNumber }}" />
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-  <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">
-    <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
-    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+            {{ govukInput({
+                label: {
+                    text: 'pages.enterMfa.code.label' | translate
+                },
+                hint: {
+                    text: 'pages.enterMfa.code.labelSummary' | translate
+                },
+                classes: "govuk-input--width-10 govuk-!-font-weight-bold",
+                id: "code",
+                name: "code",
+                inputmode: "numeric",
+                spellcheck: false,
+                autocomplete:"off",
+                errorMessage: {
+                    text: errors['code'].text
+                } if (errors['code'])}) }}
 
-    {{ govukInput({
-  label: {
-  text: 'pages.enterMfa.code.label' | translate
-  },
-  classes: "govuk-input--width-10 govuk-!-font-weight-bold",
-  id: "code",
-  name: "code",
-  inputmode: "numeric",
-  spellcheck: false,
-  autocomplete:"off",
-  errorMessage: {
-  text: errors['code'].text
-  } if (errors['code'])})
-  }}
+            {{ govukButton({
+                "text": "general.continue.label" | translate,
+                "type": "Submit",
+                "preventDoubleClick": true
+            }) }}
+        </form>
+    {% else %}
+        {{ enterMfaMobile(paragraph4, paragraph2) }}
+        <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">
+            <input type="hidden" name="phoneNumber" value="{{ phoneNumber }}" />
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-    {% set detailsHTML %}
-    <p class="govuk-body">
-      {{'pages.enterMfa.details.text1' | translate}}
-      <a href="{{'pages.enterMfa.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterMfa.details.sendCodeLinkText'| translate}}</a>
-      {{'pages.enterMfa.details.text 2' | translate}}
-    </p>
-    <p class="govuk-body">
-      {% if supportAccountRecovery %}
-        {{'pages.enterMfa.details.changeGetSecurityCodesText' | translate}}
-        <a href={{checkEmailLink}} class="govuk-link" rel="noreferrer noopener">{{'pages.enterMfa.details.changeGetSecurityCodesLinkText'| translate}}</a>.
-      {% endif %}
-    </p>
-    {% endset %}
+            {{ govukInput({
+                label: {
+                    text: 'pages.enterMfa.code.label' | translate
+                },
+                classes: "govuk-input--width-10 govuk-!-font-weight-bold",
+                id: "code",
+                name: "code",
+                inputmode: "numeric",
+                spellcheck: false,
+                autocomplete:"off",
+                errorMessage: {
+                    text: errors['code'].text
+                } if (errors['code'])}) }}
 
-    {{ govukDetails({
-      summaryText: 'pages.enterMfa.details.summaryText' | translate,
-      html: detailsHTML
-    }) }}
+            {% set detailsHTML %}
+                <p class="govuk-body">
+                    <a href="{{ 'pages.enterMfa.details.sendCodeLinkHref' | translate }}"
+                       class="govuk-link"
+                       rel="noreferrer noopener">
+                        {{'pages.enterMfa.details.sendTheCodeAgain'| translate}}
+                    </a>
+                    {{'pages.enterMfa.details.text 2' | translate}}
+                </p>
+                {% if supportAccountRecovery %}
+                    <p class="govuk-body">
+                        {{ 'pages.enterMfa.details.changeGetSecurityCodesText' | translate }}
+                        <a href={{ checkEmailLink }} class="govuk-link"
+                           rel="noreferrer noopener">{{ 'pages.enterMfa.details.changeGetSecurityCodesLinkText'| translate }}</a>.
+                    </p>
+                {% endif %}
+            {% endset %}
 
-    {{ govukButton({
-  "text": "general.continue.label" | translate,
-  "type": "Submit",
-  "preventDoubleClick": true
-  }) }}
+            {{ govukDetails({
+                summaryText: 'pages.enterMfa.details.summaryText' | translate,
+                html: detailsHTML
+            }) }}
 
-  </form>
+            {{ govukButton({
+                "text": "general.continue.label" | translate,
+                "type": "Submit",
+                "preventDoubleClick": true
+            }) }}
+
+        </form>
+    {% endif %}
 
 {% endblock %}

--- a/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-controller.test.ts
@@ -65,6 +65,7 @@ describe("enter mfa controller", () => {
 
       expect(res.render).to.have.calledWith("enter-mfa/index.njk", {
         phoneNumber: TEST_PHONE_NUMBER,
+        isAuthApp: false,
         supportAccountRecovery: false,
       });
     });
@@ -77,6 +78,7 @@ describe("enter mfa controller", () => {
 
       expect(res.render).to.have.calledWith("enter-mfa/index.njk", {
         phoneNumber: TEST_PHONE_NUMBER,
+        isAuthApp: false,
         supportAccountRecovery: true,
         checkEmailLink:
           PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES + "?type=SMS",

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -134,6 +134,7 @@ export function enterPasswordPost(
     req.session.user.isLatestTermsAndConditionsAccepted =
       userLogin.data.latestTermsAndConditionsAccepted;
     req.session.user.isPasswordChangeRequired = isPasswordChangeRequired;
+    req.session.user.mfaMethodType = userLogin.data.mfaMethodType;
 
     if (
       userLogin.data.mfaRequired &&

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -466,15 +466,21 @@
       "title": "Gwiriwch eich ffôn",
       "header": "Gwiriwch eich ffôn",
       "info": {
-        "paragraph1": "Rydym wedi anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login.",
-        "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud."
+        "paragraph1": "Rydym wedi anfon cod at y rhif ffôn yn gysylltiedig â’ch cyfrif.",
+        "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud.",
+        "paragraph3": "I gael cod diogelwch, agorwch yr ",
+        "authenticatorApp": "ap dilysydd ",
+        "paragraph3End": "rydych wedi’i ddefnyddio i greu eich GOV.UK One Login",
+        "paragraph4": "Rydym wedi anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login."
       },
       "resend": {
         "link": "Gofynnwch am god newydd",
         "paragraph1": "os nad yw’r cod yn gweithio neu mae wedi dod i ben, neu ni dderbynioch un."
       },
       "code": {
-        "label": "Rhowch y cod diogelwch 6 digid",
+        "label": "Rhowch y cod diogelwch",
+        "label2": "Rhowch y cod diogelwch 6 digid",
+        "labelSummary": "Dyma’r rhif 6-digid a ddangosir yn eich ap dilysydd",
         "validationError": {
           "required": "Rhowch y cod diogelwch",
           "maxLength": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",
@@ -485,8 +491,7 @@
       },
       "details": {
         "summaryText": "Problemau gyda’r cod?",
-        "text1": "Gallwn ",
-        "sendCodeLinkText": "anfon y cod eto",
+        "sendTheCodeAgain": "Anfon y cod eto",
         "sendCodeLinkHref": "/resend-code",
         "text 2": " os nad yw’r cod yn gweithio neu ni wnaethoch ei dderbyn.",
         "changeGetSecurityCodesText": "If you cannot access the phone number for your GOV.UK One Login, you can securely ",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -463,18 +463,24 @@
       }
     },
     "enterMfa": {
-      "title": "Check your phone",
-      "header": "Check your phone",
+      "title": "You need to enter a security code",
+      "header": "You need to enter a security code",
       "info": {
-        "paragraph1": "We sent a code to the phone number linked to your GOV.UK One Login.",
-        "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes."
+        "paragraph1": "This helps your GOV.UK One Login secure.",
+        "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes.",
+        "paragraph3": "To get a security code, open the ",
+        "authenticatorApp": "authenticator app ",
+        "paragraph3End": "you used to create your GOV.UK One Login",
+        "paragraph4": "We sent a code to the phone number linked to your GOV.UK One Login."
       },
       "resend": {
         "link": "Request a new code",
         "paragraph1": "if the code does not work or has expired, or you did not receive one."
       },
       "code": {
-        "label": "Enter the 6 digit security code",
+        "label": "Enter the security code",
+        "label2": "Enter the 6 digit security code",
+        "labelSummary": "This is the 6-digit number shown in your authenticator app",
         "validationError": {
           "required": "Enter the security code",
           "maxLength": "Enter the security code using only 6 digits",
@@ -485,8 +491,7 @@
       },
       "details": {
         "summaryText": "Problems with the code?",
-        "text1": "We can ",
-        "sendCodeLinkText": "send the code again",
+        "sendTheCodeAgain": "Send the code again",
         "sendCodeLinkHref": "/resend-code",
         "text 2": " if the code is not working or you did not receive it.",
         "changeGetSecurityCodesText": "If you cannot access the phone number for your GOV.UK One Login, you can securely ",

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export interface UserSession {
   wrongCodeEnteredLock?: string;
   codeRequestLock?: string;
   isAccountRecoveryPermitted?: boolean;
+  mfaMethodType?: string;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What?

When a user signs in with 1FA and tries to access another service like account management, they are required to go through 2FA regardless of their authentication level and redirected to `/enter-code` screen.

- Create new field `mfaMethodType` in `UserSession` during sign in journey
- Display new content for users with `MFA_METHOD_TYPE` of `AUTH_APP`

<img width="1334" alt="Screenshot 2023-03-30 at 10 21 42" src="https://user-images.githubusercontent.com/110528805/228791340-08b6853e-377b-468d-bf0b-32d3cb64e578.png">

- Display new content for users with `MFA_METHOD_TYPE` of `SMS`
<img width="1314" alt="Screenshot 2023-03-30 at 10 22 37" src="https://user-images.githubusercontent.com/110528805/228791458-6f32bd69-c330-4fba-9339-4d60dd0ee103.png">

## Why?

So that a user signed in with 1FA understands why they are required to go through 2FA process in order to access the RP's service.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
