### PR TITLE
AUT-1317: Make language links meet Level AAA WCAG Success Criterion

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -147,9 +147,9 @@
       "bullet2": "ffordd o gael codau diogelwch - gall hwn fod yn rhif ffôn symudol y DU neu’n ap dilysydd",
       "bullet2IntNumbers": "ffordd o gael codau diogelwch - gall hwn fod yn rhif ffôn symudol neu’n ap dilysydd",
       "insetAlternativeLanguage": {
-        "paragraph1": "Mae GOV.UK One Login hefyd ar gael ",
+        "paragraph1": "Gallwch hefyd ",
         "linkText": {
-          "inPageLanguage": "yn Saesneg",
+          "inPageLanguage": "ddefnyddio GOV.UK One Login yn Saesneg",
           "inDestinationLanguage": "(English)",
           "destinationLanguageCode": "en"
         },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -147,9 +147,9 @@
       "bullet2": "a way to get security codes - this can be a UK mobile phone number or an authenticator app",
       "bullet2IntNumbers": "a way to get security codes - this can be a mobile phone number or an authenticator app",
       "insetAlternativeLanguage": {
-        "paragraph1": "GOV.UK One Login is also available ",
+        "paragraph1": "You can also ",
         "linkText": {
-          "inPageLanguage": "in Welsh",
+          "inPageLanguage": "use GOV.UK One Login in Welsh",
           "inDestinationLanguage": "(Cymraeg)",
           "destinationLanguageCode": "cy"
         },


### PR DESCRIPTION
## What?

This fixes a failure of a WCAG Success Criterion 2.4.9 (Level AAA) identified during an audit of the Design System conducted in May 2023. The related issue is described in a GitHub issue

### Screenshots
<img width="418" alt="Screenshot of English page showing link to Welsh version" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/f1bd452d-2014-4cd7-8d65-665a9c0c6fcf">

<img width="418" alt="Screenshot of Welsh page showing link to English version" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/6f6cc1a9-d0dc-4275-be88-8c817d9ded93">

## Why?

Accessibility enhancement to the service

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [ ] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change
