### PR TITLE
AUT-1306 - Ensure correct template is rendered when validation error is thrown

### DIFF
--- a/src/components/account-recovery/check-your-email-security-codes/check-your-email-security-codes-validation.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/check-your-email-security-codes-validation.ts
@@ -14,6 +14,8 @@ export function validateCheckYourEmailRequest(): ValidationChainFunc {
       numbersOnlyKey:
         "pages.checkYourEmailSecurityCodes.code.validationError.invalidFormat",
     }),
-    validateBodyMiddleware("check-your-email/index.njk"),
+    validateBodyMiddleware(
+      "account-recovery/check-your-email-security-codes/index.njk"
+    ),
   ];
 }


### PR DESCRIPTION
## What?

- When the account recovery enter email OTP causes an error either by no OTP entered or an incorrect OTP entered, then make sure that the current template is persisted by passing in the correct template name in `check-your-email-security-codes-validation.ts`

## Why?

- The template was incorrectly displaying the `check-your-email/index.njk` when the template failed validation 
