### PR TITLE
AUT-1149: DOM change to satisfy acceptance tests

### DIFF
--- a/src/components/setup-authenticator-app/index.njk
+++ b/src/components/setup-authenticator-app/index.njk
@@ -21,9 +21,11 @@
 
   {% set cannotScanInsetTextHtml %}
   <p class="govuk-body">{{'pages.setupAuthenticatorApp.cannotScanDetails.paragraph1' | translate}}</p>
-  <p class="govuk-body" id="secret-key">
+  <p class="govuk-body">
     <span class="govuk-!-display-block">{{'pages.setupAuthenticatorApp.cannotScanDetails.paragraph2' | translate}}</span>
+    <span id="secret-key">
     {{ displaySecretKey(secretKeyFragmentArray) }}
+    </span>
   </p>
   <p class="govuk-body">{{'pages.setupAuthenticatorApp.cannotScanDetails.paragraph3' | translate}}</p>
   {% endset %}


### PR DESCRIPTION
## What?

Moves `id="secret-key"` to DOM element that contains only the secret key

## Why?

Previous PR had altered the DOM to accommodate the `<span>` elements for formatting and moved the ID. Since merge we've discovered the acceptance tests had relied upon the `id="secret-key"` to verify that secret keys are of the correct length.

## Related PRs
https://github.com/alphagov/di-authentication-frontend/pull/971
