### PR TITLE
Remove Concourse reference from README.md file (AUT-1241)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ ANALYTICS_COOKIE_DOMAIN=localhost
 SERVICE_DOMAIN=localhost
 ```
 
-You can find the `API_BASE_URL` in [Concourse](https://cd.gds-reliability.engineering/teams/verify/pipelines/di-authentication-deployment) under the outputs within the deploy-oidc-api-{environment} job, where {environment} is the name of the environment you want to connect to.
-
 `UI_LOCALES` can be used be the stub to request specific locales when authorising.  Only 'en' and 'cy' are supported.
 
 ### Starting all services in Docker


### PR DESCRIPTION
## What and why?

We have migrated off Concourse, which means we need to ensure to not to reference it in our documentation. The README.md file is currently referencing Concourse in the section about setting environment variable, which we can just remove. 


## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change


