### PR TITLE
AUT-1083: Show security codes changed confirmation page

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -1,3 +1,8 @@
+export enum MFA_METHOD_TYPE {
+  SMS = "SMS",
+  AUTH_APP = "AUTH_APP",
+}
+
 export const PATH_NAMES = {
   START: "/",
   ACCESSIBILITY_STATEMENT: "/accessibility-statement",
@@ -57,6 +62,10 @@ export const PATH_NAMES = {
   CHANGE_SECURITY_CODES: "/change-security-codes",
   CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES: "/check-email-change-security-codes",
   CHANGE_SECURITY_CODES_CONFIRMATION: "/change-codes-confirmed",
+  CHANGE_SECURITY_CODES_CONFIRMATION_SMS:
+    "/change-codes-confirmed" + "?type=" + MFA_METHOD_TYPE.SMS,
+  CHANGE_SECURITY_CODES_CONFIRMATION_AUTH_APP:
+    "/change-codes-confirmed" + "?type=" + MFA_METHOD_TYPE.AUTH_APP,
 };
 
 export const HREF_BACK = {
@@ -178,11 +187,6 @@ export const COOKIE_CONSENT = {
 export enum SUPPORT_TYPE {
   GOV_SERVICE = "GOV_SERVICE",
   PUBLIC = "PUBLIC",
-}
-
-export enum MFA_METHOD_TYPE {
-  SMS = "SMS",
-  AUTH_APP = "AUTH_APP",
 }
 
 export enum JOURNEY_TYPE {

--- a/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
@@ -1,30 +1,13 @@
 import { Request, Response } from "express";
-import { MFA_METHOD_TYPE, NOTIFICATION_TYPE } from "../../../app.constants";
-import { SendNotificationServiceInterface } from "../../common/send-notification/types";
-import { sendNotificationService } from "../../common/send-notification/send-notification-service";
+import { MFA_METHOD_TYPE } from "../../../app.constants";
 import { ExpressRouteFunc } from "../../../types";
-import xss from "xss";
 import { USER_JOURNEY_EVENTS } from "../../common/state-machine/state-machine";
 import { getNextPathAndUpdateJourney } from "../../common/constants";
 
-export function changeSecurityCodesConfirmationGet(
-  notificationService: SendNotificationServiceInterface = sendNotificationService()
-): ExpressRouteFunc {
+export function changeSecurityCodesConfirmationGet(): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const { email } = req.session.user;
-    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
     const type = req.query.type;
     if (type === MFA_METHOD_TYPE.SMS || type === MFA_METHOD_TYPE.AUTH_APP) {
-      await notificationService.sendNotification(
-        sessionId,
-        clientSessionId,
-        email,
-        NOTIFICATION_TYPE.CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION,
-        req.ip,
-        persistentSessionId,
-        xss(req.cookies.lng as string)
-      );
-
       res.render(
         "account-recovery/change-security-codes-confirmation/index.njk",
         {

--- a/src/components/account-recovery/change-security-codes-confirmation/index.njk
+++ b/src/components/account-recovery/change-security-codes-confirmation/index.njk
@@ -6,7 +6,7 @@
 
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.changeSecurityCodesConfirmation.header' | translate}}</h1>
 
-<form action="/account-created" method="post" novalidate>
+<form action="/change-codes-confirmed" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>

--- a/src/components/account-recovery/change-security-codes-confirmation/tests/change-security-codes-confirmation-controller.test.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/tests/change-security-codes-confirmation-controller.test.ts
@@ -11,7 +11,6 @@ import {
   RequestOutput,
   ResponseOutput,
 } from "mock-req-res";
-import { SendNotificationServiceInterface } from "../../../common/send-notification/types";
 import {
   changeSecurityCodesConfirmationGet,
   changeSecurityCodesConfirmationPost,
@@ -39,16 +38,11 @@ describe("change security codes confirmation controller", () => {
       mfaMethodType
     ) {
       it(`should render the change security codes codes confirmation page for mfaMethodType ${mfaMethodType}`, async () => {
-        const fakeNotificationService: SendNotificationServiceInterface = {
-          sendNotification: sinon.fake.returns({
-            success: true,
-          }),
-        };
         req.query.type = mfaMethodType;
         req.session.user.email = "security.codes.changed@testtwofactorauth.org";
         req.session.user.redactedPhoneNumber = "*******1234";
 
-        await changeSecurityCodesConfirmationGet(fakeNotificationService)(
+        await changeSecurityCodesConfirmationGet()(
           req as Request,
           res as Response
         );
@@ -61,8 +55,13 @@ describe("change security codes confirmation controller", () => {
     });
   });
 
-  describe("changeSecurityCodesConfirmationGetPost", () => {
-    it("should redirect to auth code", () => {
+  describe("changeSecurityCodesConfirmationPost", () => {
+    it("should redirect to auth code after security codes confirmation ", () => {
+      req = mockRequest({
+        path: PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION,
+        session: { client: {}, user: {} },
+        log: { info: sinon.fake() },
+      });
       changeSecurityCodesConfirmationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.been.calledWith(PATH_NAMES.AUTH_CODE);

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -95,6 +95,8 @@ export const checkYourPhonePost = (
         USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
+          isAccountRecoveryJourney:
+            isAccountRecoveryPermitted && isAccountRecoveryJourney,
         },
         res.locals.sessionId
       )

--- a/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
@@ -82,7 +82,7 @@ describe("check your phone controller", () => {
       );
     });
 
-    it("should redirect to /account-confirmation when valid code entered for account recovery journey (to be updated) ", async () => {
+    it("should redirect to /change-codes-confirmed when valid code entered for account recovery journey ", async () => {
       const fakeService: VerifyMfaCodeInterface = {
         verifyMfaCode: sinon.fake.returns({
           sessionState: "PHONE_NUMBER_CODE_VERIFIED",
@@ -117,7 +117,7 @@ describe("check your phone controller", () => {
         ""
       );
       expect(res.redirect).to.have.calledWith(
-        PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL
+        PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_SMS
       );
     });
 

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -257,6 +257,10 @@ const authStateMachine = createMachine(
         on: {
           [USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED]: [
             {
+              target: [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_AUTH_APP],
+              cond: "isAccountRecoveryJourney",
+            },
+            {
               target: [PATH_NAMES.PROVE_IDENTITY],
               cond: "isIdentityRequired",
             },
@@ -285,6 +289,10 @@ const authStateMachine = createMachine(
       [PATH_NAMES.CHECK_YOUR_PHONE]: {
         on: {
           [USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED]: [
+            {
+              target: [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_SMS],
+              cond: "isAccountRecoveryJourney",
+            },
             {
               target: [PATH_NAMES.PROVE_IDENTITY],
               cond: "isIdentityRequired",
@@ -616,6 +624,16 @@ const authStateMachine = createMachine(
           [USER_JOURNEY_EVENTS.CHANGE_SECURITY_CODES_COMPLETED]: [
             { target: [PATH_NAMES.AUTH_CODE] },
           ],
+        },
+      },
+      [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_SMS]: {
+        meta: {
+          optionalPaths: [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION],
+        },
+      },
+      [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_AUTH_APP]: {
+        meta: {
+          optionalPaths: [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION],
         },
       },
     },

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -114,6 +114,8 @@ export function setupAuthenticatorAppPost(
         USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
+          isAccountRecoveryJourney:
+            isAccountRecoveryPermitted && isAccountRecoveryJourney,
         },
         sessionId
       )

--- a/src/components/setup-authenticator-app/tests/setup-authenticator-app-controller.test.ts
+++ b/src/components/setup-authenticator-app/tests/setup-authenticator-app-controller.test.ts
@@ -121,7 +121,7 @@ describe("setup-authenticator-app controller", () => {
       );
 
       expect(res.redirect).to.have.calledWith(
-        PATH_NAMES.CREATE_ACCOUNT_SUCCESSFUL
+        PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_AUTH_APP
       );
     });
 


### PR DESCRIPTION
## What?

Show security codes changed confirmation page.

When a user has completed updating how they get security codes the 'You've changed how you get security codes' screen is displayed.  The screen has two modes with different text, one for SMS and one for Auth Apps.  Each mode is selected with a query parameter.

- Update the state machine to go to the correct version of the screen depending on the mfa method chosen by the user.
- Update tests to check for the correct navigation.
- Remove sending the confirmation email from the controller as the mail is already sent by 'check your phone' and 'enter authenticator app code'.

## Why?

A user should see confirmation when the how they get security codes has been updated.

## Change have been demonstrated

To be demonstrated when the complete flow is available.

## Related PRs

#1001 
#1032 
