### PR TITLE
Revert "AUT-995: Content change on /enter-code and /enter-authenticationo-app-code

### DIFF
--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -3,25 +3,11 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.enterAuthenticatorAppCode.title' | translate %}
 
 {% block content %}
 
   {% include "common/errors/errorSummary.njk" %}
-  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterAuthenticatorAppCode.header' | translate }}</h1>
-  <p class="govuk-body">{{ 'pages.enterAuthenticatorAppCode.info.paragraph1' | translate }} </p>
-
-  {% set insetTextHtml %}
-    <p class="govuk-body">
-      {{ 'pages.enterAuthenticatorAppCode.info.paragraph2' | translate }}
-      <span class="govuk-!-font-weight-bold">{{ 'pages.enterAuthenticatorAppCode.info.authenticatorApp' | translate }}</span>
-      <span>{{ 'pages.enterAuthenticatorAppCode.info.paragraph2End' | translate }}</span>
-    </p>
-  {% endset %}
-  {{ govukInsetText({
-    html: insetTextHtml
-  }) }}
 
   <form id="form-tracking" action="/enter-authenticator-app-code" method="post" novalidate="novalidate">
 
@@ -29,26 +15,26 @@
 
     {{ govukInput({
       label: {
-        text: 'pages.enterAuthenticatorAppCode.code.label' | translate
+        text: 'pages.enterAuthenticatorAppCode.header' | translate,
+        classes: "govuk-label--l",
+        isPageHeading: true
       },
-      hint: {
-        text: 'pages.enterAuthenticatorAppCode.code.labelSummary' | translate
-      },
-      classes: "govuk-input--width-10 govuk-!-font-weight-bold",
-      id: "code",
-      name: "code",
-      inputmode: "numeric",
-      spellcheck: false,
-      autocomplete:"off",
-      errorMessage: {
-        text: errors['code'].text
-      } if (errors['code'])}) }}
+    classes: "govuk-input--width-10",
+    id: "code",
+    name: "code",
+    inputmode: "numeric",
+    spellcheck: false,
+    autocomplete:"one-time-code",
+    errorMessage: {
+      text: errors['code'].text
+    } if (errors['code'])})
+  }}
 
     {{ govukButton({
-      "text": "general.continue.label" | translate,
-      "type": "Submit",
-      "preventDoubleClick": true
-    }) }}
+    "text": "general.continue.label" | translate,
+    "type": "Submit",
+    "preventDoubleClick": true
+  }) }}
 
   </form>
 

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -3,7 +3,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.enterMfa.title' | translate %}
 
 {% block content %}
@@ -11,51 +10,41 @@
   {% include "common/errors/errorSummary.njk" %}
 
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterMfa.header' | translate }}</h1>
-  <p class="govuk-body">{{ 'pages.enterMfa.info.paragraph1' | translate }} </p>
 
-  {% set insetTextHtml %}
-    <p class="govuk-body">{{ 'pages.enterMfa.info.paragraph3' | translate }}</p>
-  {% endset %}
-  {{ govukInsetText({
-    html: insetTextHtml
-  }) }}
-
-  <p class="govuk-body">{{ 'pages.enterMfa.info.paragraph2' | translate }} </p>
+  <p class="govuk-body">{{'pages.enterMfa.info.paragraph1' | translate }}</p>
+  <p class="govuk-body">{{'pages.enterMfa.info.paragraph2' | translate }}</p>
 
   <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">
-    <input type="hidden" name="phoneNumber" value="{{ phoneNumber }}" />
-    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+    <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
+    <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
     {{ govukInput({
-      label: {
-        text: 'pages.enterMfa.code.label' | translate
-      },
-      classes: "govuk-input--width-10 govuk-!-font-weight-bold",
-      id: "code",
-      name: "code",
-      inputmode: "numeric",
-      spellcheck: false,
-      autocomplete:"off",
-      errorMessage: {
-        text: errors['code'].text
-      } if (errors['code'])}) }}
+  label: {
+  text: 'pages.enterMfa.code.label' | translate
+  },
+  classes: "govuk-input--width-10 govuk-!-font-weight-bold",
+  id: "code",
+  name: "code",
+  inputmode: "numeric",
+  spellcheck: false,
+  autocomplete:"off",
+  errorMessage: {
+  text: errors['code'].text
+  } if (errors['code'])})
+  }}
 
     {% set detailsHTML %}
-      <p class="govuk-body">
-        <a href="{{ 'pages.enterMfa.details.sendCodeLinkHref' | translate }}"
-           class="govuk-link"
-           rel="noreferrer noopener">
-          {{'pages.enterMfa.details.sendTheCodeAgain'| translate}}
-        </a>
-        {{'pages.enterMfa.details.text 2' | translate}}
-      </p>
+    <p class="govuk-body">
+      {{'pages.enterMfa.details.text1' | translate}}
+      <a href="{{'pages.enterMfa.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterMfa.details.sendCodeLinkText'| translate}}</a>
+      {{'pages.enterMfa.details.text 2' | translate}}
+    </p>
+    <p class="govuk-body">
       {% if supportAccountRecovery %}
