### PR TITLE
AUT-1082: Add variant to MFA selection screen

### DIFF
--- a/src/components/check-your-email-security-codes/check-account-recovery-middleware.ts
+++ b/src/components/check-your-email-security-codes/check-account-recovery-middleware.ts
@@ -7,6 +7,7 @@ export function checkAccountRecoveryPermitted(
   next: NextFunction
 ): void {
   if (req.session.user.isAccountRecoveryPermitted === true) {
+    req.session.user.isCurrentlyInAccountRecoveryJourney = true;
     return next();
   }
 

--- a/src/components/check-your-email-security-codes/check-account-recovery-middleware.ts
+++ b/src/components/check-your-email-security-codes/check-account-recovery-middleware.ts
@@ -7,7 +7,7 @@ export function checkAccountRecoveryPermitted(
   next: NextFunction
 ): void {
   if (req.session.user.isAccountRecoveryPermitted === true) {
-    req.session.user.isCurrentlyInAccountRecoveryJourney = true;
+    req.session.user.isAccountRecoveryJourney = true;
     return next();
   }
 

--- a/src/components/select-mfa-options/index.njk
+++ b/src/components/select-mfa-options/index.njk
@@ -24,7 +24,7 @@
 {% if isAccountPartCreated %}
   {% set radioHeading = 'pages.getSecurityCodes.headerAccountPartCreated' | translate %}
   {% set radioHintText = 'pages.getSecurityCodes.summaryAccountPartCreated' | translate %}
-{% elif isAccountRecovery %}
+{% elif isAccountRecoveryJourney %}
   {% set radioHeading = 'pages.getSecurityCodes.accountRecoveryVariants.header' | translate %}
   {% set radioHintText = 'pages.getSecurityCodes.accountRecoveryVariants.summary' | translate %}
 {% else %}
@@ -33,10 +33,7 @@
 {% endif %}
 
 <form action="/get-security-codes" method="post" novalidate>
-
-<input type="hidden" name="_csrf" value="{{csrfToken}}"/>
-<input type="hidden" name="isAccountPartCreated" value="{{isAccountPartCreated}}"/>
-<input type="hidden" name="isAccountRecovery" value="{{isAccountRecovery}}"/>
+  <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 
 {{ govukRadios({
   name: "mfaOptions",

--- a/src/components/select-mfa-options/index.njk
+++ b/src/components/select-mfa-options/index.njk
@@ -6,6 +6,8 @@
 
 {% if isAccountPartCreated %}
   {% set pageTitleName = 'pages.getSecurityCodes.titleAccountPartCreated' | translate %}
+{% elif isAccountRecoveryJourney %}
+ {% set pageTitleName = 'pages.getSecurityCodes.accountRecoveryVariants.title' | translate %}
 {% else %}
   {% set pageTitleName = 'pages.getSecurityCodes.title' | translate %}
 {% endif %}
@@ -22,6 +24,9 @@
 {% if isAccountPartCreated %}
   {% set radioHeading = 'pages.getSecurityCodes.headerAccountPartCreated' | translate %}
   {% set radioHintText = 'pages.getSecurityCodes.summaryAccountPartCreated' | translate %}
+{% elif isAccountRecovery %}
+  {% set radioHeading = 'pages.getSecurityCodes.accountRecoveryVariants.header' | translate %}
+  {% set radioHintText = 'pages.getSecurityCodes.accountRecoveryVariants.summary' | translate %}
 {% else %}
   {% set radioHeading = 'pages.getSecurityCodes.header' | translate %}
   {% set radioHintText = 'pages.getSecurityCodes.summary' | translate %}
@@ -31,6 +36,7 @@
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="isAccountPartCreated" value="{{isAccountPartCreated}}"/>
+<input type="hidden" name="isAccountRecovery" value="{{isAccountRecovery}}"/>
 
 {{ govukRadios({
   name: "mfaOptions",

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -6,7 +6,7 @@ import { generateMfaSecret } from "../../utils/mfa";
 export function getSecurityCodesGet(req: Request, res: Response): void {
   res.render("select-mfa-options/index.njk", {
     isAccountPartCreated: req.session.user.isAccountPartCreated,
-    isAccountRecovery: req.session.user.isCurrentlyInAccountRecoveryJourney,
+    isAccountRecoveryJourney: req.session.user.isAccountRecoveryJourney,
   });
 }
 

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -6,6 +6,7 @@ import { generateMfaSecret } from "../../utils/mfa";
 export function getSecurityCodesGet(req: Request, res: Response): void {
   res.render("select-mfa-options/index.njk", {
     isAccountPartCreated: req.session.user.isAccountPartCreated,
+    isAccountRecovery: req.session.user.isCurrentlyInAccountRecoveryJourney,
   });
 }
 

--- a/src/components/select-mfa-options/select-mfa-options-validation.ts
+++ b/src/components/select-mfa-options/select-mfa-options-validation.ts
@@ -1,6 +1,7 @@
 import { body } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
+import { Request } from "express";
 
 export function validateMultiFactorAuthenticationRequest(): ValidationChainFunc {
   return [
@@ -11,6 +12,18 @@ export function validateMultiFactorAuthenticationRequest(): ValidationChainFunc 
           value,
         });
       }),
-    validateBodyMiddleware("select-mfa-options/index.njk"),
+    validateBodyMiddleware(
+      "select-mfa-options/index.njk",
+      postValidationLocals
+    ),
   ];
 }
+
+const postValidationLocals = function locals(
+  req: Request
+): Record<string, unknown> {
+  return {
+    isAccountPartCreated: req.session.user.isAccountPartCreated,
+    isAccountRecoveryJourney: req.session.user.isAccountRecoveryJourney,
+  };
+};

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1882,7 +1882,12 @@
         "paragraph1": "Mae ap dilysydd yn creu cod diogelwch sy’n helpu i gadarnhau mai chi yw chi pan fyddwch yn mewngofnodi.",
         "paragraph2": "Gallwch ddefnyddio ap dilysydd ar eich ffôn clyfar, llechen neu gyfrifiadur bwrdd gwaith.  Lawrlwythwch ap dilysydd ar gyfer eich ffôn clyfar neu lechen o’ch siop apiau neu chwiliwch ar-lein am ap dilysydd ar gyfer eich cyfrifiadur."
       },
-      "continueButtonText": "Parhau"
+      "continueButtonText": "Parhau",
+      "accountRecoveryVariants": {
+        "title": "Sut ydych chi am gael codau diogelwch?",
+        "header": "Sut ydych chi am gael codau diogelwch?",
+        "summary": "Dewis sut byddwch yn cael codau diogelwch pan rydych yn mewngofnodi i’ch GOV.UK One Login. Bydd hyn yn dileu eich hen rhif ffôn neu ap dilysydd o’ch GOV.UK One Login."
+      }
     },
     "setupAuthenticatorApp": {
       "title": "Sefydlu ap dilysydd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1882,7 +1882,12 @@
         "paragraph1": "An authenticator app creates a security code that helps confirm it’s you when you sign in.",
         "paragraph2": "You can use an authenticator app on your smartphone, tablet or desktop computer.  Download an authenticator app for your smartphone or tablet from your app store or search online for an authenticator app for your computer."
       },
-      "continueButtonText": "Continue"
+      "continueButtonText": "Continue",
+      "accountRecoveryVariants": {
+        "title": "How do you want to get security codes?",
+        "header": "How do you want to get security codes?",
+        "summary": "Choose how you’ll get security codes when signing in to your GOV.UK One Login. This will remove your old phone number or authenticator app from your GOV.UK One Login."
+      }
     },
     "setupAuthenticatorApp": {
       "title": "Set up an authenticator app",

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface PlaceholderReplacement {
 }
 
 export interface UserSession {
+  [key: string]: unknown;
   isAuthenticated?: boolean;
   email?: string;
   redactedPhoneNumber?: string;
@@ -57,7 +58,7 @@ export interface UserSession {
   wrongCodeEnteredLock?: string;
   codeRequestLock?: string;
   isAccountRecoveryPermitted?: boolean;
-  isCurrentlyInAccountRecoveryJourney?: boolean;
+  isAccountRecoveryJourney?: boolean;
 }
 
 export interface UserSessionClient {

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export interface UserSession {
   wrongCodeEnteredLock?: string;
   codeRequestLock?: string;
   isAccountRecoveryPermitted?: boolean;
+  isCurrentlyInAccountRecoveryJourney?: boolean;
 }
 
 export interface UserSessionClient {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -10,6 +10,24 @@ export const isObjectEmpty = (obj: Record<string, unknown>): boolean => {
   return Object.keys(obj).length === 0;
 };
 
+interface RequestBody {
+  [key: string]: string | boolean;
+}
+
+const convertStringBooleanPropertiesToJavaScriptBoolean = (
+  reqBody: RequestBody
+): RequestBody => {
+  return Object.keys(reqBody).reduce<RequestBody>(
+    (reducedObject, reqBodyObjectKey) => {
+      const value = reqBody[reqBodyObjectKey];
+      reducedObject[reqBodyObjectKey] =
+        value === "true" ? true : value === "false" ? false : value;
+      return reducedObject;
+    },
+    {}
+  );
+};
+
 export function formatValidationError(
   key: string,
   validationMessage: string
@@ -69,10 +87,11 @@ export function renderBadRequest(
   const errorParams = {
     errors,
     errorList: uniqueErrorListWithPlaceholdersReplaced,
-    ...req.body,
+    ...convertStringBooleanPropertiesToJavaScriptBoolean(req.body),
     language: req.i18n.language,
     zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
   };
+
   const params = postValidationLocals
     ? { ...errorParams, ...postValidationLocals }
     : errorParams;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -19,9 +19,17 @@ const convertStringBooleanPropertiesToJavaScriptBoolean = (
 ): RequestBody => {
   return Object.keys(reqBody).reduce<RequestBody>(
     (reducedObject, reqBodyObjectKey) => {
-      const value = reqBody[reqBodyObjectKey];
-      reducedObject[reqBodyObjectKey] =
-        value === "true" ? true : value === "false" ? false : value;
+      const valueInOriginalReqBody = reqBody[reqBodyObjectKey];
+      if (valueInOriginalReqBody === "true") {
+        reducedObject[reqBodyObjectKey] = true;
+      }
+
+      if (valueInOriginalReqBody === "false") {
+        reducedObject[reqBodyObjectKey] = false;
+      }
+
+      reducedObject[reqBodyObjectKey] = valueInOriginalReqBody;
+
       return reducedObject;
     },
     {}
@@ -95,5 +103,6 @@ export function renderBadRequest(
   const params = postValidationLocals
     ? { ...errorParams, ...postValidationLocals }
     : errorParams;
+
   return res.render(template, params);
 }


### PR DESCRIPTION
## What?
- Add variant to MFA selection screen, to be used in Account Recovery journeys
- Note: this introduces an extra boolean to the User Session, which may cause bugs if we lose track of it. At the moment, I think it is safe, because it has no effect outside of this single page, and once an account recovery journey starts, neither of the other two variants should apply i.e. account creation or account part creation; by definition account (i.e. MFA) recovery would have to happen _after_ either/both of those

The new variant looks like this:
![image](https://user-images.githubusercontent.com/106964077/234643775-e196b4b4-d044-42cf-b79c-54e81e340da2.png)

Notes:
- Whilst testing, I noticed a bug: all req.body fields were being passed to the render function as a string
- This meant that any hidden inputs (in the end not the approach used here) with value "false" were being interpreted by Nunjucks as truthy so the conditional logic based on them was executing.
- I have changed the validation util to make sure booleans are still booleans when passed back into a template

## Why?
- Part of account recovery journey - as yet under development and not accessible in production

## Change have been demonstrated
- No changes demonstrated because review will happen at feature level