### PR TITLE
AUT-1276: Split resend code account creation vs sign-in

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -38,6 +38,7 @@ export const PATH_NAMES = {
   SECURITY_CODE_CHECK_TIME_LIMIT: "/security-code-check-time-limit",
   AUTH_CODE: "/auth-code",
   RESEND_MFA_CODE: "/resend-code",
+  RESEND_MFA_CODE_ACCOUNT_CREATION: "/resend-code-create-account",
   RESEND_EMAIL_CODE: "/resend-email-code",
   SIGNED_OUT: "/signed-out",
   ACCOUNT_LOCKED: "/account-locked",

--- a/src/app.ts
+++ b/src/app.ts
@@ -44,6 +44,7 @@ import { ENVIRONMENT_NAME } from "./app.constants";
 import { enterMfaRouter } from "./components/enter-mfa/enter-mfa-routes";
 import { authCodeRouter } from "./components/auth-code/auth-code-routes";
 import { resendMfaCodeRouter } from "./components/resend-mfa-code/resend-mfa-code-routes";
+import { resendMfaCodeAccountCreationRouter } from "./components/account-creation/resend-mfa-code/resend-mfa-code-routes";
 import { resendEmailCodeRouter } from "./components/resend-email-code/resend-email-code-routes";
 import { signedOutRouter } from "./components/signed-out/signed-out-routes";
 import {
@@ -109,6 +110,7 @@ function registerRoutes(app: express.Application) {
   app.use(enterMfaRouter);
   app.use(authCodeRouter);
   app.use(resendMfaCodeRouter);
+  app.use(resendMfaCodeAccountCreationRouter);
   app.use(resendEmailCodeRouter);
   app.use(signedOutRouter);
   app.use(shareInfoRouter);

--- a/src/components/account-creation/resend-mfa-code/index.njk
+++ b/src/components/account-creation/resend-mfa-code/index.njk
@@ -1,0 +1,36 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+
+{% set pageTitleName = 'pages.resendMfaCode.title' | translate %}
+{% set showBack = true %}
+{% set hrefBack = 'enter-code' %}
+
+{% if isResendCodeRequest %}
+    {% set phoneNumberMessage %}
+       {{ 'pages.resendMfaCode.phoneNumber.isResendCodeRequest' | translate }} <span class='govuk-!-font-weight-bold'>{{ phoneNumber }}</span>
+    {% endset %}
+{% else %}
+    {% set phoneNumberMessage = 'pages.resendMfaCode.phoneNumber.default' | translate | replace("[mobile]", phoneNumber) %}
+{% endif %}
+
+{% block content %}
+    <form action="/resend-code-create-account" method="post" novalidate="novalidate">
+        <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+        <input type="hidden" name="isResendCodeRequest" value="{{isResendCodeRequest}}"/>
+
+        <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.resendMfaCode.header' | translate}}</h1>
+
+        {{ govukInsetText({
+            text: phoneNumberMessage | safe
+        }) }}
+
+        <p class="govuk-body">{{'pages.resendMfaCode.message' | translate}}</p>
+        {{ govukButton({
+        "text": "pages.resendMfaCode.continue" | translate,
+        "type": "Submit",
+        "preventDoubleClick": true
+    }) }}
+
+    </form>
+{% endblock %}

--- a/src/components/account-creation/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/account-creation/resend-mfa-code/resend-mfa-code-controller.ts
@@ -1,0 +1,83 @@
+import xss from "xss";
+import { Request, Response } from "express";
+
+import { ExpressRouteFunc } from "../../../types";
+import {
+  JOURNEY_TYPE,
+  NOTIFICATION_TYPE,
+  PATH_NAMES,
+} from "../../../app.constants";
+import { getErrorPathByCode, pathWithQueryParam } from "../../common/constants";
+import { SendNotificationServiceInterface } from "../../common/send-notification/types";
+import { sendNotificationService } from "../../common/send-notification/send-notification-service";
+import { BadRequestError } from "../../../utils/error";
+
+export function resendMfaCodeGet(req: Request, res: Response): void {
+  const newCodeLink = req.query?.isResendCodeRequest
+    ? pathWithQueryParam(
+        PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION,
+        "isResendCodeRequest",
+        "true"
+      )
+    : PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION;
+
+  if (
+    req.session.user.wrongCodeEnteredLock &&
+    new Date().getTime() <
+      new Date(req.session.user.wrongCodeEnteredLock).getTime()
+  ) {
+    res.render("security-code-error/index-security-code-entered-exceeded.njk", {
+      newCodeLink: newCodeLink,
+      isAuthApp: false,
+    });
+  } else if (
+    req.session.user.codeRequestLock &&
+    new Date().getTime() < new Date(req.session.user.codeRequestLock).getTime()
+  ) {
+    res.render("security-code-error/index-wait.njk", {
+      newCodeLink,
+    });
+  } else {
+    res.render("account-creation/resend-mfa-code/index.njk", {
+      phoneNumber: req.session.user.redactedPhoneNumber,
+      isResendCodeRequest: req.query?.isResendCodeRequest,
+    });
+  }
+}
+
+export const resendMfaCodePost = (
+  service: SendNotificationServiceInterface = sendNotificationService()
+): ExpressRouteFunc => {
+  return async function (req: Request, res: Response) {
+    console.log("LKJDHLAKJSHAKLJSH - the post is being hit");
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+    const { email, phoneNumber } = req.session.user;
+
+    const sendNotificationResponse = await service.sendNotification(
+      sessionId,
+      clientSessionId,
+      email,
+      NOTIFICATION_TYPE.VERIFY_PHONE_NUMBER,
+      req.ip,
+      persistentSessionId,
+      xss(req.cookies.lng as string),
+      JOURNEY_TYPE.REGISTRATION,
+      phoneNumber
+    );
+
+    if (!sendNotificationResponse.success) {
+      const path = getErrorPathByCode(sendNotificationResponse.data.code);
+
+      if (path) {
+        return res.redirect(path);
+      }
+
+      throw new BadRequestError(
+        sendNotificationResponse.data.message,
+        sendNotificationResponse.data.code
+      );
+    }
+
+    return res.redirect(PATH_NAMES.CHECK_YOUR_PHONE);
+  };
+};

--- a/src/components/account-creation/resend-mfa-code/resend-mfa-code-controller.ts
+++ b/src/components/account-creation/resend-mfa-code/resend-mfa-code-controller.ts
@@ -49,7 +49,6 @@ export const resendMfaCodePost = (
   service: SendNotificationServiceInterface = sendNotificationService()
 ): ExpressRouteFunc => {
   return async function (req: Request, res: Response) {
-    console.log("LKJDHLAKJSHAKLJSH - the post is being hit");
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
     const { email, phoneNumber } = req.session.user;
 

--- a/src/components/account-creation/resend-mfa-code/resend-mfa-code-routes.ts
+++ b/src/components/account-creation/resend-mfa-code/resend-mfa-code-routes.ts
@@ -1,0 +1,28 @@
+import { PATH_NAMES } from "../../../app.constants";
+
+import * as express from "express";
+import { validateSessionMiddleware } from "../../../middleware/session-middleware";
+import {
+  resendMfaCodeGet,
+  resendMfaCodePost,
+} from "./resend-mfa-code-controller";
+import { asyncHandler } from "../../../utils/async";
+import { allowUserJourneyMiddleware } from "../../../middleware/allow-user-journey-middleware";
+
+const router = express.Router();
+
+router.get(
+  PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  resendMfaCodeGet
+);
+
+router.post(
+  PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION,
+  validateSessionMiddleware,
+  allowUserJourneyMiddleware,
+  asyncHandler(resendMfaCodePost())
+);
+
+export { router as resendMfaCodeAccountCreationRouter };

--- a/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-controller.test.ts
+++ b/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-controller.test.ts
@@ -1,0 +1,69 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+
+import {
+  resendMfaCodeGet,
+  resendMfaCodePost,
+} from "../resend-mfa-code-controller";
+import { PATH_NAMES } from "../../../../app.constants";
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
+import { SendNotificationServiceInterface } from "../../../common/send-notification/types";
+
+describe("resend mfa controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = mockRequest({
+      path: PATH_NAMES.CHECK_YOUR_PHONE,
+      session: { client: {}, user: {} },
+      log: { info: sinon.fake() },
+      t: sinon.fake(),
+      i18n: { language: "en" },
+    });
+    res = mockResponse();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("resendMfaCodeGet", () => {
+    it("should render resend mfa code view", () => {
+      resendMfaCodeGet(req as Request, res as Response);
+
+      expect(res.render).to.have.calledWith(
+        "account-creation/resend-mfa-code/index.njk"
+      );
+    });
+  });
+
+  describe("resendMfaCodePost", () => {
+    it("should request new phone verification code from send notification service and if successful redirect to /enter-code view", async () => {
+      const fakeService: SendNotificationServiceInterface = {
+        sendNotification: sinon.fake.returns({
+          success: true,
+        }),
+      };
+
+      res.locals.sessionId = "123456-djjad";
+      req.session.user = {
+        email: "test@test.com",
+      };
+      req.path = PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION;
+
+      await resendMfaCodePost(fakeService)(req as Request, res as Response);
+
+      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.CHECK_YOUR_PHONE);
+      expect(fakeService.sendNotification).to.have.been.calledOnce;
+    });
+  });
+});

--- a/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
+++ b/src/components/account-creation/resend-mfa-code/tests/resend-mfa-code-integration.test.ts
@@ -1,0 +1,177 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../../test/utils/test-utils";
+import nock = require("nock");
+import * as cheerio from "cheerio";
+import decache from "decache";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  PATH_NAMES,
+} from "../../../../app.constants";
+import { ERROR_CODES } from "../../../common/constants";
+
+describe("Integration:: resend mfa code (account creation variant)", () => {
+  let token: string | string[];
+  let cookies: string;
+  let app: any;
+  let baseApi: string;
+
+  before(async () => {
+    decache("../../../../app");
+    decache("../../../../middleware/session-middleware");
+    const sessionMiddleware = require("../../../../middleware/session-middleware");
+    sinon
+      .stub(sessionMiddleware, "validateSessionMiddleware")
+      .callsFake(function (req: any, res: any, next: any): void {
+        res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+
+        req.session.user = {
+          email: "test@test.com",
+          phoneNumber: "7867",
+          journey: {
+            nextPath: PATH_NAMES.ENTER_MFA,
+            optionalPaths: [PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION],
+          },
+        };
+
+        next();
+      });
+
+    app = await require("../../../../app").createApp();
+    baseApi = process.env.FRONTEND_API_BASE_URL as string;
+
+    await request(app)
+      .get(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+      .then((res) => {
+        const $ = cheerio.load(res.text);
+        token = $("[name=_csrf]").val();
+        cookies = res.headers["set-cookie"];
+      });
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("should return resend mfa code page", (done) => {
+    request(app)
+      .get(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+      .expect(200, done);
+  });
+
+  it("should return error when csrf not present", (done) => {
+    request(app)
+      .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+      .type("form")
+      .send({
+        code: "123456",
+      })
+      .expect(500, done);
+  });
+
+  it("should redirect to /enter-code when new code requested", (done) => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.SEND_NOTIFICATION)
+      .once()
+      .reply(HTTP_STATUS_CODES.NO_CONTENT);
+
+    request(app)
+      .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+      })
+      .expect("Location", PATH_NAMES.ENTER_MFA)
+      .expect(302, done);
+  });
+
+  it("should redirect to /check-your-phone when new code requested as part of account creation journey", (done) => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.MFA)
+      .once()
+      .reply(HTTP_STATUS_CODES.NO_CONTENT);
+
+    request(app)
+      .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        isResendCodeRequest: true,
+      })
+      .expect("Location", PATH_NAMES.CHECK_YOUR_PHONE)
+      .expect(302, done);
+  });
+
+  it("should render 'You cannot get a new security code at the moment' when OTP lockout timer cookie is active", () => {
+    const testSpecificCookies = cookies + "; re=true";
+    request(app)
+      .get(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+      .set("Cookie", testSpecificCookies)
+      .expect((res) => {
+        res.text.includes("You cannot get a new security code at the moment");
+      });
+  });
+
+  it("should return 500 error screen when API call fails", (done) => {
+    nock(baseApi).post(API_ENDPOINTS.MFA).once().reply(500, {
+      errorCode: "1234",
+    });
+
+    request(app)
+      .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+      })
+      .expect(500, done);
+  });
+
+  it("should redirect to /security-code-requested-too-many-times when request OTP more than 5 times", (done) => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.MFA)
+      .times(6)
+      .reply(400, { code: ERROR_CODES.MFA_SMS_MAX_CODES_SENT });
+
+    request(app)
+      .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+      })
+      .expect(
+        "Location",
+        "/security-code-requested-too-many-times?actionType=mfaMaxCodesSent"
+      )
+      .expect(302, done);
+  });
+
+  it("should redirect to /security-code-invalid-request when exceeded OTP request limit", (done) => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.MFA)
+      .once()
+      .reply(400, { code: ERROR_CODES.MFA_CODE_REQUESTS_BLOCKED });
+
+    request(app)
+      .post(PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+      })
+      .expect(
+        "Location",
+        "/security-code-invalid-request?actionType=mfaBlocked"
+      )
+      .expect(302, done);
+  });
+});

