### PR TITLE
AUT-1089: Add 'changeHowGetSecurityCodesConfirmationEmail' to the 'CONTACT_US_REFERER_ALLOWLIST'

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -226,4 +226,5 @@ export const CONTACT_US_REFERER_ALLOWLIST = [
   "accountDeletedEmail",
   "phoneNumberUpdatedEmail",
   "passwordUpdatedEmail",
+  "changeCodesConfirmEmail",
 ];


### PR DESCRIPTION
## What?

Add 'changeCodesConfirmEmail' to the 'CONTACT_US_REFERER_ALLOWLIST'.

## Why?

To capture the referer when a user clicks 'contact us' in this new email template.

## Change have been demonstrated

The entire account recovery flow will be demonstrated when complete.

## Performance Analysis have been informed of the change

Will be informed when the entire flow is complete.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2925
https://github.com/alphagov/di-authentication-api/pull/2959
