### PR TITLE
AUT-1248: Create /authorize route and initial logic

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -5,6 +5,7 @@ export enum MFA_METHOD_TYPE {
 
 export const PATH_NAMES = {
   START: "/",
+  AUTHORIZE: "/authorize",
   ACCESSIBILITY_STATEMENT: "/accessibility-statement",
   TERMS_AND_CONDITIONS: "/terms-and-conditions",
   PRIVACY_POLICY: "/privacy-notice",

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,6 +24,7 @@ import {
   getSessionExpiry,
   getSessionSecret,
   supportAccountRecovery,
+  supportAuthOrchSplit,
 } from "./config";
 import { logErrorMiddleware } from "./middleware/log-error-middleware";
 import { getCookieLanguageMiddleware } from "./middleware/cookie-lang-middleware";
@@ -46,6 +47,7 @@ import { authCodeRouter } from "./components/auth-code/auth-code-routes";
 import { resendMfaCodeRouter } from "./components/resend-mfa-code/resend-mfa-code-routes";
 import { resendMfaCodeAccountCreationRouter } from "./components/account-creation/resend-mfa-code/resend-mfa-code-routes";
 import { resendEmailCodeRouter } from "./components/resend-email-code/resend-email-code-routes";
+import { authorizeRouter } from "./components/authorize/authorize-routes";
 import { signedOutRouter } from "./components/signed-out/signed-out-routes";
 import {
   getSessionIdMiddleware,
@@ -105,6 +107,9 @@ function registerRoutes(app: express.Application) {
   if (supportAccountRecovery()) {
     app.use(checkYourEmailSecurityCodesRouter);
     app.use(changeSecurityCodesConfirmationRouter);
+  }
+  if (supportAuthOrchSplit()) {
+    app.use(authorizeRouter);
   }
   app.use(securityCodeErrorRouter);
   app.use(enterMfaRouter);

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -1,0 +1,133 @@
+import { Request, Response } from "express";
+import {
+  COOKIE_CONSENT,
+  COOKIES_PREFERENCES_SET,
+  PATH_NAMES,
+  ERROR_LOG_LEVEL,
+  API_ERROR_CODES,
+} from "../../app.constants";
+import { getNextPathAndUpdateJourney } from "../common/constants";
+import { BadRequestError } from "../../utils/error";
+import { ExpressRouteFunc } from "../../types";
+import {
+  CookieConsentModel,
+  CookieConsentServiceInterface,
+} from "../common/cookie-consent/types";
+import { cookieConsentService } from "../common/cookie-consent/cookie-consent-service";
+import { sanitize } from "../../utils/strings";
+import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
+import { authorizeService } from "./authorize-service";
+import { AuthorizeServiceInterface } from "./types";
+
+function createConsentCookie(
+  res: Response,
+  consentCookieValue: CookieConsentModel
+) {
+  res.cookie(COOKIES_PREFERENCES_SET, consentCookieValue.value, {
+    expires: consentCookieValue.expiry,
+    secure: true,
+    domain: res.locals.analyticsCookieDomain,
+  });
+}
+
+export function authorizeGet(
+  service: AuthorizeServiceInterface = authorizeService(),
+  cookieService: CookieConsentServiceInterface = cookieConsentService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+    const loginPrompt = sanitize(req.query.prompt as string);
+
+    const startAuthResponse = await service.start(
+      sessionId,
+      clientSessionId,
+      req.ip,
+      persistentSessionId
+    );
+
+    if (!startAuthResponse.success) {
+      const startError = new BadRequestError(
+        startAuthResponse.data.message,
+        startAuthResponse.data.code
+      );
+      if (
+        startAuthResponse.data.code &&
+        startAuthResponse.data.code ===
+          API_ERROR_CODES.SESSION_ID_MISSING_OR_INVALID
+      ) {
+        startError.level = ERROR_LOG_LEVEL.INFO;
+      }
+      throw startError;
+    }
+
+    req.session.client.serviceType = startAuthResponse.data.client.serviceType;
+    req.session.client.name = startAuthResponse.data.client.clientName;
+    req.session.client.scopes = startAuthResponse.data.client.scopes;
+    req.session.client.cookieConsentEnabled =
+      startAuthResponse.data.client.cookieConsentShared;
+    req.session.client.consentEnabled =
+      startAuthResponse.data.user.consentRequired;
+    req.session.client.prompt = loginPrompt;
+    req.session.client.redirectUri = startAuthResponse.data.client.redirectUri;
+    req.session.client.state = startAuthResponse.data.client.state;
+    req.session.client.isOneLoginService =
+      startAuthResponse.data.client.isOneLoginService;
+
+    req.session.user.isIdentityRequired =
+      startAuthResponse.data.user.identityRequired;
+    req.session.user.isAuthenticated =
+      startAuthResponse.data.user.authenticated;
+    req.session.user.isUpliftRequired =
+      startAuthResponse.data.user.upliftRequired;
+    req.session.user.docCheckingAppUser =
+      startAuthResponse.data.user.docCheckingAppUser;
+
+    req.session.user.isAccountCreationJourney = undefined;
+
+    if (startAuthResponse.data.featureFlags) {
+      req.session.user.featureFlags = startAuthResponse.data.featureFlags;
+    }
+
+    const nextStateEvent = req.session.user.isAuthenticated
+      ? USER_JOURNEY_EVENTS.EXISTING_SESSION
+      : USER_JOURNEY_EVENTS.NO_EXISTING_SESSION;
+
+    let redirectPath = getNextPathAndUpdateJourney(
+      req,
+      PATH_NAMES.AUTHORIZE,
+      nextStateEvent,
+      {
+        isConsentRequired: req.session.client.consentEnabled,
+        requiresUplift: req.session.user.isUpliftRequired,
+        isIdentityRequired: req.session.user.isIdentityRequired,
+        isAuthenticated: req.session.user.isAuthenticated,
+        prompt: req.session.client.prompt,
+        skipAuthentication: req.session.user.docCheckingAppUser,
+        mfaMethodType: startAuthResponse.data.user.mfaMethodType,
+      },
+      sessionId
+    );
+
+    const cookieConsent = sanitize(startAuthResponse.data.user.cookieConsent);
+
+    if (req.session.client.cookieConsentEnabled && cookieConsent) {
+      const consentCookieValue =
+        cookieService.createConsentCookieValue(cookieConsent);
+
+      createConsentCookie(res, consentCookieValue);
+
+      if (
+        startAuthResponse.data.user.gaCrossDomainTrackingId &&
+        cookieConsent === COOKIE_CONSENT.ACCEPT
+      ) {
+        const queryParams = new URLSearchParams({
+          _ga: startAuthResponse.data.user.gaCrossDomainTrackingId,
+        }).toString();
+
+        redirectPath = redirectPath + "?" + queryParams;
+      }
+    }
+
+    return res.redirect(redirectPath);
+  };
+}

--- a/src/components/authorize/authorize-routes.ts
+++ b/src/components/authorize/authorize-routes.ts
@@ -1,0 +1,10 @@
+import * as express from "express";
+import { authorizeGet } from "./authorize-controller";
+import { asyncHandler } from "../../utils/async";
+import { PATH_NAMES } from "../../app.constants";
+
+const router = express.Router();
+
+router.get(PATH_NAMES.AUTHORIZE, asyncHandler(authorizeGet()));
+
+export { router as authorizeRouter };

--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -1,0 +1,36 @@
+import { AuthorizeServiceInterface, StartAuthResponse } from "./types";
+import { ApiResponseResult } from "../../types";
+import { API_ENDPOINTS } from "../../app.constants";
+import {
+  createApiResponse,
+  getRequestConfig,
+  http,
+  Http,
+} from "../../utils/http";
+
+export function authorizeService(
+  axios: Http = http
+): AuthorizeServiceInterface {
+  const start = async function (
+    sessionId: string,
+    clientSessionId: string,
+    sourceIp: string,
+    persistentSessionId: string
+  ): Promise<ApiResponseResult<StartAuthResponse>> {
+    const response = await axios.client.get<StartAuthResponse>(
+      API_ENDPOINTS.START,
+      getRequestConfig({
+        sessionId: sessionId,
+        clientSessionId: clientSessionId,
+        sourceIp: sourceIp,
+        persistentSessionId: persistentSessionId,
+      })
+    );
+
+    return createApiResponse<StartAuthResponse>(response);
+  };
+
+  return {
+    start,
+  };
+}

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -1,0 +1,449 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+
+import { sinon } from "../../../../test/utils/test-utils";
+import { Request, Response } from "express";
+
+import { authorizeGet } from "../authorize-controller";
+import { CookieConsentServiceInterface } from "../../common/cookie-consent/types";
+import {
+  COOKIE_CONSENT,
+  OIDC_PROMPT,
+  PATH_NAMES,
+} from "../../../app.constants";
+import {
+  mockRequest,
+  mockResponse,
+  RequestOutput,
+  ResponseOutput,
+} from "mock-req-res";
+import { AuthorizeServiceInterface } from "../types";
+import { BadRequestError } from "../../../utils/error";
+
+describe("authorize controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = mockRequest({
+      path: PATH_NAMES.AUTHORIZE,
+      session: { client: {}, user: {} },
+      log: { info: sinon.fake() },
+      t: sinon.fake(),
+      i18n: { language: "en" },
+    });
+    res = mockResponse();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("authorizeGet", () => {
+    it("should redirect to /sign-in-or-create page when no existing session for user", async () => {
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            client: {
+              scopes: ["openid", "profile"],
+              serviceType: "MANDATORY",
+              clientName: "Test client",
+              cookieConsentShared: true,
+            },
+            user: {},
+          },
+          success: true,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.SIGN_IN_OR_CREATE);
+    });
+
+    it("should redirect to /sign-in-or-create page with cookie preferences set", async () => {
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            client: {
+              scopes: ["openid", "profile"],
+              serviceType: "MANDATORY",
+              clientName: "Test client",
+              cookieConsentShared: true,
+            },
+            user: { cookieConsent: COOKIE_CONSENT.ACCEPT },
+          },
+          success: true,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake.returns({
+          value: JSON.stringify("cookieValue"),
+          expiry: "cookieExpires",
+        }),
+      };
+
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.cookie).to.have.been.called;
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.SIGN_IN_OR_CREATE);
+    });
+
+    it("should redirect to /uplift page when uplift query param set and MfaType is SMS", async () => {
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            client: {
+              scopes: ["openid", "profile"],
+              serviceType: "MANDATORY",
+              clientName: "Test client",
+              cookieConsentShared: true,
+            },
+            user: {
+              upliftRequired: true,
+              authenticated: true,
+              mfaMethodType: "SMS",
+            },
+          },
+          success: true,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.UPLIFT_JOURNEY);
+    });
+
+    it("should redirect to /enter-authenticator-app-code page when uplift query param set and MfaMethodType is AUTH_APP", async () => {
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            client: {
+              scopes: ["openid", "profile"],
+              serviceType: "MANDATORY",
+              clientName: "Test client",
+              cookieConsentShared: true,
+            },
+            user: {
+              upliftRequired: true,
+              authenticated: true,
+              mfaMethodType: "AUTH_APP",
+            },
+          },
+          success: true,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(
+        PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE
+      );
+    });
+
+    it("should redirect to /auth-code when existing session", async () => {
+      req.session.user.isAuthenticated = true;
+
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            client: {
+              scopes: ["openid", "profile"],
+              serviceType: "MANDATORY",
+              clientName: "Test client",
+              cookieConsentShared: true,
+            },
+            user: {
+              consentRequired: false,
+              identityRequired: false,
+              upliftRequired: false,
+              authenticated: true,
+            },
+          },
+          success: true,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.AUTH_CODE);
+    });
+
+    it("should redirect to /share-info when consent required", async () => {
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            client: {
+              scopes: ["openid", "profile"],
+              serviceType: "MANDATORY",
+              clientName: "Test client",
+              cookieConsentShared: true,
+            },
+            user: {
+              consentRequired: true,
+              identityRequired: false,
+              upliftRequired: false,
+              authenticated: true,
+            },
+          },
+          success: true,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.SHARE_INFO);
+    });
+
+    it("should redirect to /identity page when identity check required", async () => {
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            client: {
+              scopes: ["openid", "profile"],
+              serviceType: "MANDATORY",
+              clientName: "Test client",
+              cookieConsentShared: true,
+            },
+            user: {
+              consentRequired: false,
+              identityRequired: true,
+              upliftRequired: false,
+              authenticated: true,
+            },
+          },
+          success: true,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(
+        PATH_NAMES.PROVE_IDENTITY_WELCOME
+      );
+    });
+
+    it("should redirect to /enter-password page when prompt is login", async () => {
+      req.query.prompt = OIDC_PROMPT.LOGIN;
+
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            client: {
+              scopes: ["openid", "profile"],
+              serviceType: "MANDATORY",
+              clientName: "Test client",
+              cookieConsentShared: true,
+            },
+            user: {
+              consentRequired: false,
+              identityRequired: false,
+              upliftRequired: false,
+              authenticated: true,
+            },
+          },
+          success: true,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_PASSWORD);
+    });
+
+    it("should redirect to /sign-in-or-create page with _ga query param when present", async () => {
+      const gaTrackingId = "2.172053219.3232.1636392870-444224.1635165988";
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            client: {
+              scopes: ["openid", "profile"],
+              serviceType: "MANDATORY",
+              clientName: "Test client",
+              cookieConsentShared: true,
+              consentEnabled: true,
+            },
+            user: {
+              consentRequired: false,
+              identityRequired: false,
+              upliftRequired: false,
+              cookieConsent: COOKIE_CONSENT.ACCEPT,
+              gaCrossDomainTrackingId: gaTrackingId,
+            },
+          },
+          success: true,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake.returns({
+          value: JSON.stringify("cookieValue"),
+          expiry: "cookieExpires",
+        }),
+      };
+
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.cookie).to.have.been.called;
+      expect(res.redirect).to.have.calledWith(
+        `${PATH_NAMES.SIGN_IN_OR_CREATE}?_ga=${gaTrackingId}`
+      );
+    });
+
+    it("should redirect to /doc-checking-app when doc check app user", async () => {
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            client: {
+              scopes: ["openid", "profile"],
+              serviceType: "MANDATORY",
+              clientName: "Test client",
+              cookieConsentShared: false,
+              consentEnabled: false,
+            },
+            user: {
+              authenticated: false,
+              consentRequired: false,
+              docCheckingAppUser: true,
+            },
+          },
+          success: true,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake.returns({
+          value: JSON.stringify("cookieValue"),
+          expiry: "cookieExpires",
+        }),
+      };
+
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.calledWith(PATH_NAMES.DOC_CHECKING_APP);
+    });
+
+    it("should throw an error with level Info if the authorize service returns a code 1000 Session-Id is missing or invalid", async () => {
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            code: 1000,
+            message: "Session-Id is missing or invalid",
+          },
+          success: false,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await expect(
+        authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+          req as Request,
+          res as Response
+        )
+      )
+        .to.eventually.be.rejectedWith("1000:Session-Id is missing or invalid")
+        .and.be.an.instanceOf(BadRequestError)
+        .and.have.property("level", "Info");
+    });
+
+    it("should throw an error without level property if the authorize service returns a code 1001 Request is missing parameters", async () => {
+      const fakeAuthorizeService: AuthorizeServiceInterface = {
+        start: sinon.fake.returns({
+          data: {
+            code: 1001,
+            message: "Request is missing parameters",
+          },
+          success: false,
+        }),
+      };
+
+      const fakeCookieConsentService: CookieConsentServiceInterface = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+
+      await expect(
+        authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+          req as Request,
+          res as Response
+        )
+      )
+        .to.eventually.be.rejectedWith("1001:Request is missing parameters")
+        .and.be.an.instanceOf(BadRequestError)
+        .and.not.to.have.property("level");
+    });
+  });
+});

