### PR TITLE
AUT-1208 - Call VerifyMfaCodeHandler from the check-your-phone-controller

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -1,14 +1,14 @@
 import { Request, Response } from "express";
-import { NOTIFICATION_TYPE } from "../../app.constants";
-import { VerifyCodeInterface } from "../common/verify-code/types";
-import { codeService } from "../common/verify-code/verify-code-service";
-import { verifyCodePost } from "../common/verify-code/verify-code-controller";
+import { MFA_METHOD_TYPE, NOTIFICATION_TYPE } from "../../app.constants";
 import { ExpressRouteFunc } from "../../types";
 import { ERROR_CODES, getNextPathAndUpdateJourney } from "../common/constants";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import xss from "xss";
+import { VerifyMfaCodeInterface } from "../enter-authenticator-app-code/types";
+import { verifyMfaCodePost } from "../common/verify-mfa-code/verify-mfa-code-post";
+import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-service";
 
 const TEMPLATE_NAME = "check-your-phone/index.njk";
 
@@ -19,11 +19,12 @@ export function checkYourPhoneGet(req: Request, res: Response): void {
 }
 
 export const checkYourPhonePost = (
-  service: VerifyCodeInterface = codeService(),
+  service: VerifyMfaCodeInterface = verifyMfaCodeService(),
   notificationService: SendNotificationServiceInterface = sendNotificationService()
 ): ExpressRouteFunc => {
-  return verifyCodePost(service, {
-    notificationType: NOTIFICATION_TYPE.VERIFY_PHONE_NUMBER,
+  return verifyMfaCodePost(service, {
+    methodType: MFA_METHOD_TYPE.SMS,
+    registration: true,
     template: TEMPLATE_NAME,
     validationKey: "pages.checkYourPhone.code.validationError.invalidCode",
     validationErrorCode: ERROR_CODES.INVALID_VERIFY_PHONE_NUMBER_CODE,

--- a/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
@@ -8,7 +8,6 @@ import {
   checkYourPhonePost,
 } from "../check-your-phone-controller";
 
-import { VerifyCodeInterface } from "../../common/verify-code/types";
 import { SendNotificationServiceInterface } from "../../common/send-notification/types";
 import { PATH_NAMES } from "../../../app.constants";
 import { ERROR_CODES } from "../../common/constants";
@@ -18,6 +17,7 @@ import {
   RequestOutput,
   ResponseOutput,
 } from "mock-req-res";
+import { VerifyMfaCodeInterface } from "../../enter-authenticator-app-code/types";
 
 describe("check your phone controller", () => {
   let req: RequestOutput;
@@ -48,8 +48,8 @@ describe("check your phone controller", () => {
 
   describe("checkYourPhonePost", () => {
     it("should redirect to /create-password when valid code entered", async () => {
-      const fakeService: VerifyCodeInterface = {
-        verifyCode: sinon.fake.returns({
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
           sessionState: "PHONE_NUMBER_CODE_VERIFIED",
           success: true,
         }),
@@ -67,15 +67,15 @@ describe("check your phone controller", () => {
         res as Response
       );
 
-      expect(fakeService.verifyCode).to.have.been.calledOnce;
+      expect(fakeService.verifyMfaCode).to.have.been.calledOnce;
       expect(res.redirect).to.have.calledWith(
         PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL
       );
     });
 
     it("should return error when invalid code entered", async () => {
-      const fakeService: VerifyCodeInterface = {
-        verifyCode: sinon.fake.returns({
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
           success: false,
           data: {
             code: ERROR_CODES.INVALID_VERIFY_PHONE_NUMBER_CODE,
@@ -96,13 +96,13 @@ describe("check your phone controller", () => {
         res as Response
       );
 
-      expect(fakeService.verifyCode).to.have.been.calledOnce;
+      expect(fakeService.verifyMfaCode).to.have.been.calledOnce;
       expect(res.render).to.have.been.calledWith("check-your-phone/index.njk");
     });
 
     it("should redirect to security code expired when invalid code entered more than max retries", async () => {
-      const fakeService: VerifyCodeInterface = {
-        verifyCode: sinon.fake.returns({
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
           success: false,
           data: {
             code: ERROR_CODES.ENTERED_INVALID_VERIFY_PHONE_NUMBER_CODE_MAX_TIMES,
@@ -124,7 +124,7 @@ describe("check your phone controller", () => {
         res as Response
       );
 
-      expect(fakeService.verifyCode).to.have.been.calledOnce;
+      expect(fakeService.verifyMfaCode).to.have.been.calledOnce;
       expect(res.redirect).to.have.been.calledWith(
         `${PATH_NAMES.SECURITY_CODE_INVALID}?actionType=otpMaxRetries`
       );

--- a/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-integration.test.ts
@@ -2,7 +2,7 @@ import request from "supertest";
 import { describe } from "mocha";
 import { expect, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
-import * as cheerio from "cheerio";
+import cheerio from "cheerio";
 import decache from "decache";
 import {
   API_ENDPOINTS,
@@ -144,7 +144,7 @@ describe("Integration:: check your phone", () => {
 
   it("should redirect to /create-password when valid code entered", (done) => {
     nock(baseApi)
-      .post(API_ENDPOINTS.VERIFY_CODE)
+      .post(API_ENDPOINTS.VERIFY_MFA_CODE)
       .once()
       .reply(HTTP_STATUS_CODES.NO_CONTENT, {})
       .post(API_ENDPOINTS.SEND_NOTIFICATION)
@@ -164,7 +164,7 @@ describe("Integration:: check your phone", () => {
   });
 
   it("should return validation error when incorrect code entered", (done) => {
-    nock(baseApi).post(API_ENDPOINTS.VERIFY_CODE).once().reply(400, {
+    nock(baseApi).post(API_ENDPOINTS.VERIFY_MFA_CODE).once().reply(400, {
       code: ERROR_CODES.INVALID_VERIFY_PHONE_NUMBER_CODE,
       success: false,
     });
@@ -187,7 +187,7 @@ describe("Integration:: check your phone", () => {
   });
 
   it("should redirect to security code expired when incorrect code has been entered 5 times", (done) => {
-    nock(baseApi).post(API_ENDPOINTS.VERIFY_CODE).times(6).reply(400, {
+    nock(baseApi).post(API_ENDPOINTS.VERIFY_MFA_CODE).times(6).reply(400, {
       code: ERROR_CODES.ENTERED_INVALID_VERIFY_PHONE_NUMBER_CODE_MAX_TIMES,
       success: false,
     });

--- a/src/components/common/verify-mfa-code/verify-mfa-code-post.ts
+++ b/src/components/common/verify-mfa-code/verify-mfa-code-post.ts
@@ -1,0 +1,77 @@
+import { VerifyMfaCodeInterface } from "../../enter-authenticator-app-code/types";
+import { ExpressRouteFunc } from "../../../types";
+import { Request, Response } from "express";
+import { MFA_METHOD_TYPE } from "../../../app.constants";
+import {
+  formatValidationError,
+  renderBadRequest,
+} from "../../../utils/validation";
+import { getErrorPathByCode, getNextPathAndUpdateJourney } from "../constants";
+import { BadRequestError } from "../../../utils/error";
+import { USER_JOURNEY_EVENTS } from "../state-machine/state-machine";
+
+interface Config {
+  methodType: MFA_METHOD_TYPE;
+  registration: boolean;
+  template: string;
+  validationKey: string;
+  validationErrorCode: number;
+  callback?: (req: Request, res: Response) => void;
+}
+
+export function verifyMfaCodePost(
+  service: VerifyMfaCodeInterface,
+  options: Config
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const code = req.body["code"];
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+
+    const result = await service.verifyMfaCode(
+      options.methodType,
+      code,
+      options.registration,
+      sessionId,
+      clientSessionId,
+      req.ip,
+      persistentSessionId
+    );
+
+    if (!result.success) {
+      if (result.data.code === options.validationErrorCode) {
+        const error = formatValidationError(
+          "code",
+          req.t(options.validationKey)
+        );
+        return renderBadRequest(res, req, options.template, error);
+      }
+
+      const path = getErrorPathByCode(result.data.code);
+
+      if (path) {
+        return res.redirect(path);
+      }
+
+      throw new BadRequestError(result.data.message, result.data.code);
+    }
+
+    if (options.callback) {
+      return options.callback(req, res);
+    }
+
+    res.redirect(
+      getNextPathAndUpdateJourney(
+        req,
+        req.path,
+        USER_JOURNEY_EVENTS.AUTH_APP_CODE_VERIFIED,
+        {
+          isIdentityRequired: req.session.user.isIdentityRequired,
+          isConsentRequired: req.session.user.isConsentRequired,
+          isLatestTermsAndConditionsAccepted:
+            req.session.user.isLatestTermsAndConditionsAccepted,
+        },
+        res.locals.sessionId
+      )
+    );
+  };
+}

--- a/src/components/common/verify-mfa-code/verify-mfa-code-service.ts
+++ b/src/components/common/verify-mfa-code/verify-mfa-code-service.ts
@@ -2,17 +2,17 @@ import {
   API_ENDPOINTS,
   HTTP_STATUS_CODES,
   MFA_METHOD_TYPE,
-} from "../../app.constants";
+} from "../../../app.constants";
 import {
   createApiResponse,
   getRequestConfig,
   http,
   Http,
-} from "../../utils/http";
-import { ApiResponseResult, DefaultApiResponse } from "../../types";
-import { VerifyMfaCodeInterface } from "./types";
+} from "../../../utils/http";
+import { ApiResponseResult, DefaultApiResponse } from "../../../types";
+import { VerifyMfaCodeInterface } from "../../enter-authenticator-app-code/types";
 
-export function authenticatorAppCodeService(
+export function verifyMfaCodeService(
   axios: Http = http
 ): VerifyMfaCodeInterface {
   const verifyMfaCode = async function (

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -1,23 +1,14 @@
 import { Request, Response } from "express";
 import { ExpressRouteFunc } from "../../types";
-import {
-  ERROR_CODES,
-  getErrorPathByCode,
-  getNextPathAndUpdateJourney,
-  pathWithQueryParam,
-} from "../common/constants";
+import { ERROR_CODES, pathWithQueryParam } from "../common/constants";
 import { supportAccountRecovery } from "../../config";
-import { VerifyMfaCodeInterface, VerifyMfaCodeConfig } from "./types";
-import { authenticatorAppCodeService } from "./enter-authenticator-app-code-service";
+import { VerifyMfaCodeInterface } from "./types";
 import { AccountRecoveryInterface } from "../common/account-recovery/types";
 import { accountRecoveryService } from "../common/account-recovery/account-recovery-service";
 import { BadRequestError } from "../../utils/error";
-import {
-  formatValidationError,
-  renderBadRequest,
-} from "../../utils/validation";
 import { MFA_METHOD_TYPE, PATH_NAMES } from "../../app.constants";
-import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-service";
+import { verifyMfaCodePost } from "../common/verify-mfa-code/verify-mfa-code-post";
 
 const TEMPLATE_NAME = "enter-authenticator-app-code/index.njk";
 
@@ -82,65 +73,14 @@ export function enterAuthenticatorAppCodeGet(
 }
 
 export const enterAuthenticatorAppCodePost = (
-  service: VerifyMfaCodeInterface = authenticatorAppCodeService()
+  service: VerifyMfaCodeInterface = verifyMfaCodeService()
 ): ExpressRouteFunc => {
-  return verifyAuthenticatorAppCodePost(service, {
+  return verifyMfaCodePost(service, {
+    methodType: MFA_METHOD_TYPE.AUTH_APP,
+    registration: false,
     template: TEMPLATE_NAME,
     validationKey:
       "pages.enterAuthenticatorAppCode.code.validationError.invalidCode",
     validationErrorCode: ERROR_CODES.AUTH_APP_INVALID_CODE,
   });
 };
-
-export function verifyAuthenticatorAppCodePost(
-  service: VerifyMfaCodeInterface,
-  options: VerifyMfaCodeConfig
-): ExpressRouteFunc {
-  return async function (req: Request, res: Response) {
-    const code = req.body["code"];
-    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
-
-    const result = await service.verifyMfaCode(
-      MFA_METHOD_TYPE.AUTH_APP,
-      code,
-      false,
-      sessionId,
-      clientSessionId,
-      req.ip,
-      persistentSessionId
-    );
-
-    if (!result.success) {
-      if (result.data.code === options.validationErrorCode) {
-        const error = formatValidationError(
-          "code",
-          req.t(options.validationKey)
-        );
-        return renderBadRequest(res, req, options.template, error);
-      }
-
-      const path = getErrorPathByCode(result.data.code);
-
-      if (path) {
-        return res.redirect(path);
-      }
-
-      throw new BadRequestError(result.data.message, result.data.code);
-    }
-
-    res.redirect(
-      getNextPathAndUpdateJourney(
-        req,
-        req.path,
-        USER_JOURNEY_EVENTS.AUTH_APP_CODE_VERIFIED,
-        {
-          isIdentityRequired: req.session.user.isIdentityRequired,
-          isConsentRequired: req.session.user.isConsentRequired,
-          isLatestTermsAndConditionsAccepted:
-            req.session.user.isLatestTermsAndConditionsAccepted,
-        },
-        res.locals.sessionId
-      )
-    );
-  };
-}


### PR DESCRIPTION
## What?

- Call `/verify-mfa-code` from the check-your-phone-controller instead of `/verify-code` 
- Create a common component for calling the VerifyMfaCodeHandler
- Call the common component from the enter-authenticator-app-code-controller to avoid code duplication

## Why?

- The logic to validate registration SMS OTPs has moved to the VerifyMfaCodeHandler


## Related PRs
https://github.com/alphagov/di-authentication-api/pull/2901
