### PR TITLE
AUT-1075: Move details component below continue button

### DIFF
--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -58,16 +58,17 @@
       {% endif %}
     {% endset %}
 
-    {{ govukDetails({
-      summaryText: 'pages.enterMfa.details.summaryText' | translate,
-      html: detailsHTML
-    }) }}
-
     {{ govukButton({
       "text": "general.continue.label" | translate,
       "type": "Submit",
       "preventDoubleClick": true
     }) }}
+
+    {{ govukDetails({
+      summaryText: 'pages.enterMfa.details.summaryText' | translate,
+      html: detailsHTML
+    }) }}
+
 
   </form>
 {% endblock %}


### PR DESCRIPTION
## What?

Moves details component that appears on the "You need to enter a security code" page in the sign in journey so that it is below the "Continue" button. 

## Why?

Design change

## Screen changes

The updated screen (with details component below the "Continue" button) is shown below

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [ ] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

## Related PRs

Several other changes were introduced in https://github.com/alphagov/di-authentication-frontend/pull/940
