### PR TITLE
AUT-1075: Move details component below "Continue" button

### DIFF
--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -47,16 +47,16 @@
     </p>
     {% endset %}
 
-    {{ govukDetails({
-      summaryText: 'pages.enterMfa.details.summaryText' | translate,
-      html: detailsHTML
-    }) }}
-
     {{ govukButton({
   "text": "general.continue.label" | translate,
   "type": "Submit",
   "preventDoubleClick": true
   }) }}
+
+    {{ govukDetails({
+      summaryText: 'pages.enterMfa.details.summaryText' | translate,
+      html: detailsHTML
+    }) }}
 
   </form>
 


### PR DESCRIPTION
## What?

Moves the details component below the "Continue" button on the 2FA journey for users signing into the service. 

## Why?

Design change described in related Jira ticket

## Screen changes
The screen is shown below, with the details component expanded. 

<img width="1054" alt="Screenshot 2023-04-17 at 16 49 23" src="https://user-images.githubusercontent.com/16000203/232541549-29238922-b643-4484-b2b8-21ecd2664382.png">


## Change have been demonstrated
Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

The same changes were introduced for other pages in https://github.com/alphagov/di-authentication-frontend/pull/940
