### PR TITLE
AUT-1296: Fix new journey after multiple incorrect passwords

### DIFF
--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -49,6 +49,9 @@ export const ERROR_CODES = {
 };
 
 export const ERROR_CODE_MAPPING: { [p: string]: string } = {
+  [ERROR_CODES.ACCOUNT_LOCKED]: pathWithQueryParam(
+    PATH_NAMES["ACCOUNT_LOCKED"]
+  ),
   [ERROR_CODES.INVALID_PASSWORD_MAX_ATTEMPTS_REACHED]: pathWithQueryParam(
     PATH_NAMES["ACCOUNT_LOCKED"]
   ),

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -140,7 +140,10 @@ const authStateMachine = createMachine(
           ],
         },
         meta: {
-          optionalPaths: [PATH_NAMES.SIGN_IN_OR_CREATE],
+          optionalPaths: [
+            PATH_NAMES.SIGN_IN_OR_CREATE,
+            PATH_NAMES.ACCOUNT_LOCKED,
+          ],
         },
       },
       [PATH_NAMES.ACCOUNT_NOT_FOUND]: {

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -4,6 +4,7 @@ import { ExpressRouteFunc } from "../../types";
 import { enterEmailService } from "./enter-email-service";
 import { EnterEmailServiceInterface } from "./types";
 import {
+  ERROR_CODES,
   getErrorPathByCode,
   getNextPathAndUpdateJourney,
 } from "../common/constants";
@@ -38,6 +39,9 @@ export function enterEmailPost(
     );
 
     if (!result.success) {
+      if (result.data.code === ERROR_CODES.ACCOUNT_LOCKED) {
+        return res.redirect(getErrorPathByCode(result.data.code));
+      }
       throw new BadRequestError(result.data.message, result.data.code);
     }
 

--- a/src/components/enter-email/tests/enter-email-controller.test.ts
+++ b/src/components/enter-email/tests/enter-email-controller.test.ts
@@ -10,7 +10,7 @@ import {
   enterEmailPost,
 } from "../enter-email-controller";
 import { EnterEmailServiceInterface } from "../types";
-import { JOURNEY_TYPE } from "../../common/constants";
+import { JOURNEY_TYPE, ERROR_CODES } from "../../common/constants";
 import { PATH_NAMES } from "../../../app.constants";
 import { SendNotificationServiceInterface } from "../../common/send-notification/types";
 import {
@@ -126,6 +126,26 @@ describe("enter email controller", () => {
       );
 
       expect(fakeService.userExists).not.to.been.called;
+    });
+
+    it("should redirect to /account-locked when the account is locked", async () => {
+      const fakeService: EnterEmailServiceInterface = {
+        userExists: sinon.fake.returns({
+          success: false,
+          data: {
+            code: ERROR_CODES.ACCOUNT_LOCKED,
+          },
+        }),
+      };
+
+      req.body.email = "test@test.com";
+      res.locals.sessionId = "sadl990asdald";
+      req.path = PATH_NAMES.ENTER_EMAIL_SIGN_IN;
+
+      await enterEmailPost(fakeService)(req as Request, res as Response);
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.ACCOUNT_LOCKED);
+      expect(fakeService.userExists).to.have.been.calledOnce;
     });
   });
 


### PR DESCRIPTION
## What?

Fixes a user-facing issue where users who had entered an incorrect passwords enough times to be presented with "You entered the wrong password too many times" were presented with "Sorry, there is a problem" at the point of submitting their email in a new journey.

This has been achieved by: 

* adding a condition to `enter-email-controller.ts` so responses from the `userExists()` service which have both `result.success` as falsy and `result.data.code` for `ACCOUNT_LOCKED` are redirected to the route for that error code
* updating the state machine to permit progress from `ENTER_EMAIL_SIGN_IN` to `ACCOUNT_LOCKED` as an optional path
* adding an error code mapping between the `ACCOUNT_LOCKED` error code and path
* introducing a unit test to confirm that `res.redirect` is called once and with the `ACCOUNT_LOCKED` path

## Why?

Bug fix.
