### PR TITLE
AUT-1089: Send change security codes confirmation email in account recovery journey

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -73,11 +73,16 @@ export const checkYourPhonePost = (
       throw new BadRequestError(result.data.message, result.data.code);
     }
 
+    const notificationType =
+      isAccountRecoveryPermitted && isAccountRecoveryJourney
+        ? NOTIFICATION_TYPE.CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION
+        : NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION;
+
     await notificationService.sendNotification(
       res.locals.sessionId,
       res.locals.clientSessionId,
       req.session.user.email,
-      NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION,
+      notificationType,
       req.ip,
       res.locals.persistentSessionId,
       xss(req.cookies.lng as string)

--- a/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
@@ -9,7 +9,7 @@ import {
 } from "../check-your-phone-controller";
 
 import { SendNotificationServiceInterface } from "../../common/send-notification/types";
-import { PATH_NAMES } from "../../../app.constants";
+import { NOTIFICATION_TYPE, PATH_NAMES } from "../../../app.constants";
 import { ERROR_CODES } from "../../common/constants";
 import {
   mockRequest,
@@ -47,7 +47,7 @@ describe("check your phone controller", () => {
   });
 
   describe("checkYourPhonePost", () => {
-    it("should redirect to /create-password when valid code entered", async () => {
+    it("should redirect to //account-confirmation when valid code entered", async () => {
       const fakeService: VerifyMfaCodeInterface = {
         verifyMfaCode: sinon.fake.returns({
           sessionState: "PHONE_NUMBER_CODE_VERIFIED",
@@ -68,6 +68,54 @@ describe("check your phone controller", () => {
       );
 
       expect(fakeService.verifyMfaCode).to.have.been.calledOnce;
+      expect(fakeNotificationService.sendNotification).to.have.calledWith(
+        "123456-djjad",
+        undefined,
+        undefined,
+        NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION,
+        "127.0.0.1",
+        undefined,
+        ""
+      );
+      expect(res.redirect).to.have.calledWith(
+        PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL
+      );
+    });
+
+    it("should redirect to /account-confirmation when valid code entered for account recovery journey (to be updated) ", async () => {
+      const fakeService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({
+          sessionState: "PHONE_NUMBER_CODE_VERIFIED",
+          success: true,
+        }),
+      };
+
+      const fakeNotificationService: SendNotificationServiceInterface = {
+        sendNotification: sinon.fake(),
+      };
+
+      req.body.code = "123456";
+      res.locals.sessionId = "123456-djjad";
+      req.session.user = {
+        isAccountRecoveryPermitted: true,
+        isAccountRecoveryJourney: true,
+      };
+
+      await checkYourPhonePost(fakeService, fakeNotificationService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(fakeService.verifyMfaCode).to.have.been.calledOnce;
+      expect(fakeNotificationService.sendNotification).to.have.calledWith(
+        "123456-djjad",
+        undefined,
+        undefined,
+        NOTIFICATION_TYPE.CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION,
+        "127.0.0.1",
+        undefined,
+        ""
+      );
       expect(res.redirect).to.have.calledWith(
         PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL
       );

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -92,11 +92,16 @@ export function setupAuthenticatorAppPost(
 
     req.session.user.authAppSecret = null;
 
+    const notificationType =
+      isAccountRecoveryPermitted && isAccountRecoveryJourney
+        ? NOTIFICATION_TYPE.CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION
+        : NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION;
+
     await notificationService.sendNotification(
       res.locals.sessionId,
       res.locals.clientSessionId,
       req.session.user.email,
-      NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION,
+      notificationType,
       req.ip,
       res.locals.persistentSessionId,
       xss(req.cookies.lng as string)

--- a/src/components/setup-authenticator-app/tests/setup-authenticator-app-controller.test.ts
+++ b/src/components/setup-authenticator-app/tests/setup-authenticator-app-controller.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { describe } from "mocha";
 import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
-import { PATH_NAMES } from "../../../app.constants";
+import { NOTIFICATION_TYPE, PATH_NAMES } from "../../../app.constants";
 import {
   setupAuthenticatorAppGet,
   setupAuthenticatorAppPost,
@@ -71,6 +71,54 @@ describe("setup-authenticator-app controller", () => {
 
       expect(fakeMfAService.verifyMfaCode).to.have.been.calledOnce;
       expect(fakeNotificationService.sendNotification).to.have.been.calledOnce;
+      expect(fakeNotificationService.sendNotification).to.have.calledWith(
+        undefined,
+        undefined,
+        "t@t.com",
+        NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION,
+        "127.0.0.1",
+        undefined,
+        ""
+      );
+
+      expect(res.redirect).to.have.calledWith(
+        PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL
+      );
+    });
+
+    it("should successfully validate access code and redirect to account created for account recovery journey (to be updated)", async () => {
+      req.body.code = "123456";
+      req.session.user = {
+        authAppSecret: "testsecret",
+        email: "t@t.com",
+        isAccountRecoveryPermitted: true,
+        isAccountRecoveryJourney: true,
+      };
+
+      const fakeMfAService: VerifyMfaCodeInterface = {
+        verifyMfaCode: sinon.fake.returns({ success: true }),
+      };
+
+      const fakeNotificationService: SendNotificationServiceInterface = {
+        sendNotification: sinon.fake(),
+      };
+
+      await setupAuthenticatorAppPost(fakeMfAService, fakeNotificationService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(fakeMfAService.verifyMfaCode).to.have.been.calledOnce;
+      expect(fakeNotificationService.sendNotification).to.have.been.calledOnce;
+      expect(fakeNotificationService.sendNotification).to.have.calledWith(
+        undefined,
+        undefined,
+        "t@t.com",
+        NOTIFICATION_TYPE.CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION,
+        "127.0.0.1",
+        undefined,
+        ""
+      );
 
       expect(res.redirect).to.have.calledWith(
         PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL


### PR DESCRIPTION
## What?

Send change security codes confirmation email in account recovery journey.

The account recovery journey reuses the 'enter-phone-number' and 'setup-authenticator-app' screens so that users can switch their mfa method.  A flag in the session indicates whether the account recovery journey is in effect.  In this case a different confirmation email is sent when the journey completes: 'You’ve changed how you get security codes when you sign in to GOV.​UK One Login'.

This PR chooses the correct email template depending on the user journey, and adds tests to test each case.

A further PR will follow to route to the correct confirmation page.

## Why?

The user should receive the correct confirmation email depending on their journey.

## Change have been demonstrated

To be demonstrated when the complete flow is ready.

## Related PRs

#998 
https://github.com/alphagov/di-authentication-api/pull/2925