--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -3,12 +3,14 @@ import {
   JOURNEY_TYPE,
   MFA_METHOD_TYPE,
   NOTIFICATION_TYPE,
+  PATH_NAMES,
 } from "../../app.constants";
 import { ExpressRouteFunc } from "../../types";
 import {
   ERROR_CODES,
   getErrorPathByCode,
   getNextPathAndUpdateJourney,
+  pathWithQueryParam,
 } from "../common/constants";
 import { SendNotificationServiceInterface } from "../common/send-notification/types";
 import { sendNotificationService } from "../common/send-notification/send-notification-service";
@@ -25,8 +27,21 @@ import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-
 const TEMPLATE_NAME = "check-your-phone/index.njk";
 
 export function checkYourPhoneGet(req: Request, res: Response): void {
-  res.render(TEMPLATE_NAME, {
+  const resendCodeLink = pathWithQueryParam(
+    PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION,
+    "isResendCodeRequest",
+    "true"
+  );
+
+  if (req.session.user.isAccountCreationJourney) {
+    return res.render(TEMPLATE_NAME, {
+      phoneNumber: req.session.user.redactedPhoneNumber,
+      resendCodeLink,
+    });
+  }
+  return res.render(TEMPLATE_NAME, {
     phoneNumber: req.session.user.redactedPhoneNumber,
+    resendCodeLink,
   });
 }
 

--- a/src/components/check-your-phone/index.njk
+++ b/src/components/check-your-phone/index.njk
@@ -47,7 +47,7 @@
     {% set detailsHTML %}
     <p class="govuk-body">
       {{'pages.checkYourPhone.details.text1' | translate}}
-      <a href="{{'pages.checkYourPhone.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.sendCodeLinkText'| translate}}</a>
+      <a href="{{resendCodeLink}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.sendCodeLinkText'| translate}}</a>
       {{'pages.checkYourPhone.details.text 2' | translate}}
       <a href="{{'pages.checkYourPhone.details.changePhoneNumberLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.checkYourPhone.details.changePhoneNumberLinkText'| translate}}</a>.
     </p>

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -314,6 +314,7 @@ const authStateMachine = createMachine(
             PATH_NAMES.SECURITY_CODE_REQUEST_EXCEEDED,
             PATH_NAMES.CREATE_ACCOUNT_ENTER_PHONE_NUMBER,
             PATH_NAMES.RESEND_MFA_CODE,
+            PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION,
             PATH_NAMES.GET_SECURITY_CODES,
           ],
         },

--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -82,6 +82,8 @@ export function landingGet(
     req.session.user.docCheckingAppUser =
       startAuthResponse.data.user.docCheckingAppUser;
 
+    req.session.user.isAccountCreationJourney = undefined;
+
     if (startAuthResponse.data.featureFlags) {
       req.session.user.featureFlags = startAuthResponse.data.featureFlags;
     }

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -4,7 +4,9 @@ import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { generateMfaSecret } from "../../utils/mfa";
 
 export function getSecurityCodesGet(req: Request, res: Response): void {
-  if (!req.session.user.isAccountRecoveryJourney) {
+  if (req.session.user.isAccountRecoveryJourney) {
+    req.session.user.isAccountCreationJourney = false;
+  } else {
     req.session.user.isAccountCreationJourney = true;
   }
   res.render("select-mfa-options/index.njk", {

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -4,11 +4,9 @@ import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { generateMfaSecret } from "../../utils/mfa";
 
 export function getSecurityCodesGet(req: Request, res: Response): void {
-  if (req.session.user.isAccountRecoveryJourney) {
-    req.session.user.isAccountCreationJourney = false;
-  } else {
-    req.session.user.isAccountCreationJourney = true;
-  }
+  req.session.user.isAccountCreationJourney =
+    !req.session.user.isAccountRecoveryJourney;
+
   res.render("select-mfa-options/index.njk", {
     isAccountPartCreated: req.session.user.isAccountPartCreated,
     isAccountRecoveryJourney: req.session.user.isAccountRecoveryJourney,

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -4,6 +4,9 @@ import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { generateMfaSecret } from "../../utils/mfa";
 
 export function getSecurityCodesGet(req: Request, res: Response): void {
+  if (!req.session.user.isAccountRecoveryJourney) {
+    req.session.user.isAccountCreationJourney = true;
+  }
   res.render("select-mfa-options/index.njk", {
     isAccountPartCreated: req.session.user.isAccountPartCreated,
     isAccountRecoveryJourney: req.session.user.isAccountRecoveryJourney,

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -407,7 +407,6 @@
         "summaryText": "Problemau gyda’r cod?",
         "text1": "Gallwn ",
         "sendCodeLinkText": "anfon y cod eto",
-        "sendCodeLinkHref": "/resend-code?isResendCodeRequest=true",
         "text 2": " neu gallwch ",
         "changePhoneNumberLinkText": "ddefnyddio rhif ffôn gwahanol",
         "changePhoneNumberLinkHref": "/enter-phone-number",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -407,7 +407,6 @@
         "summaryText": "Problems with the code?",
         "text1": "We can ",
         "sendCodeLinkText": "send the code again",
-        "sendCodeLinkHref": "/resend-code?isResendCodeRequest=true",
         "text 2": " or you can ",
         "changePhoneNumberLinkText": "use a different phone number",
         "changePhoneNumberLinkHref": "/enter-phone-number",

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,7 @@ export interface UserSession {
   isLatestTermsAndConditionsAccepted?: boolean;
   isIdentityRequired?: boolean;
   isUpliftRequired?: boolean;
+  isAccountCreationJourney?: boolean;
   isAccountPartCreated?: boolean;
   docCheckingAppUser?: boolean;
   identityProcessCheckStart?: number;


### PR DESCRIPTION
## What?
- Split code for the resend SMS code screen between sign in and account creation journeys
- Note: This should make no visual difference

## Why?
- The single variant that already exists calls the MFA Handler on the back end. That handler 'assumes' that a phone number will have been stored in the user profile database. However, this is no longer true since the steps of adding and verifying a phone number were combined into a single transaction (e.g.: https://github.com/alphagov/di-authentication-api/pull/2944)
- That in turn was done to make the system work better for account recovery needs
- In the account creation journey, the user will not have a phone number stored against their profile when the code is resent
- To get around this, we will hit the send notification lambda directly (providing the phone number from the user's front end session)