--- a/src/components/authorize/tests/authorize-integration.test.ts
+++ b/src/components/authorize/tests/authorize-integration.test.ts
@@ -1,0 +1,68 @@
+import request from "supertest";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils";
+import nock = require("nock");
+import decache from "decache";
+import { HTTP_STATUS_CODES, PATH_NAMES } from "../../../app.constants";
+import { AuthorizeServiceInterface, StartAuthResponse } from "../types";
+import { createApiResponse } from "../../../utils/http";
+import { AxiosResponse } from "axios";
+const authorizeService = require("../authorize-service");
+
+describe("Integration:: authorize", () => {
+  let app: any;
+
+  before(async () => {
+    process.env.SUPPORT_AUTH_ORCH_SPLIT = "1";
+    decache("../../../app");
+    sinon
+      .stub(authorizeService, "authorizeService")
+      .callsFake((): AuthorizeServiceInterface => {
+        async function start() {
+          const fakeAxiosResponse: AxiosResponse = {
+            data: {
+              client: {
+                serviceType: "MANDATORY",
+                clientName: "test-client",
+                scopes: ["openid"],
+                cookieConsentEnabled: true,
+                consentEnabled: true,
+                redirectUri: "http://test-redirect.gov.uk/callback",
+                state: "jasldasl12312",
+                isOneLoginService: false,
+              },
+              user: {
+                consentRequired: true,
+                upliftRequired: false,
+                identityRequired: false,
+                authenticated: false,
+              },
+            },
+            status: HTTP_STATUS_CODES.OK,
+          } as AxiosResponse;
+
+          return createApiResponse<StartAuthResponse>(fakeAxiosResponse);
+        }
+
+        return { start };
+      });
+
+    app = await require("../../../app").createApp();
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  it.only("should redirect to /sign-in-or-create", (done) => {
+    request(app)
+      .get(PATH_NAMES.AUTHORIZE)
+      .expect("Location", PATH_NAMES.SIGN_IN_OR_CREATE)
+      .expect(302, done);
+  });
+});

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -1,0 +1,37 @@
+import { ApiResponseResult, DefaultApiResponse } from "../../types";
+
+export interface StartAuthResponse extends DefaultApiResponse {
+  client: ClientInfo;
+  user: UserSessionInfo;
+  featureFlags?: Record<string, unknown>;
+}
+
+export interface ClientInfo {
+  clientName: string;
+  scopes: string[];
+  serviceType: string;
+  cookieConsentShared: boolean;
+  redirectUri: string;
+  state: string;
+  isOneLoginService?: boolean;
+}
+
+export interface UserSessionInfo {
+  upliftRequired: boolean;
+  identityRequired: boolean;
+  consentRequired: boolean;
+  authenticated: boolean;
+  cookieConsent?: string;
+  gaCrossDomainTrackingId?: string;
+  docCheckingAppUser: boolean;
+  mfaMethodType?: string;
+}
+
+export interface AuthorizeServiceInterface {
+  start: (
+    sessionId: string,
+    clientSessionId: string,
+    sourceIp: string,
+    persistentSessionId: string
+  ) => Promise<ApiResponseResult<StartAuthResponse>>;
+}

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -18,6 +18,7 @@ const USER_JOURNEY_EVENTS = {
   ACCOUNT_CREATED: "ACCOUNT_CREATED",
   START: "START",
   EXISTING_SESSION: "EXISTING_SESSION",
+  NO_EXISTING_SESSION: "NO_EXISTING_SESSION",
   VERIFY_MFA: "VERIFY_MFA",
   PROVE_IDENTITY: "PROVE_IDENTITY",
   PROVE_IDENTITY_CALLBACK: "PROVE_IDENTITY_CALLBACK",
@@ -91,6 +92,38 @@ const authStateMachine = createMachine(
             { target: [PATH_NAMES.AUTH_CODE], cond: "isAuthenticated" },
           ],
           [USER_JOURNEY_EVENTS.LANDING]: [
+            {
+              target: [PATH_NAMES.DOC_CHECKING_APP],
+              cond: "skipAuthentication",
+            },
+            {
+              target: [PATH_NAMES.PROVE_IDENTITY_WELCOME],
+              cond: "isIdentityRequired",
+            },
+            { target: [PATH_NAMES.SIGN_IN_OR_CREATE] },
+          ],
+        },
+      },
+      [PATH_NAMES.AUTHORIZE]: {
+        on: {
+          [USER_JOURNEY_EVENTS.EXISTING_SESSION]: [
+            {
+              target: [PATH_NAMES.PROVE_IDENTITY_WELCOME],
+              cond: "isIdentityRequired",
+            },
+            { target: [PATH_NAMES.ENTER_PASSWORD], cond: "requiresLogin" },
+            {
+              target: [PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE],
+              cond: "requiresAuthAppUplift",
+            },
+            { target: [PATH_NAMES.UPLIFT_JOURNEY], cond: "requiresUplift" },
+            {
+              target: [PATH_NAMES.SHARE_INFO],
+              cond: "isConsentRequired",
+            },
+            { target: [PATH_NAMES.AUTH_CODE], cond: "isAuthenticated" },
+          ],
+          [USER_JOURNEY_EVENTS.NO_EXISTING_SESSION]: [
             {
               target: [PATH_NAMES.DOC_CHECKING_APP],
               cond: "skipAuthentication",

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,10 @@ export function supportAccountRecovery(): boolean {
   return process.env.SUPPORT_ACCOUNT_RECOVERY === "1";
 }
 
+export function supportAuthOrchSplit(): boolean {
+  return process.env.SUPPORT_AUTH_ORCH_SPLIT === "1";
+}
+
 export async function getRedisConfig(appEnv: string): Promise<RedisConfig> {
   const hostKey = `${appEnv}-${process.env.REDIS_KEY}-redis-master-host`;
   const portKey = `${appEnv}-${process.env.REDIS_KEY}-redis-port`;

--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -9,7 +9,7 @@ export function initialiseSessionMiddleware(
   res: Response,
   next: NextFunction
 ): void {
-  if (req.path === PATH_NAMES.START) {
+  if (req.path === PATH_NAMES.START || req.path === PATH_NAMES.AUTHORIZE) {
     req.session.client = {};
 
     const email =


### PR DESCRIPTION
## What?
- Create `/authorize` route and initial logic
- Create new router/controller/service
- Apply feature flag so that `/authorize` is only registered when `SUPPORT_AUTH_ORCH_SPLIT` is true ("1")
- Update state machine to allow same transitions from new `/authorize` route to other routes as is currently allowed for `/` (landing/start)

## Why?
- This will allow the back end (OIDC API) to redirect to `/authorize` rather than landing in due course
- `/authorize` will eventually validate and parse a JWT from OIDC API to receive some information that is currently reliant on Client Registry DB access on the frontend API
