### PR TITLE
AUT-1123: Update hint text for service trying to use

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1574,7 +1574,7 @@
       },
       "serviceTryingToUse": {
         "header": "What service were you trying to use?",
-        "hint": "For example, get a DBS check",
+        "hint": "If you cannot remember the name of the service, tell us what you were trying to do, for example get a DBS check. Or you can tell us the name of the government department you’ve been dealing with.",
         "errorMessage": "Enter the name of the service"
       },
       "replyByEmail": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1574,7 +1574,7 @@
       },
       "serviceTryingToUse": {
         "header": "What service were you trying to use?",
-        "hint": "For example, get a DBS check",
+        "hint": "If you cannot remember the name of the service, tell us what you were trying to do, for example get a DBS check. Or you can tell us the name of the government department you’ve been dealing with.",
         "errorMessage": "Enter the name of the service"
       },
       "replyByEmail": {


### PR DESCRIPTION
## What?

Updates hint text for all support forms that use the "What service were you trying to use?" question to be 

> If you cannot remember the name of the service, tell us what you were trying to do, for example get a DBS check. Or you can tell us the name of the government department you’ve been dealing with.

This includes forms for:

- [x] "You had a problem linking the app to your web browser"
- [x] "You had a problem taking a photo of your identity document using the GOV.UK ID Check app"
- [x] "You had a problem scanning your face using the GOV.UK ID Check app"
- [x] "You had a technical problem"
- [x] "A problem proving your identity"
- [x] "Another problem with the GOV.UK ID Check app"

### Screen changes

<img width="925" alt="Screenshot 2023-04-21 at 11 28 57" src="https://user-images.githubusercontent.com/16000203/233614129-89725f20-0938-4963-83a8-940fe3e2c873.png">

## Why?

Please include reason for the change and any other relevant context.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
