### PR TITLE
AUT-1311 - Change OTP validity time for account recovery

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -535,7 +535,7 @@
       "code": {
         "paragraph1": "Mae’r e-bost yn cynnwys cod diogelwch 6 digid. Ar ôl i chi roi eich cod, byddwch yn gallu newid sut i gael codau diogelwch pan fyddwch yn mewngofnodi.",
         "paragraph2": "Efallai y bydd eich e-bost yn cymryd ychydig funudau i gyrraedd. Os na chewch e-bost, edrychwch ar eich ffolder spam.",
-        "paragraph3": "Bydd y cod yn dod i ben ar ôl 2 awr.",
+        "paragraph3": "Bydd y cod yn dod i ben ar ôl 15 munud.",
         "label": "Rhowch y cod diogelwch 6 digid",
         "validationError": {
           "required": "Rhowch y cod diogelwch",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -535,7 +535,7 @@
       "code": {
         "paragraph1": "The email contains a 6 digit security code. After you enter the code, you’ll be able to change how you get security codes when you sign in.",
         "paragraph2": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
-        "paragraph3": "The code will expire after 2 hours.",
+        "paragraph3": "The code will expire after 15 minutes.",
         "label": "Enter the 6 digit security code",
         "validationError": {
           "required": "Enter the security code",


### PR DESCRIPTION
## What?

- Update content of account recovery email OTP to state it is only valid for 15 mins.

## Why?

- Email OTP validity for account recovery is 15 mins instead of 2 hours. Update content to reflect this.

## Change have been demonstrated
![Screenshot 2023-06-01 at 15 30 43](https://github.com/alphagov/di-authentication-frontend/assets/35073557/d8b9b65e-14d4-405e-b983-4d379a998e9d)


