### PR TITLE
Remove Concourse reference from README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ ANALYTICS_COOKIE_DOMAIN=localhost
 SERVICE_DOMAIN=localhost
 ```
 
-You can find the `API_BASE_URL` in [Concourse](https://cd.gds-reliability.engineering/teams/verify/pipelines/di-authentication-deployment) under the outputs within the deploy-oidc-api-{environment} job, where {environment} is the name of the environment you want to connect to.
-
 `UI_LOCALES` can be used be the stub to request specific locales when authorising.  Only 'en' and 'cy' are supported.
 
 ### Starting all services in Docker


### PR DESCRIPTION
## What?

We have migrated off Concourse, so we must avoid referencing it in our documentation. The README.md file currently references Concourse in the section about setting environment variables, which we can remove.