### PR TITLE
AUT-1242: Remove isRegistration param from VerifyMfaCode request

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -40,7 +40,6 @@ export const checkYourPhonePost = (
     const result = await service.verifyMfaCode(
       MFA_METHOD_TYPE.SMS,
       req.body["code"],
-      true,
       sessionId,
       clientSessionId,
       req.ip,

--- a/src/components/common/verify-mfa-code/verify-mfa-code-service.ts
+++ b/src/components/common/verify-mfa-code/verify-mfa-code-service.ts
@@ -19,7 +19,6 @@ export function verifyMfaCodeService(
   const verifyMfaCode = async function (
     methodType: MFA_METHOD_TYPE,
     code: string,
-    isRegistration: boolean,
     sessionId: string,
     clientSessionId: string,
     sourceIp: string,
@@ -32,7 +31,6 @@ export function verifyMfaCodeService(
       {
         mfaMethodType: methodType,
         code,
-        isRegistration,
         journeyType,
         ...(profileInformation && { profileInformation }),
       },

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -103,7 +103,6 @@ export const enterAuthenticatorAppCodePost = (
     const result = await service.verifyMfaCode(
       MFA_METHOD_TYPE.AUTH_APP,
       req.body["code"],
-      false,
       sessionId,
       clientSessionId,
       req.ip,

--- a/src/components/enter-authenticator-app-code/types.ts
+++ b/src/components/enter-authenticator-app-code/types.ts
@@ -6,7 +6,6 @@ export interface VerifyMfaCodeInterface {
   verifyMfaCode: (
     methodType: MFA_METHOD_TYPE,
     code: string,
-    isRegistration: boolean,
     sessionId: string,
     clientSessionId: string,
     sourceIp: string,

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -55,7 +55,6 @@ export function setupAuthenticatorAppPost(
     const verifyAccessCodeRes = await service.verifyMfaCode(
       MFA_METHOD_TYPE.AUTH_APP,
       code,
-      true,
       sessionId,
       clientSessionId,
       req.ip,


### PR DESCRIPTION
## What?

- `isRegistration` from the VerifyMfaCode request
- 
## Why?

`isRegistration` is no longer required as the interface in the backend has changes to generic journey type which includes registration journey.
## Change have been demonstrated

## Related PRs

[Backend change](https://github.com/alphagov/di-authentication-api/pull/2978)
