### PR TITLE
AUT-1273 - Parameterise the OTP locked duration

### DIFF
--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -5,13 +5,17 @@ import {
   SECURITY_CODE_ERROR,
 } from "../common/constants";
 import { PATH_NAMES } from "../../app.constants";
+import {
+  getCodeEnteredWrongBlockDurationInMinutes,
+  getCodeRequestBlockDurationInMinutes,
+} from "../../config";
 
 export function securityCodeInvalidGet(req: Request, res: Response): void {
   const isNotEmailCode =
     req.query.actionType !== SecurityCodeErrorType.EmailMaxRetries;
   if (isNotEmailCode) {
     req.session.user.wrongCodeEnteredLock = new Date(
-      Date.now() + 15 * 60000
+      Date.now() + getCodeEnteredWrongBlockDurationInMinutes() * 60000
     ).toUTCString();
   }
   return res.render("security-code-error/index.njk", {
@@ -26,7 +30,7 @@ export function securityCodeTriesExceededGet(
   res: Response
 ): void {
   req.session.user.codeRequestLock = new Date(
-    Date.now() + 15 * 60000
+    Date.now() + getCodeRequestBlockDurationInMinutes() * 60000
   ).toUTCString();
   return res.render("security-code-error/index-too-many-requests.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),

--- a/src/config.ts
+++ b/src/config.ts
@@ -116,3 +116,11 @@ export function getServiceDomain(): string {
 export function getServiceSignInLink(): string {
   return process.env.SERVICE_SIGN_IN_LINK || "https://www.gov.uk/sign-in";
 }
+
+export function getCodeRequestBlockDurationInMinutes(): number {
+  return Number(process.env.CODE_REQUEST_BLOCKED_MINUTES) || 15;
+}
+
+export function getCodeEnteredWrongBlockDurationInMinutes(): number {
+  return Number(process.env.CODE_ENTERED_WRONG_BLOCKED_MINUTES) || 15;
+}


### PR DESCRIPTION
## What?

- Parameterise the OTP locked duration

## Why?

- To allow it to be configured locally for testing. Default value is 15 minutes.
