### PR TITLE
AUT-1305 - Store verified account recovery method type in session

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -62,10 +62,6 @@ export const PATH_NAMES = {
   CHANGE_SECURITY_CODES: "/change-security-codes",
   CHECK_YOUR_EMAIL_CHANGE_SECURITY_CODES: "/check-email-change-security-codes",
   CHANGE_SECURITY_CODES_CONFIRMATION: "/change-codes-confirmed",
-  CHANGE_SECURITY_CODES_CONFIRMATION_SMS:
-    "/change-codes-confirmed" + "?type=" + MFA_METHOD_TYPE.SMS,
-  CHANGE_SECURITY_CODES_CONFIRMATION_AUTH_APP:
-    "/change-codes-confirmed" + "?type=" + MFA_METHOD_TYPE.AUTH_APP,
 };
 
 export const HREF_BACK = {

--- a/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-controller.ts
@@ -6,7 +6,7 @@ import { getNextPathAndUpdateJourney } from "../../common/constants";
 
 export function changeSecurityCodesConfirmationGet(): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const type = req.query.type;
+    const type = req.session.user.accountRecoveryVerifiedMfaType;
     if (type === MFA_METHOD_TYPE.SMS || type === MFA_METHOD_TYPE.AUTH_APP) {
       res.render(
         "account-recovery/change-security-codes-confirmation/index.njk",
@@ -27,6 +27,7 @@ export function changeSecurityCodesConfirmationPost(
   req: Request,
   res: Response
 ): void {
+  req.session.user.accountRecoveryVerifiedMfaType = null;
   const nextPath = getNextPathAndUpdateJourney(
     req,
     req.path,

--- a/src/components/account-recovery/change-security-codes-confirmation/tests/change-security-codes-confirmation-controller.test.ts
+++ b/src/components/account-recovery/change-security-codes-confirmation/tests/change-security-codes-confirmation-controller.test.ts
@@ -38,7 +38,7 @@ describe("change security codes confirmation controller", () => {
       mfaMethodType
     ) {
       it(`should render the change security codes codes confirmation page for mfaMethodType ${mfaMethodType}`, async () => {
-        req.query.type = mfaMethodType;
+        req.session.user.accountRecoveryVerifiedMfaType = mfaMethodType;
         req.session.user.email = "security.codes.changed@testtwofactorauth.org";
         req.session.user.redactedPhoneNumber = "*******1234";
 

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -73,10 +73,16 @@ export const checkYourPhonePost = (
       throw new BadRequestError(result.data.message, result.data.code);
     }
 
-    const notificationType =
-      isAccountRecoveryPermitted && isAccountRecoveryJourney
-        ? NOTIFICATION_TYPE.CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION
-        : NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION;
+    const accountRecoveryEnabledJourney =
+      isAccountRecoveryPermitted && isAccountRecoveryJourney;
+
+    let notificationType = NOTIFICATION_TYPE.ACCOUNT_CREATED_CONFIRMATION;
+
+    if (accountRecoveryEnabledJourney) {
+      req.session.user.accountRecoveryVerifiedMfaType = MFA_METHOD_TYPE.SMS;
+      notificationType =
+        NOTIFICATION_TYPE.CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION;
+    }
 
     await notificationService.sendNotification(
       res.locals.sessionId,
@@ -95,8 +101,7 @@ export const checkYourPhonePost = (
         USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED,
         {
           isIdentityRequired: req.session.user.isIdentityRequired,
-          isAccountRecoveryJourney:
-            isAccountRecoveryPermitted && isAccountRecoveryJourney,
+          isAccountRecoveryJourney: accountRecoveryEnabledJourney,
         },
         res.locals.sessionId
       )

--- a/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
+++ b/src/components/check-your-phone/tests/check-your-phone-controller.test.ts
@@ -117,7 +117,7 @@ describe("check your phone controller", () => {
         ""
       );
       expect(res.redirect).to.have.calledWith(
-        PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_SMS
+        PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION
       );
     });
 

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -260,7 +260,7 @@ const authStateMachine = createMachine(
         on: {
           [USER_JOURNEY_EVENTS.MFA_CODE_VERIFIED]: [
             {
-              target: [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_AUTH_APP],
+              target: [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION],
               cond: "isAccountRecoveryJourney",
             },
             {
@@ -293,7 +293,7 @@ const authStateMachine = createMachine(
         on: {
           [USER_JOURNEY_EVENTS.PHONE_NUMBER_VERIFIED]: [
             {
-              target: [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_SMS],
+              target: [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION],
               cond: "isAccountRecoveryJourney",
             },
             {
@@ -627,16 +627,6 @@ const authStateMachine = createMachine(
           [USER_JOURNEY_EVENTS.CHANGE_SECURITY_CODES_COMPLETED]: [
             { target: [PATH_NAMES.AUTH_CODE] },
           ],
-        },
-      },
-      [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_SMS]: {
-        meta: {
-          optionalPaths: [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION],
-        },
-      },
-      [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_AUTH_APP]: {
-        meta: {
-          optionalPaths: [PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION],
         },
       },
     },

--- a/src/components/setup-authenticator-app/tests/setup-authenticator-app-controller.test.ts
+++ b/src/components/setup-authenticator-app/tests/setup-authenticator-app-controller.test.ts
@@ -121,7 +121,7 @@ describe("setup-authenticator-app controller", () => {
       );
 
       expect(res.redirect).to.have.calledWith(
-        PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION_AUTH_APP
+        PATH_NAMES.CHANGE_SECURITY_CODES_CONFIRMATION
       );
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface UserSession {
   isAccountRecoveryPermitted?: boolean;
   isAccountRecoveryJourney?: boolean;
   isAccountRecoveryCodeResent?: boolean;
+  accountRecoveryVerifiedMfaType?: string;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What?

- Store the verified account recovery method type in the session and finally clear this when they select continue on the confirmation page.
- Clear the phone number from the user session when the user has successfully verified their authenticator apps.
- Remove unused code and redundant state transitions

## Why?

- We were previously passing the account recovery method type to the change security codes confirmation page via a query parameter. This opened it up to be changed by the user and allowed the content to change. There was a small flaw where this allowed the last few digits of the old users mobile to be displayed.
