### PR TITLE
AUT-1242: Include ACCOUNT_RECOVERY journey type in VerifyMFACode request

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -36,6 +36,13 @@ export const checkYourPhonePost = (
 ): ExpressRouteFunc => {
   return async function (req: Request, res: Response) {
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+    const { isAccountRecoveryJourney, isAccountRecoveryPermitted } =
+      req.session.user;
+
+    const journeyType =
+      isAccountRecoveryPermitted && isAccountRecoveryJourney
+        ? JOURNEY_TYPE.ACCOUNT_RECOVERY
+        : JOURNEY_TYPE.REGISTRATION;
 
     const result = await service.verifyMfaCode(
       MFA_METHOD_TYPE.SMS,
@@ -44,7 +51,7 @@ export const checkYourPhonePost = (
       clientSessionId,
       req.ip,
       persistentSessionId,
-      JOURNEY_TYPE.REGISTRATION,
+      journeyType,
       req.session.user.phoneNumber
     );
 

--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -94,11 +94,20 @@ export const enterAuthenticatorAppCodePost = (
 ): ExpressRouteFunc => {
   return async function (req: Request, res: Response) {
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
-    const { isUpliftRequired } = req.session.user;
+    const {
+      isUpliftRequired,
+      isAccountRecoveryJourney,
+      isAccountRecoveryPermitted,
+    } = req.session.user;
 
     const template = isUpliftRequired
       ? UPLIFT_REQUIRED_AUTH_APP_TEMPLATE_NAME
       : ENTER_AUTH_APP_CODE_DEFAULT_TEMPLATE_NAME;
+
+    const journeyType =
+      isAccountRecoveryPermitted && isAccountRecoveryJourney
+        ? JOURNEY_TYPE.ACCOUNT_RECOVERY
+        : JOURNEY_TYPE.SIGN_IN;
 
     const result = await service.verifyMfaCode(
       MFA_METHOD_TYPE.AUTH_APP,
@@ -107,7 +116,7 @@ export const enterAuthenticatorAppCodePost = (
       clientSessionId,
       req.ip,
       persistentSessionId,
-      JOURNEY_TYPE.SIGN_IN
+      journeyType
     );
 
     if (!result.success) {

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -48,9 +48,18 @@ export function setupAuthenticatorAppPost(
   notificationService: SendNotificationServiceInterface = sendNotificationService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const { authAppSecret } = req.session.user;
+    const {
+      authAppSecret,
+      isAccountRecoveryJourney,
+      isAccountRecoveryPermitted,
+    } = req.session.user;
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
     const code = req.body.code;
+
+    const journeyType =
+      isAccountRecoveryPermitted && isAccountRecoveryJourney
+        ? JOURNEY_TYPE.ACCOUNT_RECOVERY
+        : JOURNEY_TYPE.REGISTRATION;
 
     const verifyAccessCodeRes = await service.verifyMfaCode(
       MFA_METHOD_TYPE.AUTH_APP,
@@ -59,7 +68,7 @@ export function setupAuthenticatorAppPost(
       clientSessionId,
       req.ip,
       persistentSessionId,
-      JOURNEY_TYPE.REGISTRATION,
+      journeyType,
       authAppSecret
     );
 


### PR DESCRIPTION
## What?

Include `ACCOUNT_RECOVERY` journey type in verify MFA code request when user session is in account recovery journey

## Why?

To ensure the `VerifyMfaCode` lambda is aware of what journey is motion

## Related PRs

[Part 2](https://github.com/alphagov/di-authentication-frontend/pull/1018)
[Bug Fix](https://github.com/alphagov/di-authentication-frontend/pull/1017)
[Part 1](https://github.com/alphagov/di-authentication-frontend/pull/1012)
