### PR TITLE
AUT-1050: Additional logging for support form

### DIFF
--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -11,6 +11,7 @@ import { defaultZendeskClient } from "../../utils/zendesk";
 import { getZendeskGroupIdPublic } from "../../config";
 import { CreateTicketPayload, ZendeskInterface } from "../../utils/types";
 import { ZENDESK_THEMES } from "../../app.constants";
+import { logger } from "../../utils/logger";
 
 export function getZendeskIdentifierTag(theme: string): string {
   if (theme === ZENDESK_THEMES.ID_CHECK_APP) {
@@ -53,7 +54,47 @@ export function contactUsService(
       };
     }
 
-    await zendeskClient.createTicket(payload);
+    try {
+      logger.info(
+        `Submitting support ticket, see field information:
+      subject: ${contactForm?.subject?.length}
+      descriptions.issueDescription: ${
+        contactForm?.descriptions?.issueDescription?.length
+      }
+      descriptions.additionalDescription: ${
+        contactForm?.descriptions?.additionalDescription?.length
+      }
+      descriptions.optionalDescription: ${
+        contactForm?.descriptions?.optionalDescription?.length
+      }
+      descriptions.moreDetailDescription: ${
+        contactForm?.descriptions?.moreDetailDescription?.length
+      }
+      descriptions.serviceTryingToUse: ${
+        contactForm?.descriptions?.serviceTryingToUse?.length
+      }
+      optionalData.userAgent: ${contactForm?.optionalData?.userAgent}
+      optionalData.ticketIdentifier: ${
+        contactForm?.optionalData?.ticketIdentifier
+      }
+      optionalData.appSessionId: ${contactForm?.optionalData?.appSessionId}
+      optionalData.appErrorCode: ${contactForm?.optionalData?.appErrorCode}
+      referer: ${contactForm?.referer}
+      securityCodeSentMethod: ${contactForm?.securityCodeSentMethod}
+      payload.ticket.requester.email: ${
+        payload?.ticket?.requester?.email?.length
+      }
+      payload.ticket.requester.name: ${payload?.ticket?.requester?.name?.length}
+      payload.ticket.tags: ${JSON.stringify(payload?.ticket?.tags)}`
+      );
+    } catch (e) {
+      logger.error("Unable to log support ticket details due to error.", e);
+    }
+
+    await zendeskClient.createTicket(
+      payload,
+      contactForm?.optionalData?.ticketIdentifier
+    );
   };
 
   function formatCommentBody(

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -22,7 +22,10 @@ interface RequesterAnonymous {
 }
 
 export interface ZendeskInterface {
-  createTicket(form: CreateTicketPayload): Promise<void>;
+  createTicket(
+    form: CreateTicketPayload,
+    ticketIdentifier?: string
+  ): Promise<void>;
 }
 
 export interface RedisConfig {

--- a/src/utils/zendesk.ts
+++ b/src/utils/zendesk.ts
@@ -13,7 +13,10 @@ export class ZendeskService implements ZendeskInterface {
     this.apiUrl = config.remoteUri;
   }
 
-  async createTicket(form: CreateTicketPayload): Promise<void> {
+  async createTicket(
+    form: CreateTicketPayload,
+    ticketIdentifier?: string
+  ): Promise<void> {
     const instance = axios.create({
       baseURL: this.apiUrl,
       headers: {
@@ -26,7 +29,15 @@ export class ZendeskService implements ZendeskInterface {
       },
     });
 
-    await instance.post("/tickets.json", form);
+    await instance.post("/tickets.json", form).catch((error) => {
+      throw new Error(
+        error.response.status +
+          " " +
+          error.response.statusText +
+          " - ticketIdentifier: " +
+          ticketIdentifier
+      );
+    });
   }
 }
 


### PR DESCRIPTION
## What?

Log information about the contents of the support form without logging any user entered text.  Able to see which fields are empty and which ones have content. 
Log the error code and status text from the zendesk api on error.

## Why?

Provide more information to help with diagnosis when dealing with zendesk api errors.
 