### PR TITLE
AUT-1082: Add account recovery variation to MFA method selection page

### DIFF
--- a/src/components/select-mfa-options/index.njk
+++ b/src/components/select-mfa-options/index.njk
@@ -6,6 +6,8 @@
 
 {% if isAccountPartCreated %}
   {% set pageTitleName = 'pages.getSecurityCodes.titleAccountPartCreated' | translate %}
+{% elif isAccountRecoveryJourney %}
+ {% set pageTitleName = 'pages.getSecurityCodes.accountRecoveryVariants.title' | translate %}
 {% else %}
   {% set pageTitleName = 'pages.getSecurityCodes.title' | translate %}
 {% endif %}
@@ -22,12 +24,15 @@
 {% if isAccountPartCreated %}
   {% set radioHeading = 'pages.getSecurityCodes.headerAccountPartCreated' | translate %}
   {% set radioHintText = 'pages.getSecurityCodes.summaryAccountPartCreated' | translate %}
+{% elif isAccountRecoveryJourney %}
+  {% set radioHeading = 'pages.getSecurityCodes.accountRecoveryVariants.header' | translate %}
+  {% set radioHintText = 'pages.getSecurityCodes.accountRecoveryVariants.summary' | translate %}
 {% else %}
   {% set radioHeading = 'pages.getSecurityCodes.header' | translate %}
   {% set radioHintText = 'pages.getSecurityCodes.summary' | translate %}
 {% endif %}
 
-<form action="/get-security-codes" method="post" novalidate>
+<form action="/get-security-codes?accountRecovery={{isAccountRecoveryJourney}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="isAccountPartCreated" value="{{isAccountPartCreated}}"/>

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -6,6 +6,7 @@ import { generateMfaSecret } from "../../utils/mfa";
 export function getSecurityCodesGet(req: Request, res: Response): void {
   res.render("select-mfa-options/index.njk", {
     isAccountPartCreated: req.session.user.isAccountPartCreated,
+    isAccountRecoveryJourney: req.query.accountRecovery === "true",
   });
 }
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1874,7 +1874,12 @@
         "paragraph1": "Mae ap dilysydd yn creu cod diogelwch sy’n helpu i gadarnhau mai chi yw chi pan fyddwch yn mewngofnodi.",
         "paragraph2": "Gallwch ddefnyddio ap dilysydd ar eich ffôn clyfar, llechen neu gyfrifiadur bwrdd gwaith.  Lawrlwythwch ap dilysydd ar gyfer eich ffôn clyfar neu lechen o’ch siop apiau neu chwiliwch ar-lein am ap dilysydd ar gyfer eich cyfrifiadur."
       },
-      "continueButtonText": "Parhau"
+      "continueButtonText": "Parhau",
+      "accountRecoveryVariants": {
+        "title": "How do you want to get security codes?",
+        "header": "How do you want to get security codes?",
+        "summary": "Choose how you’ll get security codes when signing in to your GOV.UK One Login. This will remove your old phone number or authenticator app from your GOV.UK One Login."
+      }
     },
     "setupAuthenticatorApp": {
       "title": "Sefydlu ap dilysydd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1874,7 +1874,12 @@
         "paragraph1": "An authenticator app creates a security code that helps confirm it’s you when you sign in.",
         "paragraph2": "You can use an authenticator app on your smartphone, tablet or desktop computer.  Download an authenticator app for your smartphone or tablet from your app store or search online for an authenticator app for your computer."
       },
-      "continueButtonText": "Continue"
+      "continueButtonText": "Continue",
+      "accountRecoveryVariants": {
+        "title": "How do you want to get security codes?",
+        "header": "How do you want to get security codes?",
+        "summary": "Choose how you’ll get security codes when signing in to your GOV.UK One Login. This will remove your old phone number or authenticator app from your GOV.UK One Login."
+      }
     },
     "setupAuthenticatorApp": {
       "title": "Set up an authenticator app",


### PR DESCRIPTION
## What?
- Add account recovery variation to MFA method selection page
- Initial GET will originate from a relatively new page that is specific to account creation journey (where user must enter an OTP from email to verify their identity)
- I have added a query param to the POST request to assist in the next step of the journey if similar differentiation is needed (i.e. because next page also adapts an existing view)
- This content, unlike the one immediately before it in the journey, reuses an existing page, which already had one variant (account part created) - there should be no overlap between the three possible situations as a part created account has no MFA to be recovered. However, for clarity this page could show:
    - Account part created - if true, this governs the content, even if this somehow evaluated to true as part of an account recovery journey
    - If not, then  account recovery journey is checked - if true, this variant is show
    - If neither is true, then the base variant is shown (see below for comparison)

The new variant looks like this:
![image](https://user-images.githubusercontent.com/106964077/232725349-33120f41-0cc9-462b-8504-9a78d54e7d8a.png)

The base variant looks like this:
![image](https://user-images.githubusercontent.com/106964077/232726761-93dec043-1b29-4bf8-9a0c-0cf92c42dfc8.png)


## Why?
- Getting pages in place for account recovery feature.

## Change have been demonstrated
- No, as this will happen at completed feature level

## Related PRs
Request will start here: https://github.com/alphagov/di-authentication-frontend/pull/967/files#diff-657568ad5af530f144e76eae824dea62340efdeaa0c427318c5c08395fdc7dd0L26 before going through verify code controller, which based on state machine will route user to this page
