### PR TITLE
BAU - Add journeyType to send notification requests

### DIFF
--- a/src/components/account-not-found/account-not-found-controller.ts
+++ b/src/components/account-not-found/account-not-found-controller.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from "express";
-import { NOTIFICATION_TYPE, SERVICE_TYPE } from "../../app.constants";
+import {
+  JOURNEY_TYPE,
+  NOTIFICATION_TYPE,
+  SERVICE_TYPE,
+} from "../../app.constants";
 import { ExpressRouteFunc } from "../../types";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
@@ -43,7 +47,8 @@ export function accountNotFoundPost(
       NOTIFICATION_TYPE.VERIFY_EMAIL,
       req.ip,
       persistentSessionId,
-      xss(req.cookies.lng as string)
+      xss(req.cookies.lng as string),
+      JOURNEY_TYPE.REGISTRATION
     );
 
     if (!result.success) {

--- a/src/components/account-recovery/check-your-email-security-codes/send-email-otp-middleware.ts
+++ b/src/components/account-recovery/check-your-email-security-codes/send-email-otp-middleware.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import { sendNotificationService } from "../../common/send-notification/send-notification-service";
-import { NOTIFICATION_TYPE } from "../../../app.constants";
+import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../../app.constants";
 import { getErrorPathByCode } from "../../common/constants";
 import { BadRequestError } from "../../../utils/error";
 import xss from "xss";
@@ -25,7 +25,8 @@ export function sendEmailOtp(
       NOTIFICATION_TYPE.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
       req.ip,
       persistentSessionId,
-      xss(req.cookies.lng as string)
+      xss(req.cookies.lng as string),
+      JOURNEY_TYPE.ACCOUNT_RECOVERY
     );
 
     if (sendNotificationResponse.success) {

--- a/src/components/common/send-notification/send-notification-service.ts
+++ b/src/components/common/send-notification/send-notification-service.ts
@@ -19,6 +19,7 @@ export function sendNotificationService(
     sourceIp: string,
     persistentSessionId: string,
     userLanguage: string,
+    journeyType?: string,
     phoneNumber?: string,
     requestNewCode?: boolean
   ): Promise<ApiResponseResult<DefaultApiResponse>> {
@@ -33,6 +34,10 @@ export function sendNotificationService(
 
     if (requestNewCode) {
       payload.requestNewCode = requestNewCode;
+    }
+
+    if (journeyType) {
+      payload.journeyType = journeyType;
     }
 
     const response = await axios.client.post<DefaultApiResponse>(

--- a/src/components/common/send-notification/types.ts
+++ b/src/components/common/send-notification/types.ts
@@ -9,6 +9,7 @@ export interface SendNotificationServiceInterface {
     sourceIp: string,
     persistentSessionId: string,
     userLanguage: string,
+    journeyType?: string,
     phoneNumber?: string,
     requestNewCode?: boolean
   ) => Promise<ApiResponseResult<DefaultApiResponse>>;

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { NOTIFICATION_TYPE } from "../../app.constants";
+import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../app.constants";
 import { ExpressRouteFunc } from "../../types";
 import { enterEmailService } from "./enter-email-service";
 import { EnterEmailServiceInterface } from "./types";
@@ -99,7 +99,8 @@ export function enterEmailCreatePost(
       NOTIFICATION_TYPE.VERIFY_EMAIL,
       req.ip,
       persistentSessionId,
-      xss(req.cookies.lng as string)
+      xss(req.cookies.lng as string),
+      JOURNEY_TYPE.REGISTRATION
     );
 
     if (!sendNotificationResponse.success) {

--- a/src/components/enter-phone-number/enter-phone-number-controller.ts
+++ b/src/components/enter-phone-number/enter-phone-number-controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { NOTIFICATION_TYPE } from "../../app.constants";
+import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../app.constants";
 import { ExpressRouteFunc } from "../../types";
 import { redactPhoneNumber } from "../../utils/strings";
 import {
@@ -11,7 +11,10 @@ import { SendNotificationServiceInterface } from "../common/send-notification/ty
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { convertInternationalPhoneNumberToE164Format } from "../../utils/phone-number";
-import { supportInternationalNumbers } from "../../config";
+import {
+  supportAccountRecovery,
+  supportInternationalNumbers,
+} from "../../config";
 import xss from "xss";
 
 export function enterPhoneNumberGet(req: Request, res: Response): void {
@@ -25,9 +28,11 @@ export function enterPhoneNumberPost(
   service: SendNotificationServiceInterface = sendNotificationService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
+    const { email, isAccountRecoveryJourney, isAccountRecoveryPermitted } =
+      req.session.user;
     const hasInternationalPhoneNumber = req.body.hasInternationalPhoneNumber;
-    const { email } = req.session.user;
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+    const isAccountRecoveryEnabledForEnvironment = supportAccountRecovery();
     let phoneNumber;
 
     if (
@@ -44,6 +49,15 @@ export function enterPhoneNumberPost(
     req.session.user.redactedPhoneNumber = redactPhoneNumber(phoneNumber);
     req.session.user.phoneNumber = phoneNumber;
 
+    const accountRecovery =
+      isAccountRecoveryJourney &&
+      isAccountRecoveryPermitted &&
+      isAccountRecoveryEnabledForEnvironment;
+
+    const journeyType = accountRecovery
+      ? JOURNEY_TYPE.ACCOUNT_RECOVERY
+      : JOURNEY_TYPE.REGISTRATION;
+
     const sendNotificationResponse = await service.sendNotification(
       sessionId,
       clientSessionId,
@@ -52,6 +66,7 @@ export function enterPhoneNumberPost(
       req.ip,
       persistentSessionId,
       xss(req.cookies.lng as string),
+      journeyType,
       phoneNumber
     );
 

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { ExpressRouteFunc } from "../../types";
-import { NOTIFICATION_TYPE } from "../../app.constants";
+import { JOURNEY_TYPE, NOTIFICATION_TYPE } from "../../app.constants";
 import {
   getErrorPathByCode,
   getNextPathAndUpdateJourney,
@@ -40,6 +40,10 @@ export function resendEmailCodePost(
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
     const isAccountRecoveryJourney = req.session.user?.isAccountRecoveryJourney;
 
+    const journeyType = isAccountRecoveryJourney
+      ? JOURNEY_TYPE.ACCOUNT_RECOVERY
+      : JOURNEY_TYPE.REGISTRATION;
+
     const sendNotificationResponse = await notificationService.sendNotification(
       sessionId,
       clientSessionId,
@@ -48,6 +52,7 @@ export function resendEmailCodePost(
       req.ip,
       persistentSessionId,
       xss(req.cookies.lng as string),
+      journeyType,
       undefined,
       xss(req.body.requestNewCode as string) === "true"
     );


### PR DESCRIPTION
## What?

- Add journeyType to send notification requests

## Why?

- To allow the API to be able to differentiate between requests that use the same notification type but are from different journeys.