### PR TITLE
AUT-1273 - Compare time rather than UTC string

### DIFF
--- a/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
+++ b/src/components/enter-authenticator-app-code/enter-authenticator-app-code-controller.ts
@@ -36,7 +36,8 @@ export function enterAuthenticatorAppCodeGet(
 
     if (
       req.session.user.wrongCodeEnteredLock &&
-      new Date().toUTCString() < req.session.user.wrongCodeEnteredLock
+      new Date().getTime() <
+        new Date(req.session.user.wrongCodeEnteredLock).getTime()
     ) {
       return res.render(
         "security-code-error/index-security-code-entered-exceeded.njk",

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -74,10 +74,10 @@ export function securityCodeCheckTimeLimit(): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const { sessionId } = res.locals;
     const isAccountRecoveryJourney = req.session.user?.isAccountRecoveryJourney;
-
     if (
       req.session.user.codeRequestLock &&
-      new Date().toUTCString() < req.session.user.codeRequestLock
+      new Date().getTime() <
+        new Date(req.session.user.codeRequestLock).getTime()
     ) {
       const newCodeLink = req.query?.isResendCodeRequest
         ? "/security-code-check-time-limit?isResendCodeRequest=true"

--- a/src/components/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/resend-mfa-code/resend-mfa-code-controller.ts
@@ -9,7 +9,8 @@ import { pathWithQueryParam } from "../common/constants";
 export function resendMfaCodeGet(req: Request, res: Response): void {
   if (
     req.session.user.wrongCodeEnteredLock &&
-    new Date().toUTCString() < req.session.user.wrongCodeEnteredLock
+    new Date().getTime() <
+      new Date(req.session.user.wrongCodeEnteredLock).getTime()
   ) {
     const newCodeLink = req.query?.isResendCodeRequest
       ? pathWithQueryParam(
@@ -24,7 +25,7 @@ export function resendMfaCodeGet(req: Request, res: Response): void {
     });
   } else if (
     req.session.user.codeRequestLock &&
-    new Date().toUTCString() < req.session.user.codeRequestLock
+    new Date().getTime() < new Date(req.session.user.codeRequestLock).getTime()
   ) {
     const newCodeLink = req.query?.isResendCodeRequest
       ? "/resend-code?isResendCodeRequest=true"


### PR DESCRIPTION
## What?

- Compare time rather than UTC string

## Why?

- Comparing UTC string isn't reliable and instead we should convert them to Date and compare the time for a more accurate comparison