### PR TITLE
[DO NOT MERGE until Wed 31 May 2023] AUT-1287: Updates to privacy notice

### DIFF
--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -96,20 +96,9 @@
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_four' | translate }}
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-        <li>{{ 'pages.privacy.sections.using_id_check_app.list_two.item_one' | translate }}</li>
-        <li>{{ 'pages.privacy.sections.using_id_check_app.list_two.item_two' | translate }}</li>
-        <li>{{ 'pages.privacy.sections.using_id_check_app.list_two.item_three' | translate }}</li>
-    </ul>
-
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_five' | translate }}
     </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-        <li>{{ 'pages.privacy.sections.using_id_check_app.list_three.item_one' | translate }}</li>
-        <li>{{ 'pages.privacy.sections.using_id_check_app.list_three.item_two' | translate }}</li>
-    </ul>
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_six' | translate }}
@@ -119,27 +108,27 @@
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_seven' | translate }}
     </p>
 
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.privacy.sections.using_id_check_app.list_two.item_one' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.using_id_check_app.list_two.item_two' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.using_id_check_app.list_two.item_three' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.using_id_check_app.list_two.item_four' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.using_id_check_app.list_two.item_five' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.using_id_check_app.list_two.item_six' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.using_id_check_app.list_two.item_seven' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.using_id_check_app.list_two.item_eight' | translate }}</li>
+    </ul>
+
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_eight' | translate }}
     </p>
-
-
-    <h3 class="govuk-heading-s">
-        {{ 'pages.privacy.sections.using_id_check_app.sub_header_two' | translate }}
-    </h3>
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_nine' | translate }}
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-        <li>{{ 'pages.privacy.sections.using_id_check_app.list_four.item_one' | translate }}</li>
-        <li>{{ 'pages.privacy.sections.using_id_check_app.list_four.item_two' | translate }}</li>
-    </ul>
-
     <p class="govuk-body">
-        {{ 'pages.privacy.sections.using_id_check_app.paragraph_ten.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_ten.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_ten.link.link_text' | translate }}</a>.
+        {{ 'pages.privacy.sections.using_id_check_app.paragraph_ten' | translate }}
     </p>
 
     <p class="govuk-body">
@@ -148,6 +137,40 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_twelve' | translate }}
+    </p>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.using_id_check_app.paragraph_thirteen' | translate }}
+    </p>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.using_id_check_app.paragraph_fourteen' | translate }}
+    </p>
+
+    <h3 class="govuk-heading-s">
+        {{ 'pages.privacy.sections.using_id_check_app.sub_header_two' | translate }}
+    </h3>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.using_id_check_app.paragraph_fifteen' | translate }}
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+        <li>{{ 'pages.privacy.sections.using_id_check_app.list_four.item_one' | translate }}</li>
+        <li>{{ 'pages.privacy.sections.using_id_check_app.list_four.item_two' | translate }}</li>
+    </ul>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.part_one' | translate }}
+        <a href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_ten.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_ten.link.link_text' | translate }}</a>.
+    </p>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.using_id_check_app.paragraph_seventeen' | translate }}
+    </p>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.using_id_check_app.paragraph_eighteen' | translate }}
     </p>
 
     <h2 class="govuk-heading-m">

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1385,7 +1385,7 @@
           "header": "Newidiadau i’r hysbysiad hwn",
           "paragraph_one": "Efallai y byddwn yn newid yr hysbysiad preifatrwydd hwn. Yn yr achos hynny, bydd dyddiad ’diweddaru olaf’ y ddogfen hon hefyd yn newid. Bydd unrhyw newidiadau i’r hysbysiad preifatrwydd hwn yn berthnasol i chi a’ch gwybodaeth ar unwaith.",
           "paragraph_two": "Os yw’r newidiadau hyn yn effeithio ar sut mae eich gwybodaeth bersonol yn cael ei phrosesu, bydd GDS yn rhoi gwybod i chi.",
