### PR TITLE
create_before_destroy on certificate

### DIFF
--- a/ci/terraform/route53.tf
+++ b/ci/terraform/route53.tf
@@ -35,6 +35,10 @@ resource "aws_acm_certificate" "frontend_alb_certificate" {
   validation_method = "DNS"
 
   tags = local.default_tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_route53_record" "frontend_alb_certificate_validation" {


### PR DESCRIPTION
## What?

create_before_destroy on certificate resource

## Why?

Certificates can't be destroyed while in used
