### PR TITLE
Add OneAgent to frontend

### DIFF
--- a/ci/terraform/dynatrace.tf
+++ b/ci/terraform/dynatrace.tf
@@ -1,0 +1,26 @@
+data "aws_secretsmanager_secret" "dynatrace_paas_token" {
+  name = "DynatracePaaSToken"
+}
+
+data "aws_iam_policy_document" "dynatrace_paas_token" {
+  statement {
+    sid    = "AllowGetSecret"
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = [
+      data.aws_secretsmanager_secret.dynatrace_paas_token.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "dynatrace_paas_token" {
+  policy      = data.aws_iam_policy_document.dynatrace_paas_token.json
+  path        = "/${var.environment}/secretsmanager/dynatrace_paas_token/"
+  name_prefix = "dynatrace_paas_token"
+
+  tags = local.default_tags
+}

--- a/ci/terraform/ecs-roles.tf
+++ b/ci/terraform/ecs-roles.tf
@@ -22,6 +22,11 @@ resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_attach
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_role_policy_attachment_dynatrace_paas_token" {
+  role       = aws_iam_role.ecs_task_execution_role.name
+  policy_arn = aws_iam_policy.dynatrace_paas_token.arn
+}
+
 resource "aws_iam_role" "ecs_task_role" {
   name               = "${var.environment}-frontend-ecs-task-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role_policy.json

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -25,6 +25,10 @@ locals {
     }]
     environment = [
       {
+        name  = "LD_PRELOAD",
+        value = "/opt/dynatrace/oneagent/agent/lib64/liboneagentproc.s"
+      },
+      {
         name  = "NODE_ENV"
         value = "production"
       },
@@ -105,6 +109,20 @@ locals {
         value = local.service_domain
       },
     ]
+
+    dependsOn = [
+      {
+        condition     = "COMPLETE"
+        containerName = "oneagent-installer"
+      }
+    ]
+
+    mountPoints = [
+      {
+        sourceVolume  = "oneagent"
+        containerPath = "/opt/dynatrace/oneagent"
+      }
+    ]
   }
 
   sidecar_container_definition = {
@@ -154,6 +172,49 @@ locals {
         name  = "TRUSTED_PROXIES"
         value = jsonencode(local.public_subnet_cidr_blocks)
       },
+    ]
+  }
+
+  oneagent_installer_container_definition = {
+    name      = "oneagent-installer"
+    image     = "alpine:3"
+    essential = false
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        awslogs-group         = aws_cloudwatch_log_group.ecs_frontend_task_log.name
+        awslogs-region        = var.aws_region
+        awslogs-stream-prefix = local.service_name
+      }
+    }
+
+    entrypoint = ["/bin/sh", "-c"]
+    command    = ["ARCHIVE=$(mktemp) && wget -O $ARCHIVE \"$DT_API_URL/v1/deployment/installer/agent/unix/paas/latest?Api-Token=$DT_PAAS_TOKEN&$DT_ONEAGENT_OPTIONS\" && unzip -o -d /opt/dynatrace/oneagent $ARCHIVE && rm -f $ARCHIVE"]
+
+    environment = [
+      {
+        name  = "DT_API_URL",
+        value = "https://khw46367.live.dynatrace.com/api"
+      },
+      {
+        name  = "DT_ONEAGENT_OPTIONS",
+        value = "flavor=default&include=all"
+      }
+    ]
+
+    secrets = [
+      {
+        name      = "DT_PAAS_TOKEN"
+        valueFrom = data.aws_secretsmanager_secret.dynatrace_paas_token.arn
+      }
+    ]
+
+    mountPoints = [
+      {
+        sourceVolume  = "oneagent"
+        containerPath = "/opt/dynatrace/oneagent"
+      }
     ]
   }
 }
@@ -209,7 +270,12 @@ resource "aws_ecs_task_definition" "frontend_task_definition" {
   container_definitions = var.basic_auth_password == "" ? jsonencode([local.frontend_container_definition]) : jsonencode([
     local.frontend_container_definition,
     local.sidecar_container_definition,
+    local.oneagent_installer_container_definition,
   ])
+
+  volume {
+    name = "oneagent"
+  }
 
   tags = local.default_tags
 }


### PR DESCRIPTION
## What?

Adds the OneAgent installer sidecar to the frontend deployment.

## Why?

This will instrument the frontend within Dynatrace.