-          "paragraph_three": "Diweddarwyd diwethaf: 30 Mai 2023"
+          "paragraph_three": "Diweddarwyd diwethaf: 31 Mai 2023"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1053,7 +1053,7 @@
           "paragraph_three": "Rydym yn defnyddio darparwr gwasanaeth gwirio hunaniaeth o’r enw Iproov a’u his-gontractwyr Veriff ac Innovalor i gynnal y gwiriadau hyn. Mae Iproov yn gweithredu fel prosesydd data gyda Veriff ac Innovalor fel is-broseswyr, sy’n golygu y gallant ond prosesu eich data personol at bwrpas cyflawni ein cyfarwyddiadau.",
           "paragraph_four": "Mae angen i ni wirio eich nodweddion diogelwch eich dogfennau hunaniaeth i brofi eu bod yn ddogfennau dilys.",
           "paragraph_five": "Ar gyfer trwyddedau gyrru, bydd angen i chi dynnu llun o flaen a chefn eich trwydded gyda chamera eich ffôn. Bydd yr ap yn gofyn am ganiatâd i fynd i mewn i’ch camera a’ch lluniau i wneud hyn.",
-          "paragraph_six": "Ar gyfer e-basbort a thrwyddedau preswyl biometrig, bydd yr Ap yn darllen y wybodaeth ar eich dogfen trwy’r sglodyn near field communication (NFC).",
+          "paragraph_six": "Ar gyfer e-basbort a thrwyddedau preswyl biometrig, bydd yr ap yn darllen y wybodaeth ar eich dogfen trwy’r sglodyn near field communication (NFC).",
           "paragraph_seven": "Rydym yn casglu’r wybodaeth ganlynol:",
           "list_two": {
             "item_one": "enw",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1052,34 +1052,41 @@
           },
           "paragraph_three": "Rydym yn defnyddio darparwr gwasanaeth gwirio hunaniaeth o’r enw Iproov a’u his-gontractwyr Veriff ac Innovalor i gynnal y gwiriadau hyn. Mae Iproov yn gweithredu fel prosesydd data gyda Veriff ac Innovalor fel is-broseswyr, sy’n golygu y gallant ond prosesu eich data personol at bwrpas cyflawni ein cyfarwyddiadau.",
           "paragraph_four": "Mae angen i ni wirio eich nodweddion diogelwch eich dogfennau hunaniaeth i brofi eu bod yn ddogfennau dilys.",
+          "paragraph_five": "Ar gyfer trwyddedau gyrru, bydd angen i chi dynnu llun o flaen a chefn eich trwydded gyda chamera eich ffôn. Bydd yr ap yn gofyn am ganiatâd i fynd i mewn i’ch camera a’ch lluniau i wneud hyn.",
+          "paragraph_six": "Ar gyfer e-basbort a thrwyddedau preswyl biometrig, bydd yr Ap yn darllen y wybodaeth ar eich dogfen trwy’r sglodyn near field communication (NFC).",
+          "paragraph_seven": "Rydym yn casglu’r wybodaeth ganlynol:",
           "list_two": {
-            "item_one": "Ar gyfer trwyddedau gyrru, bydd angen i chi dynnu llun o flaen a chefn eich trwydded gyda camera eich ffôn. Bydd angen caniatâd ar yr ap i gael mynediad at eich camera a’ch lluniau ar gyfer hyn.",
-            "item_two": "Ar gyfer e-basbortau, bydd yr Ap yn darllen eich gwybodaeth pasbort o sglodyn Near Field Communication (NFC).",
-            "item_three": "Pan fydd Iproov wedi cwblhau’r gwiriad, maent yn anfon canlyniad y gwiriad a’ch trwydded yrru neu wybodaeth pasbort atom ni."
+            "item_one": "enw",
+            "item_two": "dyddiad geni",
+            "item_three": "cyfeiriad (trwyddedau gyrru’n unig)",
+            "item_four": "rhif y ddogfen",
+            "item_five": "dyddiad dod i ben",
+            "item_six": "gwlad gyhoeddi",
+            "item_seven": "cenedligrwydd (heblaw am drwyddedau gyrru)",
+            "item_eight": "llun"
           },
