### PR TITLE
Terraform will error instead of destroy zone

### DIFF
--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -1,5 +1,9 @@
 resource "aws_route53_zone" "zone" {
   name = local.frontend_fqdn
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_route53_record" "frontend" {


### PR DESCRIPTION
## What?

Terraform will error instead of destroy zones

## Why?

This will ensure hosted zones don't accidentally get deleted, as the name server values will be hardcoded in the root zone.
