### PR TITLE
added config files

### DIFF
--- a/ci/terraform/api.tf
+++ b/ci/terraform/api.tf
@@ -2,7 +2,7 @@ data "terraform_remote_state" "api" {
   backend = "s3"
   config = {
     bucket   = var.common_state_bucket
-    key      = "${var.environment}-terraform.tfstate"
+    key      = "${var.environment}-oidc-terraform.tfstate"
     role_arn = var.deployer_role_arn
     region   = var.aws_region
   }

--- a/ci/terraform/dev.tfvars
+++ b/ci/terraform/dev.tfvars
@@ -1,0 +1,14 @@
+basic_auth_bypass_cidr_blocks = []
+deployer_role_arn             = "arn:aws:iam::761723964695:role/deployer-role-pipeline-dev"
+common_state_bucket           = "digital-identity-dev-tfstate"
+incoming_traffic_cidr_blocks  = ["0.0.0.0/0"]
+logging_endpoint_arns         = []
+image_uri                     = "114407264696.dkr.ecr.eu-west-2.amazonaws.com/frontend-image-repository:0.0.717"
+image_tag                     = "0.0.717"
+image_digest                  = "sha256:580e7ee8f530a34afeefb1c25a8fdd7131654ecf63ba3daa67b3871d463e7210"
+sidecar_image_uri             = "114407264696.dkr.ecr.eu-west-2.amazonaws.com/basic-auth-sidecar-image-repository:401949c2915b552bf21513b8fc79233dea2d7e4e"
+sidecar_image_tag             = "401949c2915b552bf21513b8fc79233dea2d7e4e"
+sidecar_image_digest          = "sha256:44f84dd16e44dcbe1ed9331a3b66aba07a290f75bca232084b975a2cfed896d5"
+support_language_cy           = "0"
+support_account_recovery      = "1"
+support_international_numbers = "1"

--- a/ci/terraform/read_secrets.sh
+++ b/ci/terraform/read_secrets.sh
@@ -1,0 +1,15 @@
+ENVIRONMENT=$1
+
+if [ "$ENVIRONMENT" = "dev" ]; then
+	ENVIRONMENT="build";
+fi
+
+secrets=$(aws secretsmanager list-secrets --filter Key="name",Values="/deploy/$ENVIRONMENT/" --region eu-west-2 | jq -c '.SecretList[]')
+
+for i in $secrets; do
+  arn=$(echo $i | jq -r '.ARN')
+  name=$(echo $i | jq -r '.Name | split("/") | last')
+  value=$(aws secretsmanager get-secret-value --secret-id $arn | jq -r '.SecretString')
+  VAR=(TF_VAR_$name=$value)
+  export $VAR
+done


### PR DESCRIPTION
## What & Why?

To make the `auth-deploy-pipeline` run terraform the following have been created for each component:
- `dev.tfvars` file containing the input vars
- A `read_secretes.sh` file to get any secrets from SM

[PLAT-1487: Create the configs for frontend terraform component](https://govukverify.atlassian.net/browse/PLAT-1487)
Passing build for all comps: https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/auth-deploy-pipeline-dev-Pipeline-1QOPM6CF737BW/view?region=eu-west-2#
