### PR TITLE
AUT-1158: Refactor account-created content for optional services

### DIFF
--- a/src/components/account-created/index.njk
+++ b/src/components/account-created/index.njk
@@ -2,37 +2,30 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.accountCreated.title' | translate %}
 {% block content %}
 
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.accountCreated.header' | translate}}</h1>
 
-<p class="govuk-body">{{'pages.accountCreated.text' | translate}}</p>
-
 <form id="form-tracking" action="/account-created" method="post" novalidate>
 <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+
+{% if serviceType === 'OPTIONAL' %}
+    <p class="govuk-body">{{'pages.accountCreated.youCanNowSaveYourProgress' | translate}}</p>
+
+    {{ govukButton({
+        "text": "pages.accountCreated.saveYourProgress" | translate,
+        "preventDoubleClick": true
+    }) }}
+{% else %}
+    <p class="govuk-body">{{'pages.accountCreated.text' | translate}}</p>
 
     {{ govukButton({
         "text": "pages.accountCreated.continue" | translate,
         "type": "Submit",
         "preventDoubleClick": true
     }) }}
-
-{% if serviceType === 'OPTIONAL' %}
-    <h1 class="govuk-body govuk-bold">{{'pages.accountCreated.progressSaved' | translate}}</h1>
-
-    {{ govukButton({
-        "text": "pages.accountCreated.continue" | translate,
-        "preventDoubleClick": true
-    }) }}
-
-    <br>
-
-    <a href="{{ logoutUrl }}" class="govuk-link govuk-body">
-        {{'pages.accountCreated.signOut' | translate}}
-    </a>
 {% endif %}
 </form>
 {% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -353,12 +353,9 @@
       "title": "Rydych wedi creu eich GOV.UK One Login",
       "header": "Rydych wedi creu eich GOV.UK One Login",
       "text": "Nawr ewch yn eich blaen i ddefnyddio’r gwasanaeth.",
-      "inset": "Mae eich cynnydd ar ",
-      "insetContinued": " wedi cael ei arbed.",
       "continue": "Parhau",
-      "signOut": "Allgofnodi",
-      "continueReport": "Parhau eich adroddiad",
-      "progressSaved": "Mae eich cynnydd wedi cael ei arbed."
+      "youCanNowSaveYourProgress": "Gallwch nawr arbed eich cynnydd.",
+      "saveYourProgress": "Arbed eich cynnydd"
     },
     "checkYourEmail": {
       "title": "Gwiriwch eich e-bost",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -353,12 +353,9 @@
       "title": "You’ve created your GOV.UK One Login",
       "header": "You’ve created your GOV.UK One Login",
       "text": "Now continue to use the service.",
-      "inset": "Your progress on ",
-      "insetContinued": " has been saved.",
       "continue": "Continue",
-      "signOut": "Sign out",
-      "continueReport": "Continue your report",
-      "progressSaved": "Your progress has been saved."
+      "youCanNowSaveYourProgress": "You can now save your progress.",
+      "saveYourProgress": "Save your progress"
     },
     "checkYourEmail": {
       "title": "Check your email",


### PR DESCRIPTION
## What?

Refactor account-created content for optional services (CICS save and resume).
- When the user has created their account, they will see this page:
![Screenshot 2023-04-03 at 14 36 09](https://user-images.githubusercontent.com/110528805/229533025-cd26ef54-0639-4d2c-bc28-f722c31b2f84.png)

## Why?

When CICS service users create their account via GOV.UK One login through their application, they are provided with an option to save their progress

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated
