### PR TITLE
AUT:1281: OTP Block for Account Recovery journey

### DIFF
--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -12,6 +12,19 @@ import { sendNotificationService } from "../common/send-notification/send-notifi
 import xss from "xss";
 
 export function resendEmailCodeGet(req: Request, res: Response): void {
+  if (
+    req.session.user.wrongCodeEnteredAccountRecoveryLock &&
+    new Date().getTime() <
+      new Date(req.session.user.wrongCodeEnteredAccountRecoveryLock).getTime()
+  ) {
+    const newCodeLink = req.query?.isResendCodeRequest
+      ? "/security-code-check-time-limit?isResendCodeRequest=true"
+      : "/security-code-check-time-limit";
+    return res.render("security-code-error/index-wait.njk", {
+      newCodeLink,
+    });
+  }
+
   res.render("resend-email-code/index.njk", {
     emailAddress: req.session.user.email,
     requestNewCode:

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -6,18 +6,33 @@ import {
 } from "../common/constants";
 import { PATH_NAMES } from "../../app.constants";
 import {
+  getAccountRecoveryCodeEnteredWrongBlockDurationInMinutes,
   getCodeEnteredWrongBlockDurationInMinutes,
   getCodeRequestBlockDurationInMinutes,
 } from "../../config";
 
 export function securityCodeInvalidGet(req: Request, res: Response): void {
   const isNotEmailCode =
-    req.query.actionType !== SecurityCodeErrorType.EmailMaxRetries;
+    req.query.actionType !== SecurityCodeErrorType.EmailMaxRetries &&
+    req.query.actionType !==
+      SecurityCodeErrorType.ChangeSecurityCodesEmailMaxRetries;
+
   if (isNotEmailCode) {
     req.session.user.wrongCodeEnteredLock = new Date(
       Date.now() + getCodeEnteredWrongBlockDurationInMinutes() * 60000
     ).toUTCString();
   }
+
+  if (
+    req.query.actionType ===
+    SecurityCodeErrorType.ChangeSecurityCodesEmailMaxRetries
+  ) {
+    req.session.user.wrongCodeEnteredAccountRecoveryLock = new Date(
+      Date.now() +
+        getAccountRecoveryCodeEnteredWrongBlockDurationInMinutes() * 60000
+    ).toUTCString();
+  }
+
   return res.render("security-code-error/index.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
     isAuthApp: isAuthApp(req.query.actionType as SecurityCodeErrorType),

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,3 +124,10 @@ export function getCodeRequestBlockDurationInMinutes(): number {
 export function getCodeEnteredWrongBlockDurationInMinutes(): number {
   return Number(process.env.CODE_ENTERED_WRONG_BLOCKED_MINUTES) || 15;
 }
+
+export function getAccountRecoveryCodeEnteredWrongBlockDurationInMinutes(): number {
+  return (
+    Number(process.env.ACCOUNT_RECOVERY_CODE_ENTERED_WRONG_BLOCKED_MINUTES) ||
+    15
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export interface UserSession {
   featureFlags?: any;
   wrongCodeEnteredLock?: string;
   codeRequestLock?: string;
+  wrongCodeEnteredAccountRecoveryLock?: string;
   isAccountRecoveryPermitted?: boolean;
   isAccountRecoveryJourney?: boolean;
   isAccountRecoveryCodeResent?: boolean;


### PR DESCRIPTION
## What?

Ensure user cannot request new code when the user has entered invalid email verification code too many times before the 15 minute blocked period.

- A new lock `wrongCodeEnteredAccountRecoveryLock` is stored in the user session when user is blocked from entering invalid verification code too many times. The API returns error code `1046`

## Why?

To block users from requesting a new code multiple times.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

## Related PRs

[Backend change](https://github.com/alphagov/di-authentication-api/pull/3017)
