### PR TITLE
AUT-1304 - Ensure Account Recovery links persist 

### DIFF
--- a/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
+++ b/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
@@ -26,6 +26,8 @@
     <form id="form-tracking" action="/enter-authenticator-app-code" method="post" novalidate="novalidate">
 
         <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+        <input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted}}"/>
+        <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
 
         {{ govukInput({
             label: {

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -12,6 +12,8 @@
   <form id="form-tracking" action="/enter-authenticator-app-code" method="post" novalidate="novalidate">
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="isAccountRecoveryPermitted" value="{{isAccountRecoveryPermitted}}"/>
+    <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
 
     {{ govukInput({
       label: {

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-controller.test.ts
@@ -32,6 +32,7 @@ describe("enter authenticator app code controller", () => {
       i18n: { language: "en" },
     });
     res = mockResponse();
+    process.env.SUPPORT_ACCOUNT_RECOVERY = "1";
   });
 
   afterEach(() => {
@@ -39,11 +40,13 @@ describe("enter authenticator app code controller", () => {
   });
 
   describe("enterAuthenticatorAppCodeGet", () => {
-    it("should render enter mfa code view", async () => {
+    it("should render enter mfa code view with isAccountRecoveryPermitted true when user is permitted to perform account recovery and account recovery is enabled for environment", async () => {
       const fakeService: AccountRecoveryInterface = {
         accountRecovery: sinon.fake.returns({
           success: true,
-          isAccountRecoveryPermitted: true,
+          data: {
+            accountRecoveryPermitted: true,
+          },
         }),
       };
 
@@ -53,7 +56,63 @@ describe("enter authenticator app code controller", () => {
       );
 
       expect(res.render).to.have.calledWith(
-        "enter-authenticator-app-code/index.njk"
+        "enter-authenticator-app-code/index.njk",
+        {
+          isAccountRecoveryPermitted: true,
+          checkEmailLink:
+            PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
+            "?type=AUTH_APP",
+        }
+      );
+    });
+
+    it("should render enter mfa code view with isAccountRecoveryPermitted false when user is not permitted to perform account recovery", async () => {
+      const fakeService: AccountRecoveryInterface = {
+        accountRecovery: sinon.fake.returns({
+          success: true,
+          data: {
+            accountRecoveryPermitted: false,
+          },
+        }),
+      };
+
+      await enterAuthenticatorAppCodeGet(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.render).to.have.calledWith(
+        "enter-authenticator-app-code/index.njk",
+        {
+          isAccountRecoveryPermitted: false,
+          checkEmailLink:
+            PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
+            "?type=AUTH_APP",
+        }
+      );
+    });
+
+    it("should render enter mfa code view with isAccountRecoveryPermitted false when account recovery is disable for the environment", async () => {
+      process.env.SUPPORT_ACCOUNT_RECOVERY = "0";
+      const fakeService: AccountRecoveryInterface = {
+        accountRecovery: sinon.fake.returns({
+          success: true,
+          data: {
+            accountRecoveryPermitted: true,
+          },
+        }),
+      };
+
+      await enterAuthenticatorAppCodeGet(fakeService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.render).to.have.calledWith(
+        "enter-authenticator-app-code/index.njk",
+        {
+          isAccountRecoveryPermitted: false,
+        }
       );
     });
 
@@ -63,6 +122,9 @@ describe("enter authenticator app code controller", () => {
       const fakeService: AccountRecoveryInterface = {
         accountRecovery: sinon.fake.returns({
           success: true,
+          data: {
+            accountRecoveryPermitted: true,
+          },
         }),
       };
 
@@ -72,7 +134,13 @@ describe("enter authenticator app code controller", () => {
       );
 
       expect(res.render).to.have.calledWith(
-        UPLIFT_REQUIRED_AUTH_APP_TEMPLATE_NAME
+        UPLIFT_REQUIRED_AUTH_APP_TEMPLATE_NAME,
+        {
+          isAccountRecoveryPermitted: true,
+          checkEmailLink:
+            PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
+            "?type=AUTH_APP",
+        }
       );
     });
 
@@ -82,6 +150,9 @@ describe("enter authenticator app code controller", () => {
       const fakeService: AccountRecoveryInterface = {
         accountRecovery: sinon.fake.returns({
           success: true,
+          data: {
+            accountRecoveryPermitted: true,
+          },
         }),
       };
 
@@ -91,7 +162,13 @@ describe("enter authenticator app code controller", () => {
       );
 
       expect(res.render).to.have.calledWith(
-        ENTER_AUTH_APP_CODE_DEFAULT_TEMPLATE_NAME
+        ENTER_AUTH_APP_CODE_DEFAULT_TEMPLATE_NAME,
+        {
+          isAccountRecoveryPermitted: true,
+          checkEmailLink:
+            PATH_NAMES.CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES +
+            "?type=AUTH_APP",
+        }
       );
     });
   });

--- a/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
+++ b/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
@@ -25,6 +25,8 @@
     <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">
         <input type="hidden" name="phoneNumber" value="{{ phoneNumber }}" />
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <input type="hidden" name="supportAccountRecovery" value="{{supportAccountRecovery}}"/>
+        <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
 
         {{ govukInput({
             label: {

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -25,6 +25,8 @@
   <form id="form-tracking" action="/enter-code" method="post" novalidate="novalidate">
     <input type="hidden" name="phoneNumber" value="{{phoneNumber}}"/>
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+    <input type="hidden" name="supportAccountRecovery" value="{{supportAccountRecovery}}"/>
+    <input type="hidden" name="checkEmailLink" value="{{checkEmailLink}}"/>
 
     {{ govukInput({
   label: {


### PR DESCRIPTION
## What?

- Ensure the link to perform account recovery persists when either the wrong OTP is entered or no OTP is entered and the user clicks continue 
- Add more unit tests to the enter-authenticator-app-code-controller.ts

## Why?

- When the page re-renders due to no OTP being entered, we need to ensure that the fields supportAccountRecovery and checkEmailLink persist otherwise the link to change how you get security codes disappears
- We can achieve this by passing supportAccountRecovery and checkEmailLink as hidden fields