### PR TITLE
Privacy statement was using the wrong locale key

### DIFF
--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -162,7 +162,7 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_ten.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_ten.link.link_text' | translate }}</a>.
+        <a href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.link.link_text' | translate }}</a>.
     </p>
 
     <p class="govuk-body">


### PR DESCRIPTION
## What?

paragraph_ten was used here when it should have been paragraph_sixteen.

## Why?

It looks like it was mistyped on the original change.