### PR TITLE
AUT-1228: Fix overflow on interrupt screen

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -6,6 +6,7 @@
   padding: 30px;
   margin-right: 15px;
   margin-left: 15px;
+  width: auto;
 }
 
 .govuk-white-text {


### PR DESCRIPTION
## What?

Small CSS change to fix overflow bug affecting on smaller screen sizes. 
<img width="441" alt="Screenshot 2023-04-27 at 13 34 46" src="https://user-images.githubusercontent.com/16000203/234922374-44c64873-08c6-4ccd-ba72-0f87f451cdb0.png">

### Cross-browser testing
Change has been tested across in [browsers to test (from June 2022)](browsers-to-test-in-from-june-2022), including: 

OS | Browser | Result
-- | -- | --
Windows | Edge (latest two versions) | ✅ ✅
  | Google Chrome (latest two versions) | ✅ ✅
  | Mozilla Firefox (latest two versions) | ✅ ✅
macOS | Safari 12, 13, 14, 15, 16 | ✅ ✅ ✅ ✅ ✅
  | Google Chrome (latest two versions) | ✅ ✅
  | Mozilla Firefox (latest two versions) | ✅ ✅
iOS | Safari for iOS 12, 13, 14, 15, 16 and later | 16, 15, 13,  tested. Browserstack remote devices running 14 could not access the page (seemingly as a result of the way they handle redirects). It seems very low risk that the bug will be present there.
  | Google Chrome (latest two versions) | ✅ ✅
Android | Google Chrome (latest two versions) |  ✅ ✅
  | Samsung Internet (latest two versions) | Browserstack remote devices were unable to connect to the page (this seems to be a bug with Browserstack). Given the consistency across other browsers, and relatively low impact of the bug, it seems unlikely problems will be introduced.



## Why?

Layout bug fix