### PR TITLE
Add 'include' line to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
             "/node_modules/@types"
         ]
     },
+    "include": ["src/**/*.ts"],
     "exclude": [
       "test",
         "coverage",


### PR DESCRIPTION
## What?
- Add all .ts files within `src` directory to TS project

## Why?
- The include property specifies the files to be included in the TypeScript project
- By default, this should have included all files within the directory where the tsconfig.json file is stored except those specified in exclude
- In reality, however, it seemed to miss the server file intermittently
- This change ensures that all TS files in src will be picked up

## Change have been demonstrated
N/A
