### PR TITLE
AUT-1223: Fix error message link anchoring

### DIFF
--- a/src/components/create-password/create-password-validation.ts
+++ b/src/components/create-password/create-password-validation.ts
@@ -5,6 +5,24 @@ import { ValidationChainFunc } from "../../types";
 
 export function validateCreatePasswordRequest(): ValidationChainFunc {
   return [
+    body("confirm-password")
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.createPassword.confirmPassword.validationError.required",
+          { value }
+        );
+      })
+      .custom((value, { req }) => {
+        if (value !== req.body["password"]) {
+          throw new Error(
+            req.t(
+              "pages.createPassword.confirmPassword.validationError.matches"
+            )
+          );
+        }
+        return true;
+      }),
     body("password")
       .notEmpty()
       .withMessage((value, { req }) => {
@@ -35,24 +53,6 @@ export function validateCreatePasswordRequest(): ValidationChainFunc {
       })
       .custom((value, { req }) => {
         if (value !== req.body["confirm-password"]) {
-          throw new Error(
-            req.t(
-              "pages.createPassword.confirmPassword.validationError.matches"
-            )
-          );
-        }
-        return true;
-      }),
-    body("confirm-password")
-      .notEmpty()
-      .withMessage((value, { req }) => {
-        return req.t(
-          "pages.createPassword.confirmPassword.validationError.required",
-          { value }
-        );
-      })
-      .custom((value, { req }) => {
-        if (value !== req.body["password"]) {
           throw new Error(
             req.t(
               "pages.createPassword.confirmPassword.validationError.matches"


### PR DESCRIPTION
## What?

Fixes issue where the error message link was giving focus to the second input rather than the first. Having considered the issue it seemed most sensible to simply switch the order of validation rules (so that the `password` field is evaluated after `confirm-password`, and is therefore the input linked to). 

The screenshot below shows the fix with focus state after a user has clicked on the validation message. 

<img width="898" alt="Screenshot 2023-04-28 at 11 11 05" src="https://user-images.githubusercontent.com/16000203/235121654-75c1187f-e438-46e0-acb9-89af75f9e957.png">

## Why?

While this bug might appear minor, it could be especially confusing for screenreader users (or those using other technologies where content is encountered sequentially) because presenting a single error message that moves focus to the last error in the DOM could likely result in the additional errored field being missed. 
