### PR TITLE
AUT-1229: Bug fix to use post validation local in enter password form to access email from session

### DIFF
--- a/src/components/enter-password/enter-password-validation.ts
+++ b/src/components/enter-password/enter-password-validation.ts
@@ -1,6 +1,7 @@
 import { body } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
+import { Request } from "express";
 
 export function validateEnterPasswordRequest(): ValidationChainFunc {
   return [
@@ -27,6 +28,17 @@ export function validateEnterPasswordAccountExistsRequest(): ValidationChainFunc
           }
         );
       }),
-    validateBodyMiddleware("enter-password/index-account-exists.njk"),
+    validateBodyMiddleware(
+      "enter-password/index-account-exists.njk",
+      postValidationLocals
+    ),
   ];
 }
+
+const postValidationLocals = function locals(
+  req: Request
+): Record<string, unknown> {
+  return {
+    email: req.session.user.email,
+  };
+};


### PR DESCRIPTION
## What?

Use post validation locals to access email param from session when validating enter password form

## Why?

When form validation fails, i.e. user does not enter a password and proceeds to continue `/enter-password-account-exists` page, the user's email disappears from the content on the page.