### PR TITLE
AUT-1285: Introduce error banner to reset password OTP

### DIFF
--- a/src/components/reset-password-check-email/index.njk
+++ b/src/components/reset-password-check-email/index.njk
@@ -6,6 +6,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% set pageTitleName = 'pages.resetPasswordCheckEmail.title' | translate %}
 {% block content %}
+    {% include "common/errors/errorSummary.njk" %}
 
     <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resetPasswordCheckEmail.header' | translate}}</h1>
 


### PR DESCRIPTION
## What?

Introduces the error summary to the form that asks users to provide the email OTP code with the expected behaviour (i.e. where a user has occurred the banner is shown and clicks on the link within the summary send focus to the invalid input).

## Why?

Prior to this change, errors would be shown but without the summary.

<img width="353" alt="Screenshot 2023-05-15 at 11 01 04" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/1f26a148-5d1c-4163-b045-74e55d5ca116">

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [ ] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change