### PR TITLE
AUT-1275: Loosen international phone number validation to include 00 format

### DIFF
--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -10,7 +10,7 @@ import { BadRequestError } from "../../utils/error";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
-import { prependInternationalPrefix } from "../../utils/phone-number";
+import { convertInternationalPhoneNumberToE164Format } from "../../utils/phone-number";
 import { supportInternationalNumbers } from "../../config";
 import xss from "xss";
 
@@ -31,11 +31,10 @@ export function enterPhoneNumberPost(
     let phoneNumber;
 
     if (
-      hasInternationalPhoneNumber &&
       hasInternationalPhoneNumber === "true" &&
       supportInternationalNumbers()
     ) {
-      phoneNumber = prependInternationalPrefix(
+      phoneNumber = convertInternationalPhoneNumberToE164Format(
         req.body.internationalPhoneNumber
       );
     } else {

--- a/src/components/enter-phone-number/enter-phone-number-validation.ts
+++ b/src/components/enter-phone-number/enter-phone-number-validation.ts
@@ -67,7 +67,7 @@ export function validateEnterPhoneNumberRequest(): ValidationChainFunc {
         return true;
       })
       .custom((value, { req }) => {
-        if (!lengthInRangeWithoutSpaces(value, 5, 25)) {
+        if (!lengthInRangeWithoutSpaces(value, 5, 26)) {
           throw new Error(
             req.t(
               "pages.enterPhoneNumber.internationalPhoneNumber.validationError.internationalFormat"

--- a/src/utils/phone-number.ts
+++ b/src/utils/phone-number.ts
@@ -25,7 +25,8 @@ export function containsUKMobileNumber(value: string): boolean {
 }
 
 export function containsInternationalMobileNumber(value: string): boolean {
-  return isValidPhoneNumber(prependInternationalPrefix(value));
+  const formattedNumber = convertInternationalPhoneNumberToE164Format(value);
+  return isValidPhoneNumber(formattedNumber);
 }
 
 export function containsLeadingPlusNumbersOrSpacesOnly(value: string): boolean {
@@ -41,6 +42,16 @@ export function lengthInRangeWithoutSpaces(
   return length >= min && length <= max;
 }
 
-export function prependInternationalPrefix(value: string): string {
-  return value.startsWith("+") ? value : "+".concat(value);
+export function convertInternationalPhoneNumberToE164Format(
+  value: string
+): string {
+  if (value.startsWith("+")) {
+    return value;
+  }
+
+  if (value.startsWith("00")) {
+    return value.replace("00", "+");
+  }
+
+  return "+".concat(value);
 }

--- a/test/unit/utils/phone-number.test.ts
+++ b/test/unit/utils/phone-number.test.ts
@@ -4,7 +4,7 @@ import {
   containsInternationalMobileNumber,
   containsUKMobileNumber,
   lengthInRangeWithoutSpaces,
-  prependInternationalPrefix,
+  convertInternationalPhoneNumberToE164Format,
 } from "../../../src/utils/phone-number";
 
 describe("phone-number", () => {
@@ -171,9 +171,9 @@ describe("phone-number", () => {
       expect(containsInternationalMobileNumber("07911123456")).to.equal(false);
     });
 
-    it("should return false with valid uk mobile without lib country code", () => {
+    it("should return true with valid uk mobile without lib country code", () => {
       expect(containsInternationalMobileNumber("00447911123456")).to.equal(
-        false
+        true
       );
     });
 
@@ -193,10 +193,8 @@ describe("phone-number", () => {
       expect(containsInternationalMobileNumber("0645453322")).to.equal(false);
     });
 
-    it("should return false with valid French mobile without lib country code", () => {
-      expect(containsInternationalMobileNumber("0033645453322")).to.equal(
-        false
-      );
+    it("should return true with valid French mobile without lib country code", () => {
+      expect(containsInternationalMobileNumber("0033645453322")).to.equal(true);
     });
 
     it("should return true with valid French mobile in E164 without lib country code", () => {
@@ -213,10 +211,8 @@ describe("phone-number", () => {
       expect(containsInternationalMobileNumber("608453322")).to.equal(false);
     });
 
-    it("should return false with valid Spanish mobile without lib country code", () => {
-      expect(containsInternationalMobileNumber("0034608453322")).to.equal(
-        false
-      );
+    it("should return true with valid Spanish mobile without lib country code", () => {
+      expect(containsInternationalMobileNumber("0034608453322")).to.equal(true);
     });
 
     it("should return true with valid Spanish mobile in E164 without lib country code", () => {
@@ -224,17 +220,23 @@ describe("phone-number", () => {
     });
   });
 
-  describe("prependInternationalPrefix", () => {
+  describe("convertInternationalPhoneNumberToE164Format", () => {
     it("should prepend + to an international number without the prefix", () => {
-      expect(prependInternationalPrefix("34608453322")).to.equal(
-        "+34608453322"
-      );
+      expect(
+        convertInternationalPhoneNumberToE164Format("34608453322")
+      ).to.equal("+34608453322");
     });
 
     it("should not prepend + to an international number with the prefix", () => {
-      expect(prependInternationalPrefix("+34608453322")).to.equal(
-        "+34608453322"
-      );
+      expect(
+        convertInternationalPhoneNumberToE164Format("+34608453322")
+      ).to.equal("+34608453322");
+    });
+
+    it("should swap out a 00 for a + when the input uses this format", () => {
+      expect(
+        convertInternationalPhoneNumberToE164Format("0034608453322")
+      ).to.equal("+34608453322");
     });
   });
 });


### PR DESCRIPTION
## What?
- Loosen international phone number validation to include 00 prefix format
- For example 0034608453322 would be rejected prior to the change
- After the change it would be transformed into a '+' format number, but accepted in validation

## Implied acceptable numbers for being treated as 'valid international number'
The field in question is the bottom one below:
![image](https://github.com/alphagov/di-authentication-frontend/assets/106964077/5b593d0c-a6bb-495d-9ab8-80f3ac07160b)

I considered also validating that this field was a non-UK number by changing the following function to:

```
export function containsInternationalMobileNumber(value: string): boolean {
  const formattedNumber = convertInternationalPhoneNumberToE164Format(value);
  return (
      isValidPhoneNumber(formattedNumber) &&
      parsePhoneNumberWithError(formattedNumber).countryCallingCode !== "44"
    );
}
```

This would have eliminated UK-format values like `0044 7777 777 777`. The reason that I did not add this extra check is that I could see unit tests were already accepting E164 format UK numbers:

```
    it("should return true with valid uk mobile in E164 without lib country code", () => {
      expect(containsInternationalMobileNumber("+447911123456")).to.equal(true);
    });
```

It therefore felt most in the spirit of the existing code _not_ to implement an extra check of this kind

## Why?
- User research suggested that supporting the `00` format would be useful - and indeed that users expected to be able to

## Change have been demonstrated
No change to UI - only validation behaviour

## Performance Analysis have been informed of the change
No change to UI/HTML - only validation behaviour
