### PR TITLE
AUT-1196: Add last three phone-number digits during sign in journey

### DIFF
--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% set pageTitleName = 'pages.enterMfa.title' | translate %}
 
 {% block content %}
@@ -11,7 +12,14 @@
 
   <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.enterMfa.header' | translate }}</h1>
 
-  <p class="govuk-body">{{'pages.enterMfa.info.paragraph1' | translate }}</p>
+  {% set insetText %}
+    {{ 'pages.enterMfa.info.paragraph1' | translate }} <span class='govuk-!-font-weight-bold'>{{ phoneNumber.slice(-3) }}</span>
+  {% endset %}
+
+  {{ govukInsetText({
+    text: insetText | safe
+  }) }}
+
   <p class="govuk-body">{{'pages.enterMfa.info.paragraph2' | translate }}</p>
 
   <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -22,6 +22,7 @@ describe("Integration:: enter mfa", () => {
   let cookies: string;
   let app: any;
   let baseApi: string;
+  const PHONE_NUMBER = "7867";
 
   before(async () => {
     decache("../../../app");
@@ -37,7 +38,8 @@ describe("Integration:: enter mfa", () => {
 
         req.session.user = {
           email: "test@test.com",
-          phoneNumber: "7867",
+          phoneNumber: PHONE_NUMBER,
+          redactedPhoneNumber: PHONE_NUMBER,
           journey: {
             nextPath: PATH_NAMES.ENTER_MFA,
           },
@@ -105,6 +107,7 @@ describe("Integration:: enter mfa", () => {
       .send({
         _csrf: token,
         code: "",
+        phoneNumber: PHONE_NUMBER,
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
@@ -121,6 +124,7 @@ describe("Integration:: enter mfa", () => {
       .send({
         _csrf: token,
         code: "2",
+        phoneNumber: PHONE_NUMBER,
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
@@ -139,6 +143,7 @@ describe("Integration:: enter mfa", () => {
       .send({
         _csrf: token,
         code: "1234567",
+        phoneNumber: PHONE_NUMBER,
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
@@ -157,6 +162,7 @@ describe("Integration:: enter mfa", () => {
       .send({
         _csrf: token,
         code: "12ert-",
+        phoneNumber: PHONE_NUMBER,
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);
@@ -180,6 +186,7 @@ describe("Integration:: enter mfa", () => {
       .send({
         _csrf: token,
         code: "123456",
+        phoneNumber: PHONE_NUMBER,
       })
       .expect("Location", PATH_NAMES.AUTH_CODE)
       .expect(302, done);
@@ -198,6 +205,7 @@ describe("Integration:: enter mfa", () => {
       .send({
         _csrf: token,
         code: "123455",
+        phoneNumber: PHONE_NUMBER,
       })
       .expect(function (res) {
         const $ = cheerio.load(res.text);

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -455,7 +455,7 @@
       "title": "Gwiriwch eich ffôn",
       "header": "Gwiriwch eich ffôn",
       "info": {
-        "paragraph1": "Rydym wedi anfon cod at y rhif ffôn sy’n gysylltiedig â’ch GOV.UK One Login.",
+        "paragraph1": "Rydym wedi anfon cod i’ch rhif ffôn sy’n gorffen gyda ",
         "paragraph2": "Efallai y bydd yn cymryd ychydig funudau i gyrraedd. Bydd y cod yn dod i ben ar ôl 15 munud."
       },
       "resend": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -455,7 +455,7 @@
       "title": "Check your phone",
       "header": "Check your phone",
       "info": {
-        "paragraph1": "We sent a code to the phone number linked to your GOV.UK One Login.",
+        "paragraph1": "We have sent a code to your phone number ending with ",
         "paragraph2": "It might take a few minutes to arrive. The code will expire after 15 minutes."
       },
       "resend": {


### PR DESCRIPTION
## What?

Add last three digits of a user's phone-number in `/enter-code` screen

## Why?

Required so that user's are reassured of the number they'll be receiving the OTP code
## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
