### PR TITLE
AUT-1197: Reduce number of characters in secret key presented to users

### DIFF
--- a/src/utils/mfa.ts
+++ b/src/utils/mfa.ts
@@ -21,7 +21,7 @@ export function generateMfaSecret(): string {
     keyEncoder: base32EncDec.keyEncoder,
     keyDecoder: base32EncDec.keyDecoder,
   };
-  return authenticatorGenerateSecret(32, options);
+  return authenticatorGenerateSecret(20, options);
 }
 
 export function generateQRCodeValue(

--- a/test/unit/utils/mfa.ts
+++ b/test/unit/utils/mfa.ts
@@ -4,9 +4,9 @@ import { generateMfaSecret, generateQRCodeValue } from "../../../src/utils/mfa";
 
 describe("mfa", () => {
   describe("generateMfaSecret", () => {
-    it("should return a secret with a length of 52 chars", () => {
+    it("should return a secret with a length of 32 chars", () => {
       const secret = generateMfaSecret();
-      expect(secret.length).to.equal(52);
+      expect(secret.length).to.equal(32);
     });
   });
 


### PR DESCRIPTION
## What?

Reduces the number of characters in the secret key shown to users when setting up an authenticator app from 52 characters to 32 characters. 

## Why?

While working on AUT-1149 it came to light that the secret key we present to users setting up an auth app is 52 rather than 32 characters long. When this was queried by Content and Interaction Design, a technical conversation concluded that the initial implementation of the auth app secret set it to be longer than is recommended by [RFC4226](https://www.ietf.org/rfc/rfc4226.txt).

## Screen changes
<img width="624" alt="Screenshot 2023-05-17 at 12 48 41" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/07bfc8cc-0a09-46b6-b146-04dc9e063dfa">


## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
