### PR TITLE
AUT-1206: Change 'another' to 'a' in form heading

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1600,8 +1600,8 @@
         "privacyNote": "Read our <a href=\"/privacy-notice\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">privacy notice</a> for more information on how we use your personal information."
       },
       "anotherProblem": {
-        "title": "Problem arall wrth ddefnyddio eich GOV.UK One Login",
-        "header": "Problem arall wrth ddefnyddio eich GOV.UK One Login",
+        "title": "Problem wrth ddefnyddio eich GOV.UK One Login",
+        "header": "Problem wrth ddefnyddio eich GOV.UK One Login",
         "section1": {
           "header": "What were you trying to do?",
           "errorMessage": "Enter what you were trying to do"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1600,8 +1600,8 @@
         "privacyNote": "Read our <a href=\"/privacy-notice\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">privacy notice</a> for more information on how we use your personal information."
       },
       "anotherProblem": {
-        "title": "Another problem using your GOV.UK One Login",
-        "header": "Another problem using your GOV.UK One Login",
+        "title": "A problem using your GOV.UK One Login",
+        "header": "A problem using your GOV.UK One Login",
         "section1": {
           "header": "What were you trying to do?",
           "errorMessage": "Enter what you were trying to do"


### PR DESCRIPTION
## What?

Changes 'another' to 'a' in the page heading for 'Another problem using your GOV.UK One Login'. This does not change the previous page (as shown below). Note that while the contact forms are currently only available in English, this PR also updates the Welsh version so that translations are consistent.

### Screenshot

#### Option is unchanged

<img width="328" alt="Screenshot showing option for 'Another problem' is unchanged on form selection page" src="https://user-images.githubusercontent.com/16000203/235152213-c6320c31-8c50-41cc-9226-96d85cfb3d0f.png">

#### Form is changed
<img width="329" alt="Screenshot showing that the form heading has been changed to 'A problem'" src="https://user-images.githubusercontent.com/16000203/235152241-3e962e5f-09c3-4ef4-9311-6030cb41bf77.png">

## Why?

Change requested by Content Design

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