-        <p class="govuk-body">
-          {{ 'pages.enterMfa.details.changeGetSecurityCodesText' | translate }}
-          <a href={{ checkEmailLink }} class="govuk-link"
-             rel="noreferrer noopener">{{ 'pages.enterMfa.details.changeGetSecurityCodesLinkText'| translate }}</a>.
-        </p>
+        {{'pages.enterMfa.details.changeGetSecurityCodesText' | translate}}
+        <a href={{checkEmailLink}} class="govuk-link" rel="noreferrer noopener">{{'pages.enterMfa.details.changeGetSecurityCodesLinkText'| translate}}</a>.
       {% endif %}
+    </p>
     {% endset %}
 
     {{ govukDetails({
@@ -64,10 +53,11 @@
     }) }}
 
     {{ govukButton({
-      "text": "general.continue.label" | translate,
-      "type": "Submit",
-      "preventDoubleClick": true
-    }) }}
+  "text": "general.continue.label" | translate,
+  "type": "Submit",
+  "preventDoubleClick": true
+  }) }}
 
   </form>
+
 {% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -452,12 +452,11 @@
       }
     },
     "enterMfa": {
-      "title": "Mae angen i chi roi cod diogelwch",
-      "header": "Mae angen i chi roi cod diogelwch",
+      "title": "Gwiriwch eich ffôn",
+      "header": "Gwiriwch eich ffôn",
       "info": {
-        "paragraph1": "Mae hwn yn helpu i gadw eich GOV.UK One Login yn ddiogel.",
-        "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud.",
-        "paragraph3": "Rydym wedi anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login."
+        "paragraph1": "Rydym wedi anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login.",
+        "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud."
       },
       "resend": {
         "link": "Gofynnwch am god newydd",
@@ -475,7 +474,6 @@
       },
       "details": {
         "summaryText": "Problemau gyda’r cod?",
-        "sendTheCodeAgain": "Anfon y cod eto",
         "text1": "Gallwn ",
         "sendCodeLinkText": "anfon y cod eto",
         "sendCodeLinkHref": "/resend-code",
@@ -1910,17 +1908,9 @@
       "changeMfaChoiceLinkText": "Cael cod mewn ffordd arall"
     },
     "enterAuthenticatorAppCode": {
-      "title": "Mae angen i chi roi cod diogelwch",
-      "header": "Mae angen i chi roi cod diogelwch",
-      "info": {
-        "paragraph1": "Mae hwn yn helpu i gadw eich GOV.UK One Login yn ddiogel.",
-        "paragraph2": "I gael cod diogelwch, agorwch yr ",
-        "authenticatorApp": "ap dilysydd ",
-        "paragraph2End": "rydych wedi’i ddefnyddio i greu eich GOV.UK One Login"
-      },
+      "title": "Rhowch y cod diogelwch 6 digid a ddangosir yn eich ap dilysydd",
+      "header": "Rhowch y cod diogelwch 6 digid a ddangosir yn eich ap dilysydd",
       "code": {
-        "label": "Rhowch y cod diogelwch",
-        "labelSummary": "Dyma’r rhif 6-digid a ddangosir yn eich ap dilysydd",
         "validationError": {
           "required": "Rhowch y cod diogelwch",
           "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -452,12 +452,11 @@
       }
     },
     "enterMfa": {
-      "title": "You need to enter a security code",
-      "header": "You need to enter a security code",
+      "title": "Check your phone",
+      "header": "Check your phone",
       "info": {
-        "paragraph1": "This helps your GOV.UK One Login secure.",
-        "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes.",
-        "paragraph3": "We sent a code to the phone number linked to your GOV.UK One Login."
+        "paragraph1": "We sent a code to the phone number linked to your GOV.UK One Login.",
+        "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes."
       },
       "resend": {
         "link": "Request a new code",
@@ -475,7 +474,6 @@
       },
       "details": {
         "summaryText": "Problems with the code?",
-        "sendTheCodeAgain": "Send the code again",
         "text1": "We can ",
         "sendCodeLinkText": "send the code again",
         "sendCodeLinkHref": "/resend-code",
@@ -1910,17 +1908,9 @@
       "changeMfaChoiceLinkText": "Get a code another way"
     },
     "enterAuthenticatorAppCode": {
-      "title": "You need to enter a security code",
-      "header": "You need to enter a security code",
-      "info": {
-        "paragraph1": "This helps your GOV.UK One Login secure.",
-        "paragraph2": "To get a security code, open the ",
-        "authenticatorApp": "authenticator app ",
-        "paragraph2End": "you used to create your GOV.UK One Login"
-      },
+      "title": "Enter the 6 digit security code shown in your authenticator app",
+      "header": "Enter the 6 digit security code shown in your authenticator app",
       "code": {
-        "label": "Enter the security code",
-        "labelSummary": "This is the 6-digit number shown in your authenticator app",
         "validationError": {
           "required": "Enter the security code",
           "invalidFormat": "Enter the security code using only 6 digits",


### PR DESCRIPTION
## What?

This reverts commit 206ab7ac490471f7c3a0268ef1837253011d0115.

## Why?

Should use `isUpliftRequired` flag to switch the content in "Check your phone" screen when uplifting to 2FA service

## Related PRs
[Original PR](https://github.com/alphagov/di-authentication-frontend/pull/990)
