### PR TITLE
AUT-1273 - Stop email OTP being sent twice after 15 minute block

### DIFF
--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -83,10 +83,10 @@ export const ERROR_CODE_MAPPING: { [p: string]: string } = {
       SECURITY_CODE_ERROR,
       SecurityCodeErrorType.OtpMaxRetries
     ),
-  [ERROR_CODES.VERIFY_EMAIL_MAX_CODES_SENT]: pathWithQueryParam(
+  [ERROR_CODES.VERIFY_EMAIL_CODE_REQUEST_BLOCKED]: pathWithQueryParam(
     PATH_NAMES["SECURITY_CODE_REQUEST_EXCEEDED"],
     SECURITY_CODE_ERROR,
-    SecurityCodeErrorType.EmailMaxCodesSent
+    SecurityCodeErrorType.EmailBlocked
   ),
   [ERROR_CODES.ENTERED_INVALID_VERIFY_EMAIL_CODE_MAX_TIMES]: pathWithQueryParam(
     PATH_NAMES["SECURITY_CODE_INVALID"],
@@ -99,10 +99,10 @@ export const ERROR_CODE_MAPPING: { [p: string]: string } = {
       SECURITY_CODE_ERROR,
       SecurityCodeErrorType.EmailMaxRetries
     ),
-  [ERROR_CODES.VERIFY_EMAIL_CODE_REQUEST_BLOCKED]: pathWithQueryParam(
+  [ERROR_CODES.VERIFY_EMAIL_MAX_CODES_SENT]: pathWithQueryParam(
     PATH_NAMES["SECURITY_CODE_WAIT"],
     SECURITY_CODE_ERROR,
-    SecurityCodeErrorType.EmailBlocked
+    SecurityCodeErrorType.EmailMaxCodesSent
   ),
   [ERROR_CODES.AUTH_APP_INVALID_CODE_MAX_ATTEMPTS_REACHED]: pathWithQueryParam(
     PATH_NAMES["SECURITY_CODE_INVALID"],

--- a/src/components/enter-email/tests/enter-email-create-account-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-create-account-integration.test.ts
@@ -200,7 +200,7 @@ describe("Integration::enter email (create account)", () => {
       .expect(500, done);
   });
 
-  it("should redirect to /security-code-invalid-request when exceeded OTP request limit", (done) => {
+  it("should redirect to /security-code-requested-too-many-times when exceeded OTP request limit", (done) => {
     nock(baseApi)
       .post(API_ENDPOINTS.USER_EXISTS)
       .once()
@@ -222,12 +222,12 @@ describe("Integration::enter email (create account)", () => {
       })
       .expect(
         "Location",
-        `${PATH_NAMES.SECURITY_CODE_WAIT}?actionType=${SecurityCodeErrorType.EmailBlocked}`
+        `${PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED}?actionType=${SecurityCodeErrorType.EmailBlocked}`
       )
       .expect(302, done);
   });
 
-  it("should redirect to /security-code-requested-too-many-times when request OTP more than 5 times", (done) => {
+  it("should redirect to /security-code-invalid-request when request OTP more than 5 times", (done) => {
     nock(baseApi)
       .post(API_ENDPOINTS.USER_EXISTS)
       .once()
@@ -249,7 +249,7 @@ describe("Integration::enter email (create account)", () => {
       })
       .expect(
         "Location",
-        `${PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED}?actionType=${SecurityCodeErrorType.EmailMaxCodesSent}`
+        `${PATH_NAMES.SECURITY_CODE_WAIT}?actionType=${SecurityCodeErrorType.EmailMaxCodesSent}`
       )
       .expect(302, done);
   });

--- a/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
+++ b/src/components/resend-email-code/tests/resend-email-code-integration.test.ts
@@ -115,7 +115,7 @@ describe("Integration:: resend email code", () => {
       .expect(500, done);
   });
 
-  it("should redirect to /security-code-requested-too-many-times when request OTP more than 5 times", (done) => {
+  it("should redirect to /security-code-invalid-request when request OTP more than 5 times", (done) => {
     nock(baseApi)
       .post(API_ENDPOINTS.SEND_NOTIFICATION)
       .times(6)
@@ -130,12 +130,12 @@ describe("Integration:: resend email code", () => {
       })
       .expect(
         "Location",
-        "/security-code-requested-too-many-times?actionType=emailMaxCodesSent"
+        "/security-code-invalid-request?actionType=emailMaxCodesSent"
       )
       .expect(302, done);
   });
 
-  it("should redirect to /security-code-invalid-request when exceeded OTP request limit", (done) => {
+  it("should redirect to /security-code-requested-too-many-times when exceeded OTP request limit", (done) => {
     nock(baseApi)
       .post(API_ENDPOINTS.SEND_NOTIFICATION)
       .once()
@@ -150,7 +150,7 @@ describe("Integration:: resend email code", () => {
       })
       .expect(
         "Location",
-        "/security-code-invalid-request?actionType=emailBlocked"
+        "/security-code-requested-too-many-times?actionType=emailBlocked"
       )
       .expect(302, done);
   });


### PR DESCRIPTION
## What?

- When a user has requested more than 5 email OTPs during account creation, they are blocked for 15 minutes from requesting anymore codes. After the block had expired and they asked to resend the code, previously 2 codes were being sent at once when only 1 has been requested
- To fix this we will stop relying on the send-notification lambda to tell us when the user is blocked or not and instead set an attribute in the user session which will be a timestamp telling us when the user is no longer blocked. Update the logic in the resend-email-controller to check this attribute in the session rather than send a request to the send-notification lambda
- Update the ERROR_CODE_MAPPING in constants.ts to ensure that routes are called in the correct order and the block is put on the session when the frontend receives error code - `1029:System has sent too many email verifications codes`

## Why?

- This was happening because we were relying on the send notification lambda to tell us when they user was blocked or not. After the 15 minute block expired, we were sending a request to the send notification lambda which was successful and informed the frontend that the user was no longer blocked but it also sent an email OTP to the user, the user then clicked the resend email code button which sent another email OTP.


