### PR TITLE
AUT-1050: Send email as contact name when contact name not provided

### DIFF
--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -48,9 +48,12 @@ export function contactUsService(
     };
 
     if (contactForm.feedbackContact && contactForm.email) {
+      const contactName = contactForm.name
+        ? contactForm.name
+        : contactForm.email;
       payload.ticket.requester = {
         email: contactForm.email,
-        name: contactForm.name,
+        name: contactName,
       };
     }
 


### PR DESCRIPTION
## What?

On the support form users have an option to provide a contact email and contact name.  The contact name is not mandatory.  If a user does not already have a Zendesk account then the requester name field is mandatory and the ticket creation request will be rejected by the api.

If a user does not supply a contact name then the email address will be used by default instead.  In Zendesk the account will be created with the first part of the email address before the '@'.  Users can change their account name if they so wish by logging into their Zendesk account.

For users who do have an existing account this change makes no difference, and the requester name will not be updated.

## Why?

Resolves an issue where support form submissions were unsuccessful, returning an HTTP 422 error for users not having an accout and who did not provide a contact name.

## Change have been demonstrated

This is a bug fix with no content changes.

## Performance Analysis have been informed of the change

No PA impact.