-          "paragraph_five": "Rydym yn gwneud gwiriad \"bywiogrwydd\" i brofi a yw defnyddiwr yn berson go iawn ac nid unrhyw beth a allai dynwared unigolyn fel mannequin, ffigwr cwyr, mwgwd 3D, llun neu ffugiad dwfn.",
-          "list_three": {
-            "item_one": "Bydd angen i chi gymryd fideo hunlun gan ddefnyddio camera eich ffôn. Bydd angen caniatâd i’r ap gael mynediad at eich camera a fideos ar gyfer hyn. Mae’r gwiriad hwn yn cael ei gynnal mewn amser real sy’n golygu nad ydym ni nac Iproov yn storio’r fideo.",
-            "item_two": "Pan mae Iproov wedi cwblhau’r gwiriad, maent yn anfon canlyniad y gwiriad atom."
-          },
-          "paragraph_six": "Rydym yn gwneud gwiriad tebygrwydd i brofi mai chi yw’r un person ag yn eich dogfen hunaniaeth gyda llun.",
-          "paragraph_seven": "Mae’r gwiriad hwn yn defnyddio delwedd llonydd a gynhyrchir o’ch fideo hunlun a’r llun yn eich dogfen hunaniaeth i fesur patrymau unigryw eich wyneb. Data biometrig wynebol yw’r enw ar hyn. Mae’r data biometrig o’r ddwy ddelwedd yn cael ei gymharu i sefydlu ai’r defnyddiwr yw gwir berchennog y ddogfen hunaniaeth.",
-          "paragraph_eight": "Pan mae Iproov wedi cwblhau’r gwiriad, maent yn anfon canlyniad y gwiriad atom.",
+          "paragraph_eight": "Pan fydd Iproov wedi cwblhau’r gwiriad, byddant yn anfon canlyniad y gwiriad a gwybodaeth eich dogfen hunaniaeth atom.",
+          "paragraph_nine": "Rydym yn gwneud gwiriad \"bywiogrwydd\" i brofi a yw defnyddiwr yn berson go iawn ac nid unrhyw beth a allai dynwared unigolyn fel mannequin, ffigwr cwyr, mwgwd 3D, llun neu ffugiad dwfn.",
+          "paragraph_ten": "Bydd angen i chi gymryd fideo hunlun gan ddefnyddio camera eich ffôn. Bydd angen caniatâd i’r ap gael mynediad at eich camera a fideos ar gyfer hyn. Mae’r gwiriad hwn yn cael ei gynnal mewn amser real sy’n golygu nad ydym ni nac Iproov yn storio’r fideo.",
+          "paragraph_eleven": "Pan mae Iproov wedi cwblhau’r gwiriad, maent yn anfon canlyniad y gwiriad atom.",
+          "paragraph_twelve": "Rydym yn gwneud gwiriad tebygrwydd i brofi mai chi yw’r un person ag yn eich dogfen hunaniaeth gyda llun.",
+          "paragraph_thirteen": "Mae’r gwiriad hwn yn defnyddio delwedd llonydd a gynhyrchir o’ch fideo hunlun a’r llun yn eich dogfen hunaniaeth i fesur patrymau unigryw eich wyneb. Data biometrig wynebol yw’r enw ar hyn. Mae’r data biometrig o’r ddwy ddelwedd yn cael ei gymharu i sefydlu ai’r defnyddiwr yw gwir berchennog y ddogfen hunaniaeth.",
+          "paragraph_fourteen": "Pan mae Iproov wedi cwblhau’r gwiriad, maent yn anfon canlyniad y gwiriad atom.",
           "sub_header_two": "Gwiriad twyll",
-          "paragraph_nine": "Rydym yn defnyddio darparwr gwasanaeth gwirio hunaniaeth o’r enw Experian i:",
+          "paragraph_fifteen": "Rydym yn defnyddio darparwr gwasanaeth gwirio hunaniaeth o’r enw Experian i:",
           "list_four": {
             "item_one": "gynnal gwiriad twyll i chwilio am unrhyw arwyddion bod eich hunaniaeth wedi cael ei ddwyn neu ei gamddefnyddio",
             "item_two": "gwirio os oes cofnod ohonoch yn bodoli dros amser"
           },
