### PR TITLE
AUT-1143: Sass optimisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build-ts": "tsc",
     "build": "yarn build-sass && yarn build-ts && yarn minfiy-build-js && yarn copy-assets",
-    "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/style.css --style compressed",
+    "build-sass": "rm -rf dist/public/style.css && sass --load-path=node_modules/govuk-frontend/govuk --no-source-map src/assets/scss/application.scss dist/public/style.css --style compressed",
     "clean": "rm -rf dist node_modules logs.json",
     "clean-modules": "rm -rf node_modules",
     "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ src/config/*.txt dist/ && copyfiles -u 3 src/assets/javascript/*.js dist/public/scripts -e **/all.js && cp node_modules/govuk-frontend/govuk/all.js dist/public/scripts",
@@ -30,7 +30,7 @@
     "test:coverage": "nyc report --reporter=lcov --reporter=text",
     "watch-node": "nodemon -r dotenv/config --inspect=0.0.0.0:9230 dist/server.js | pino-pretty",
     "watch-ts": "tsc -w",
-    "watch-sass": "sass --watch src/assets/scss/application.scss dist/public/style.css"
+    "watch-sass": "sass --load-path=node_modules/govuk-frontend/govuk --watch src/assets/scss/application.scss dist/public/style.css"
   },
   "mocha": {
     "diff": true,

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -1,5 +1,28 @@
-@use "../../../node_modules/govuk-frontend/govuk/all";
-@import "../../../node_modules/govuk-frontend/govuk/base";
+@import "base";
+@import "core/all";
+@import "utilities/all";
+@import "objects/all";
+@import "overrides/all";
+
+@import "components/back-link/back-link";
+@import "components/button/button";
+@import "components/character-count/character-count";
+@import "components/checkboxes/checkboxes";
+@import "components/cookie-banner/cookie-banner";
+@import "components/details/details";
+@import "components/error-summary/error-summary";
+@import "components/footer/footer";
+@import "components/header/header";
+@import "components/input/input";
+@import "components/inset-text/inset-text";
+@import "components/notification-banner/notification-banner";
+@import "components/panel/panel";
+@import "components/phase-banner/phase-banner";
+@import "components/radios/radios";
+@import "components/skip-link/skip-link";
+@import "components/summary-list/summary-list";
+@import "components/table/table";
+@import "components/warning-text/warning-text";
 
 .interrupt-screen {
   background-color: #1d70b8;
@@ -193,7 +216,7 @@
 }
 
 .contact {
-  border-left: 1px solid all.$govuk-border-colour;
+  border-left: 1px solid $govuk-border-colour;
   padding-left: 15px;
   margin-bottom: 30px;
   margin-top: 30px;


### PR DESCRIPTION
## What?

Import only those GOV.UK Frontend components we use and tidy import paths through use of `--load-path` [CLI option](https://sass-lang.com/documentation/cli/dart-sass#load-path).

I've tested the create and sign in journeys locally to ensure there is no visual change to pages. 

## Why?

Avoids users loading CSS which isn't used and reduces page weight by 20kB

## Related PRs

This reflects changes made by the Accounts Team in [#818](https://github.com/alphagov/di-account-management-frontend/pull/818)
