### PR TITLE
AUT-1282: Create new code request lock for account recovery journey

### DIFF
--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -87,10 +87,17 @@ export function securityCodeCheckTimeLimit(): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const { sessionId } = res.locals;
     const isAccountRecoveryJourney = req.session.user?.isAccountRecoveryJourney;
+
+    const currentTime = new Date().getTime();
+    const codeRequestLockTime = req.session.user.codeRequestLock;
+    const codeRequestAccountRecoveryLockTime =
+      req.session.user.codeRequestAccountRecoveryLock;
+
     if (
-      req.session.user.codeRequestLock &&
-      new Date().getTime() <
-        new Date(req.session.user.codeRequestLock).getTime()
+      (codeRequestLockTime &&
+        currentTime < new Date(codeRequestLockTime).getTime()) ||
+      (codeRequestAccountRecoveryLockTime &&
+        currentTime < new Date(codeRequestAccountRecoveryLockTime).getTime())
     ) {
       const newCodeLink = req.query?.isResendCodeRequest
         ? "/security-code-check-time-limit?isResendCodeRequest=true"

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -8,6 +8,7 @@ import { PATH_NAMES } from "../../app.constants";
 import {
   getAccountRecoveryCodeEnteredWrongBlockDurationInMinutes,
   getCodeEnteredWrongBlockDurationInMinutes,
+  getCodeRequestAccountRecoveryBlockDurationInMinutes,
   getCodeRequestBlockDurationInMinutes,
 } from "../../config";
 
@@ -44,9 +45,19 @@ export function securityCodeTriesExceededGet(
   req: Request,
   res: Response
 ): void {
-  req.session.user.codeRequestLock = new Date(
-    Date.now() + getCodeRequestBlockDurationInMinutes() * 60000
-  ).toUTCString();
+  if (
+    req.query.actionType ===
+    SecurityCodeErrorType.ChangeSecurityCodesEmailMaxCodesSent
+  ) {
+    req.session.user.codeRequestAccountRecoveryLock = new Date(
+      Date.now() + getCodeRequestAccountRecoveryBlockDurationInMinutes() * 60000
+    ).toUTCString();
+  } else {
+    req.session.user.codeRequestLock = new Date(
+      Date.now() + getCodeRequestBlockDurationInMinutes() * 60000
+    ).toUTCString();
+  }
+
   return res.render("security-code-error/index-too-many-requests.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
     isResendCodeRequest: req.query.isResendCodeRequest,

--- a/src/config.ts
+++ b/src/config.ts
@@ -131,3 +131,9 @@ export function getAccountRecoveryCodeEnteredWrongBlockDurationInMinutes(): numb
     15
   );
 }
+
+export function getCodeRequestAccountRecoveryBlockDurationInMinutes(): number {
+  return (
+    Number(process.env.CODE_REQUEST_ACCOUNT_RECOVERY_BLOCKED_MINUTES) || 15
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export interface UserSession {
   featureFlags?: any;
   wrongCodeEnteredLock?: string;
   codeRequestLock?: string;
+  codeRequestAccountRecoveryLock?: string;
   wrongCodeEnteredAccountRecoveryLock?: string;
   isAccountRecoveryPermitted?: boolean;
   isAccountRecoveryJourney?: boolean;


### PR DESCRIPTION
## What?

Initiate a 15 minutes block for a user in account recovery journey when they requested an OTP to be sent more than 5 times.

- Create new `codeRequestAccountRecoveryLock` in user session to store the block duration to stop users from requesting a new code

## Why?

To block users from requesting a new code multiple times.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated
