### PR TITLE
AUT-1242: Refactor VerifyMfaCode interface to use Journey Type parameter

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -185,6 +185,12 @@ export enum MFA_METHOD_TYPE {
   AUTH_APP = "AUTH_APP",
 }
 
+export enum JOURNEY_TYPE {
+  REGISTRATION = "REGISTRATION",
+  ACCOUNT_RECOVERY = "ACCOUNT_RECOVERY",
+  SIGN_IN = "SIGN_IN",
+}
+
 export const ENVIRONMENT_NAME = {
   PROD: "production",
   DEV: "development",

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from "express";
-import { MFA_METHOD_TYPE, NOTIFICATION_TYPE } from "../../app.constants";
+import {
+  JOURNEY_TYPE,
+  MFA_METHOD_TYPE,
+  NOTIFICATION_TYPE,
+} from "../../app.constants";
 import { ExpressRouteFunc } from "../../types";
 import {
   ERROR_CODES,
@@ -37,6 +41,7 @@ export const checkYourPhonePost = (
       MFA_METHOD_TYPE.SMS,
       req.body["code"],
       true,
+      JOURNEY_TYPE.REGISTRATION,
       sessionId,
       clientSessionId,
       req.ip,

--- a/src/components/common/verify-mfa-code/verify-mfa-code-service.ts
+++ b/src/components/common/verify-mfa-code/verify-mfa-code-service.ts
@@ -1,6 +1,7 @@
 import {
   API_ENDPOINTS,
   HTTP_STATUS_CODES,
+  JOURNEY_TYPE,
   MFA_METHOD_TYPE,
 } from "../../../app.constants";
 import {
@@ -19,6 +20,7 @@ export function verifyMfaCodeService(
     methodType: MFA_METHOD_TYPE,
     code: string,
     isRegistration: boolean,
+    journeyType: JOURNEY_TYPE,
     sessionId: string,
     clientSessionId: string,
     sourceIp: string,

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -11,7 +11,7 @@ import { VerifyMfaCodeInterface } from "./types";
 import { AccountRecoveryInterface } from "../common/account-recovery/types";
 import { accountRecoveryService } from "../common/account-recovery/account-recovery-service";
 import { BadRequestError } from "../../utils/error";
-import { MFA_METHOD_TYPE, PATH_NAMES } from "../../app.constants";
+import { JOURNEY_TYPE, MFA_METHOD_TYPE, PATH_NAMES } from "../../app.constants";
 import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-service";
 import {
   formatValidationError,
@@ -104,6 +104,7 @@ export const enterAuthenticatorAppCodePost = (
       MFA_METHOD_TYPE.AUTH_APP,
       req.body["code"],
       false,
+      JOURNEY_TYPE.SIGN_IN,
       sessionId,
       clientSessionId,
       req.ip,

--- a/src/components/enter-authenticator-app-code/types.ts
+++ b/src/components/enter-authenticator-app-code/types.ts
@@ -1,12 +1,13 @@
 import { ApiResponseResult, DefaultApiResponse } from "../../types";
 import { Request, Response } from "express";
-import { MFA_METHOD_TYPE } from "../../app.constants";
+import { JOURNEY_TYPE, MFA_METHOD_TYPE } from "../../app.constants";
 
 export interface VerifyMfaCodeInterface {
   verifyMfaCode: (
     methodType: MFA_METHOD_TYPE,
     code: string,
     isRegistration: boolean,
+    journeyType: JOURNEY_TYPE,
     sessionId: string,
     clientSessionId: string,
     sourceIp: string,

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -12,7 +12,11 @@ import {
 } from "../../utils/validation";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
-import { MFA_METHOD_TYPE, NOTIFICATION_TYPE } from "../../app.constants";
+import {
+  JOURNEY_TYPE,
+  MFA_METHOD_TYPE,
+  NOTIFICATION_TYPE,
+} from "../../app.constants";
 import xss from "xss";
 import { VerifyMfaCodeInterface } from "../enter-authenticator-app-code/types";
 import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-service";
@@ -52,6 +56,7 @@ export function setupAuthenticatorAppPost(
       MFA_METHOD_TYPE.AUTH_APP,
       code,
       true,
+      JOURNEY_TYPE.REGISTRATION,
       sessionId,
       clientSessionId,
       req.ip,


### PR DESCRIPTION
## What?

Introduce `JOURNEY_TYPE` parameter for the `VerifyMfaCodeInterface`
- Registration
- Account Recovery
- Sign In

## Why?

In order to redirect to the corresponding feature in the `VerifyMfaCode` lambda.

## Related PRs

[Changes in the Auth API](https://github.com/alphagov/di-authentication-api/pull/2962)
