### PR TITLE
AUT-1242: Reorder verify mfa code interface to ensure journey type pa…

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -41,11 +41,11 @@ export const checkYourPhonePost = (
       MFA_METHOD_TYPE.SMS,
       req.body["code"],
       true,
-      JOURNEY_TYPE.REGISTRATION,
       sessionId,
       clientSessionId,
       req.ip,
       persistentSessionId,
+      JOURNEY_TYPE.REGISTRATION,
       req.session.user.phoneNumber
     );
 

--- a/src/components/common/verify-mfa-code/verify-mfa-code-service.ts
+++ b/src/components/common/verify-mfa-code/verify-mfa-code-service.ts
@@ -24,8 +24,8 @@ export function verifyMfaCodeService(
     clientSessionId: string,
     sourceIp: string,
     persistentSessionId: string,
-    profileInformation?: string,
-    journeyType?: JOURNEY_TYPE
+    journeyType?: JOURNEY_TYPE,
+    profileInformation?: string
   ): Promise<ApiResponseResult<DefaultApiResponse>> {
     const response = await axios.client.post<DefaultApiResponse>(
       API_ENDPOINTS.VERIFY_MFA_CODE,

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -104,11 +104,11 @@ export const enterAuthenticatorAppCodePost = (
       MFA_METHOD_TYPE.AUTH_APP,
       req.body["code"],
       false,
-      JOURNEY_TYPE.SIGN_IN,
       sessionId,
       clientSessionId,
       req.ip,
-      persistentSessionId
+      persistentSessionId,
+      JOURNEY_TYPE.SIGN_IN
     );
 
     if (!result.success) {

--- a/src/components/enter-authenticator-app-code/types.ts
+++ b/src/components/enter-authenticator-app-code/types.ts
@@ -7,11 +7,11 @@ export interface VerifyMfaCodeInterface {
     methodType: MFA_METHOD_TYPE,
     code: string,
     isRegistration: boolean,
-    journeyType: JOURNEY_TYPE,
     sessionId: string,
     clientSessionId: string,
     sourceIp: string,
     persistentSessionId: string,
+    journeyType: JOURNEY_TYPE,
     profileInformation?: string
   ) => Promise<ApiResponseResult<DefaultApiResponse>>;
 }

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -56,11 +56,11 @@ export function setupAuthenticatorAppPost(
       MFA_METHOD_TYPE.AUTH_APP,
       code,
       true,
-      JOURNEY_TYPE.REGISTRATION,
       sessionId,
       clientSessionId,
       req.ip,
       persistentSessionId,
+      JOURNEY_TYPE.REGISTRATION,
       authAppSecret
     );
 


### PR DESCRIPTION
## What?

Reorder verify mfa code interface to ensure journey type param is correctly passed

## Why?

Fixes error in build environment causing error:
`
{
    "instant": {
        "epochSecond": 1683637549,
        "nanoOfSecond": 937861000
    },
    "thread": "main",
    "level": "WARN",
    "loggerName": "uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper",
    "message": "Session-Id is missing or invalid",
    "endOfBatch": false,
    "loggerFqcn": "org.apache.logging.log4j.spi.AbstractLogger",
    "threadId": 1,
    "threadPriority": 5,
    "session-id": "unknown",
    "client-session-id": "gdASBg0HMokBOr_OaKFw-67i-pw",
    "govuk_signin_journey_id": "gdASBg0HMokBOr_OaKFw-67i-pw"
}
`
## Related PRs

[Initial PR](https://github.com/alphagov/di-authentication-frontend/pull/1012)
