### PR TITLE
BAU - Enable account recovery in build

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -7,7 +7,7 @@ frontend_task_definition_memory = 1024
 
 support_international_numbers = "1"
 support_language_cy           = "1"
-support_account_recovery      = "0"
+support_account_recovery      = "1"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"


### PR DESCRIPTION
## What?

 - Enable account recovery in build
 
## Why?

- So we can test the account recovery journey in a non prod environment