-          "paragraph_ten": {
+          "paragraph_sixteen": {
             "part_one": "Maent yn gwneud hynny fel rheolydd data annibynnol yn unol â’u",
             "link": {
               "link_text": "hysbysiad preifatrwydd",
               "link_href": "https://www.experian.co.uk/consumer/privacy.html"
             }
           },
-          "paragraph_eleven": "Pan fyddwch wedi cwblhau’r gwiriadau uchod gan ddefnyddio’r Ap, byddwch yn cael eich dychwelyd i wefan GOV.UK One Login lle byddwn yn casglu eich enw, eich dyddiad geni a’ch cyfeiriad. Rydym yn anfon y rhain i Experian er mwyn iddynt allu cynnal gwiriad gwrth-dwyll.",
-          "paragraph_twelve": "Pan mae Experian wedi cwblhau’r gwiriad, maent yn anfon sgôr twyll atom, ynghyd â manylion am unrhyw weithgaredd twyllodrus cysylltiedig."
+          "paragraph_seventeen": "Pan fyddwch wedi cwblhau’r gwiriadau uchod gan ddefnyddio’r Ap, byddwch yn cael eich dychwelyd i wefan GOV.UK One Login lle byddwn yn casglu eich enw, eich dyddiad geni a’ch cyfeiriad. Rydym yn anfon y rhain i Experian er mwyn iddynt allu cynnal gwiriad gwrth-dwyll.",
+          "paragraph_eighteen": "Pan mae Experian wedi cwblhau’r gwiriad, maent yn anfon sgôr twyll atom, ynghyd â manylion am unrhyw weithgaredd twyllodrus cysylltiedig."
         },
         "using_web_to_prove_identity": {
           "header": "Defnyddio eich porwr gwe i brofi eich hunaniaeth",
@@ -1378,7 +1385,7 @@
           "header": "Newidiadau i’r hysbysiad hwn",
           "paragraph_one": "Efallai y byddwn yn newid yr hysbysiad preifatrwydd hwn. Yn yr achos hynny, bydd dyddiad ’diweddaru olaf’ y ddogfen hon hefyd yn newid. Bydd unrhyw newidiadau i’r hysbysiad preifatrwydd hwn yn berthnasol i chi a’ch gwybodaeth ar unwaith.",
           "paragraph_two": "Os yw’r newidiadau hyn yn effeithio ar sut mae eich gwybodaeth bersonol yn cael ei phrosesu, bydd GDS yn rhoi gwybod i chi.",
-          "paragraph_three": "Diweddarwyd diwethaf: 11 Ebrill 2023"
+          "paragraph_three": "Diweddarwyd diwethaf: 30 Mai 2023"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1385,7 +1385,7 @@
           "header": "Changes to this notice",
           "paragraph_one": "We may change this privacy notice. In that case, the ‘last updated’ date of this document will also change. Any changes to this privacy notice will apply to you and your information immediately.",
           "paragraph_two": "If these changes affect how your personal information is processed, GDS will let you know.",
-          "paragraph_three": "Last updated: 30 May 2023"
+          "paragraph_three": "Last updated: 31 May 2023"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1053,7 +1053,7 @@
           "paragraph_three": "We use an identity checking service provider called Iproov and their subcontractors Veriff and Innovalor to conduct these checks. Iproov acts as a data processor with Veriff and Innovalor as sub-processors, which means that they may only process your personal data for the sole purpose of fulfilling our instructions.",
           "paragraph_four": "We need to check your identity document security features to prove that they are genuine documents.",
           "paragraph_five": "For driving licences, you will need to take a photo of the front and back of your licence with your phone camera. The app will require permission to access your camera and photos for this.",
-          "paragraph_six": "For e-passports and biometric residence permits, the App will read your document information from its near field communication (NFC) chip.",
+          "paragraph_six": "For e-passports and biometric residence permits, the app will read your document information from its near field communication (NFC) chip.",
           "paragraph_seven": "We collect the following information",
           "list_two": {
             "item_one": "name",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1052,34 +1052,41 @@
           },
           "paragraph_three": "We use an identity checking service provider called Iproov and their subcontractors Veriff and Innovalor to conduct these checks. Iproov acts as a data processor with Veriff and Innovalor as sub-processors, which means that they may only process your personal data for the sole purpose of fulfilling our instructions.",
           "paragraph_four": "We need to check your identity document security features to prove that they are genuine documents.",
+          "paragraph_five": "For driving licences, you will need to take a photo of the front and back of your licence with your phone camera. The app will require permission to access your camera and photos for this.",
+          "paragraph_six": "For e-passports and biometric residence permits, the App will read your document information from its near field communication (NFC) chip.",
+          "paragraph_seven": "We collect the following information",
           "list_two": {
-            "item_one": "For drivers’ licences, you will need to take a photo of the front and back of your licence with your phone camera. The App will require permission to access your camera and photos for this.",
-            "item_two": "For e-passports, the App will read your passport information from your document’s Near Field Communication (NFC) chip.",
-            "item_three": "When Iproov has completed the check, they send us the outcome of the check and your driving licence or passport information."
+            "item_one": "name",
+            "item_two": "date of birth",
+            "item_three": "address (driving licences only)",
+            "item_four": "document number",
+            "item_five": "expiry date",
+            "item_six": "issuing country",
+            "item_seven": "nationality (except driving licences)",
+            "item_eight": "photo image"
           },
-          "paragraph_five": "We do a “liveness” check to prove whether a user is a real person and not anything that might impersonate an individual such as a mannequin, wax figure, 3D mask, picture or deepfake.",
-          "list_three": {
-            "item_one": "You will need to take a selfie video using your phone camera. The App will require permission to access your camera and videos for this. This check is conducted in real-time which means that neither we nor Iproov store the video.",
-            "item_two": "When Iproov has completed the check, they send us the outcome of the check."
-          },
-          "paragraph_six": "We do a likeness check to prove that you are the same person as in your identity document photo.",
-          "paragraph_seven": "This check uses a still image generated from your selfie video and your identity document photo to measure the unique patterns of your face. This is called facial biometric data. The biometric data from both images is compared to establish whether the user is the actual owner of the identity document.",
-          "paragraph_eight": "When Iproov has completed the check, they send us the outcome of the check.",
+          "paragraph_eight": "When Iproov has completed the check, they send us the outcome of the check and your identity document information.",
+          "paragraph_nine": "We do a “liveness” check to prove whether a user is a real person and not anything that might impersonate an individual such as a mannequin, wax figure, 3D mask, picture or deepfake.",
+          "paragraph_ten": "You will need to take a selfie video using your phone camera. The App will require permission to access your camera and videos for this. This check is conducted in real-time which means that neither we nor Iproov store the video.",
+          "paragraph_eleven": "When Iproov has completed the check, they send us the outcome of the check.",
+          "paragraph_twelve": "We do a likeness check to prove that you are the same person as in your identity document photo.",
+          "paragraph_thirteen": "This check uses a still image generated from your selfie video and your identity document photo to measure the unique patterns of your face. This is called facial biometric data. The biometric data from both images is compared to establish whether the user is the actual owner of the identity document.",
+          "paragraph_fourteen": "When Iproov has completed the check, they send us the outcome of the check.",
           "sub_header_two": "Fraud check",
-          "paragraph_nine": "We use an identity checking service provider called Experian to:",
+          "paragraph_fifteen": "We use an identity checking service provider called Experian to:",
           "list_four": {
             "item_one": "conduct a fraud check to look for any signs that your identity has been stolen or misused",
             "item_two": "check whether there is a record of you existing over time"
           },
-          "paragraph_ten": {
+          "paragraph_sixteen": {
             "part_one": "They do so as an independent data controller in accordance with their",
             "link": {
               "link_text": "privacy notice",
               "link_href": "https://www.experian.co.uk/consumer/privacy.html"
             }
           },
-          "paragraph_eleven": "When you have completed the checks above using the App, you will be returned to the GOV.UK One Login website where we will collect your name, date of birth and address. We send these to Experian so they can conduct a counter fraud check.",
-          "paragraph_twelve": "When Experian has completed the check, they send us a fraud score, plus details of any associated fraudulent activity."
+          "paragraph_seventeen": "When you have completed the checks above using the App, you will be returned to the GOV.UK One Login website where we will collect your name, date of birth and address. We send these to Experian so they can conduct a counter fraud check.",
+          "paragraph_eighteen": "When Experian has completed the check, they send us a fraud score, plus details of any associated fraudulent activity."
         },
         "using_web_to_prove_identity": {
           "header": "Using your web browser to prove your identity",
@@ -1378,7 +1385,7 @@
           "header": "Changes to this notice",
           "paragraph_one": "We may change this privacy notice. In that case, the ‘last updated’ date of this document will also change. Any changes to this privacy notice will apply to you and your information immediately.",
           "paragraph_two": "If these changes affect how your personal information is processed, GDS will let you know.",
-          "paragraph_three": "Last updated: 11 April 2023"
+          "paragraph_three": "Last updated: 30 May 2023"
         }
       }
     },


### PR DESCRIPTION
## What?
Text and HTML semantics changes to the "Using the GOV.UK ID Check app to prove your identity" section of the privacy notice (i.e. some items that were previously lists are now paragraphs etc.). This also changes the last published date to 30 May 2023. 

## Why?
To reflect the fact that the ID journey will start using data from biometric residence permits (BRPs).

## Changes

### English version
<img width="681" alt="Screenshot 2023-05-22 at 16 36 58" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/6da6c409-7a05-4cb7-b54c-6d78a24b176f">

### Welsh version
<img width="668" alt="Screenshot 2023-05-22 at 16 36 33" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/bc69db4f-825a-458f-a098-5dd51ef4ee14">

## Change have been demonstrated
Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Another change to the privacy notice is scheduled to go live on the same day (30 May). The PR for this is https://github.com/alphagov/di-authentication-frontend/pull/1010
