### PR TITLE
Decouple usage of DNS

### DIFF
--- a/ci/tasks/deploy-frontend.yml
+++ b/ci/tasks/deploy-frontend.yml
@@ -10,9 +10,6 @@ params:
   DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
   STATE_BUCKET: digital-identity-dev-tfstate
   DEPLOY_ENVIRONMENT: build
-  DNS_DEPLOYER_ROLE_ARN: ((deployer-role-arn-production))
-  DNS_STATE_BUCKET: ((dns-state-bucket))
-  DNS_STATE_KEY: ((dns-state-key))
   GTM_ID: ((build-gtm-id))
   SESSION_EXPIRY: ((build-session-expiry))
   LOGGING_ENDPOINT_ARN: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
@@ -63,9 +60,6 @@ run:
       terraform apply -auto-approve \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "common_state_bucket=${STATE_BUCKET}" \
-        -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
-        -var "dns_state_key=${DNS_STATE_KEY}" \
-        -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \
         -var "session_expiry=${SESSION_EXPIRY}" \
         -var "logging_endpoint_arn=${LOGGING_ENDPOINT_ARN}" \
         -var 'logging_endpoint_arns=["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"]' \

--- a/ci/terraform/core.tf
+++ b/ci/terraform/core.tf
@@ -9,7 +9,6 @@ data "terraform_remote_state" "core" {
 }
 
 locals {
-  vpc_arn                                    = data.terraform_remote_state.core.outputs.vpc_arn
   vpc_id                                     = data.terraform_remote_state.core.outputs.vpc_id
   allow_aws_service_access_security_group_id = data.terraform_remote_state.core.outputs.allow_aws_service_access_security_group_id
   allow_egress_security_group_id             = data.terraform_remote_state.core.outputs.allow_egress_security_group_id

--- a/ci/terraform/dns.tf
+++ b/ci/terraform/dns.tf
@@ -1,5 +1,5 @@
 data "terraform_remote_state" "dns" {
-  count = var.account_management_fqdn == null && var.oidc_api_fqdn == null ? 1 : 0
+  count = var.zone_id == null ? 1 : 0
 
   backend = "s3"
   config = {
@@ -11,10 +11,10 @@ data "terraform_remote_state" "dns" {
 }
 
 locals {
-  account_management_fqdn = var.account_management_fqdn == null ? lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_account_management_url", "") : var.account_management_fqdn
-  frontend_fqdn           = var.frontend_fqdn == null ? lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_frontend_url", "") : var.frontend_fqdn
-  frontend_api_fqdn       = var.frontend_api_fqdn == null ? lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_api_frontend_url", "") : var.frontend_api_fqdn
-  oidc_api_fqdn           = var.oidc_api_fqdn == null ? lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_api_url", "") : var.oidc_api_fqdn
-  service_domain          = var.service_domain == null ? lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_service_domain", "") : var.service_domain
+  service_domain          = var.service_domain == null ? "${var.environment}.account.gov.uk" : var.service_domain
+  account_management_fqdn = local.service_domain
+  frontend_fqdn           = "signin.${local.service_domain}"
+  frontend_api_fqdn       = "auth.${local.service_domain}"
+  oidc_api_fqdn           = "oidc.${local.service_domain}"
   zone_id                 = var.zone_id == null ? lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_zone_id", "") : var.zone_id
 }

--- a/ci/terraform/dns.tf
+++ b/ci/terraform/dns.tf
@@ -1,20 +1,11 @@
-data "terraform_remote_state" "dns" {
-  count = var.zone_id == null ? 1 : 0
-
-  backend = "s3"
-  config = {
-    bucket   = var.dns_state_bucket
-    key      = var.dns_state_key
-    role_arn = var.dns_state_role
-    region   = var.aws_region
-  }
-}
-
 locals {
   service_domain          = var.service_domain == null ? "${var.environment}.account.gov.uk" : var.service_domain
   account_management_fqdn = local.service_domain
   frontend_fqdn           = "signin.${local.service_domain}"
   frontend_api_fqdn       = "auth.${local.service_domain}"
   oidc_api_fqdn           = "oidc.${local.service_domain}"
-  zone_id                 = var.zone_id == null ? lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_zone_id", "") : var.zone_id
+}
+
+data "aws_route53_zone" "service_domain" {
+  name = local.service_domain
 }

--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -1,7 +1,23 @@
+resource "aws_route53_zone" "zone" {
+  name = local.frontend_fqdn
+}
+
 resource "aws_route53_record" "frontend" {
   name    = local.frontend_fqdn
   type    = "A"
   zone_id = local.zone_id
+
+  alias {
+    evaluate_target_health = false
+    name                   = aws_lb.frontend_alb.dns_name
+    zone_id                = aws_lb.frontend_alb.zone_id
+  }
+}
+
+resource "aws_route53_record" "frontend_record" {
+  name    = local.frontend_fqdn
+  type    = "A"
+  zone_id = aws_route53_record.frontend.zone_id
 
   alias {
     evaluate_target_health = false
@@ -35,7 +51,29 @@ resource "aws_route53_record" "frontend_alb_certificate_validation" {
   zone_id         = local.zone_id
 }
 
+resource "aws_route53_record" "frontend_validation_record" {
+
+  for_each = {
+    for dvo in aws_acm_certificate.frontend_alb_certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.zone.zone_id
+}
+
 resource "aws_acm_certificate_validation" "frontend_acm_alb_certificate_validation" {
   certificate_arn         = aws_acm_certificate.frontend_alb_certificate.arn
-  validation_record_fqdns = [for record in aws_route53_record.frontend_alb_certificate_validation : record.fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.frontend_validation_record : record.fqdn]
+}
+
+output "signin_nameservers" {
+  value = aws_route53_zone.zone.name_servers
 }

--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -5,7 +5,7 @@ resource "aws_route53_zone" "zone" {
 resource "aws_route53_record" "frontend" {
   name    = local.frontend_fqdn
   type    = "A"
-  zone_id = local.zone_id
+  zone_id = data.aws_route53_zone.service_domain.zone_id
 
   alias {
     evaluate_target_health = false
@@ -17,7 +17,7 @@ resource "aws_route53_record" "frontend" {
 resource "aws_route53_record" "frontend_record" {
   name    = local.frontend_fqdn
   type    = "A"
-  zone_id = aws_route53_record.frontend.zone_id
+  zone_id = aws_route53_zone.zone.zone_id
 
   alias {
     evaluate_target_health = false
@@ -34,7 +34,6 @@ resource "aws_acm_certificate" "frontend_alb_certificate" {
 }
 
 resource "aws_route53_record" "frontend_alb_certificate_validation" {
-
   for_each = {
     for dvo in aws_acm_certificate.frontend_alb_certificate.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
@@ -48,11 +47,10 @@ resource "aws_route53_record" "frontend_alb_certificate_validation" {
   records         = [each.value.record]
   ttl             = 60
   type            = each.value.type
-  zone_id         = local.zone_id
+  zone_id         = data.aws_route53_zone.service_domain.zone_id
 }
 
 resource "aws_route53_record" "frontend_validation_record" {
-
   for_each = {
     for dvo in aws_acm_certificate.frontend_alb_certificate.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -17,30 +17,6 @@ variable "redis_node_size" {
   default = "cache.t2.small"
 }
 
-variable "dns_state_bucket" {
-  default = ""
-}
-
-variable "dns_state_key" {
-  default = ""
-}
-
-variable "dns_state_role" {
-  default = ""
-}
-
-variable "account_management_fqdn" {
-  default = null
-}
-
-variable "oidc_api_fqdn" {
-  default = null
-}
-
-variable "frontend_fqdn" {
-  default = null
-}
-
 variable "service_domain" {
   default = null
 }
@@ -51,10 +27,6 @@ variable "support_international_numbers" {
 
 variable "support_language_cy" {
   type = string
-}
-
-variable "zone_id" {
-  default = null
 }
 
 variable "image_uri" {
@@ -137,20 +109,10 @@ variable "cloudwatch_log_retention" {
   type    = number
 }
 
-variable "logging_endpoint_arn" {
-  default = ""
-}
-
 variable "logging_endpoint_arns" {
   type        = list(string)
   default     = []
   description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
-}
-
-variable "logging_endpoint_enabled" {
-  type        = bool
-  default     = false
-  description = "Whether the service should ship its Lambda logs to the `logging_endpoint_arn`"
 }
 
 variable "zendesk_username" {
@@ -166,10 +128,6 @@ variable "zendesk_group_id_public" {
 variable "zendesk_api_token" {
   type    = string
   default = ""
-}
-
-variable "frontend_api_fqdn" {
-  default = null
 }
 
 variable "deployment_min_healthy_percent" {


### PR DESCRIPTION
## What?

Adds a new hosted zone so that di-authentication-frontend is entirely responsible for its DNS configuration.

## Why?

This decouples from the dns configuration in di-infrastructure, eliminating the need for remote state.
