### PR TITLE
PYIC-2949 Change Welsh link in pre-auth

### DIFF
--- a/src/components/prove-identity-welcome/index-existing-session.njk
+++ b/src/components/prove-identity-welcome/index-existing-session.njk
@@ -17,7 +17,6 @@
                class="govuk-link" rel="noreferrer">
                 {{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
                 <span lang="{{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span></a>.
-            {{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguageAppWarning' | translate | safe }}
         {% endset %}
 
         {{ govukInsetText({

--- a/src/components/prove-identity-welcome/index.njk
+++ b/src/components/prove-identity-welcome/index.njk
@@ -19,7 +19,6 @@
                class="govuk-link"
                rel="noreferrer">{{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkText.inPageLanguage' | translate }}
                 <span lang="{{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkText.destinationLanguageCode' | translate }}">{{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguage.linkText.inDestinationLanguage' | translate }}</span></a>.
-            {{ 'pages.proveIdentityWelcome.section1.insetAlternativeLanguageAppWarning' | translate | safe }}
 
         {% endset %}
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1864,9 +1864,9 @@
       "section1": {
         "paragraph1": "Bydd yn cymryd tua 10 munud i chi brofi pwy ydych chi yn y ffordd hyn.",
         "insetAlternativeLanguage": {
-          "paragraph1": "Mae’r gwasanaeth hwn hefyd ar gael yn ",
+          "paragraph1": "Gallwch hefyd ",
           "linkText": {
-            "inPageLanguage": "Saesneg",
+            "inPageLanguage": "ddefnyddio GOV.UK One Login yn Saesneg",
             "inDestinationLanguage": "(English)",
             "destinationLanguageCode": "en"
           },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1872,8 +1872,7 @@
           },
           "linkHref": "?lng=en"
         },
-        "insetTextEnglishOnly": "This service is currently only available in English.",
-        "insetAlternativeLanguageAppWarning": "Mae’r ap GOV.UK ID Check ond ar gael yn Saesneg yn unig ar hyn o bryd."
+        "insetTextEnglishOnly": "This service is currently only available in English."
       },
       "section2": {
         "paragraph1": "Byddwch angen:",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1872,8 +1872,7 @@
           },
           "linkHref": "?lng=cy"
         },
-        "insetTextEnglishOnly": "This service is currently only available in English.",
-        "insetAlternativeLanguageAppWarning": "The GOV.UK ID Check app is currently only available in English."
+        "insetTextEnglishOnly": "This service is currently only available in English."
       },
       "section2": {
         "paragraph1": "You’ll need:",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1864,9 +1864,9 @@
       "section1": {
         "paragraph1": "It will take you about 10 minutes to prove your identity this way.",
         "insetAlternativeLanguage": {
-          "paragraph1": "This service is also available in ",
+          "paragraph1": "You can also ",
           "linkText": {
-            "inPageLanguage": "Welsh",
+            "inPageLanguage": "use GOV.UK One Login in Welsh",
             "inDestinationLanguage": "(Cymraeg)",
             "destinationLanguageCode": "cy"
           },


### PR DESCRIPTION
## What?

The two translation files have been slightly updated for `prove-identity-welcome` to match the content already in `sign-in-or-create`. 

The `src/components/prove-identity-welcome/index.njk` page has had the `insetAlternativeLanguageAppWarning` content nunjucks tag removed as the app is now available in Welsh, as requested in [PYIC-2948](https://govukverify.atlassian.net/browse/PYIC-2948).

## Why?

The old version of the content was not understandable in isolation for screen reader users or other users navigating links on the page out of context.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
* [AUT-1317](https://govukverify.atlassian.net/browse/AUT-1317)


[AUT-1317]: https://govukverify.atlassian.net/browse/AUT-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PYIC-2948]: https://govukverify.atlassian.net/browse/PYIC-2948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Screenshots of user interface

### English · Prove identity welcome

![removed-content-en](https://github.com/alphagov/di-authentication-frontend/assets/101639632/5af2541e-d1e1-4dc9-a268-c64304359475)

### Welsh · Prove identity welcome

![removed-content-cy](https://github.com/alphagov/di-authentication-frontend/assets/101639632/47ac4fb8-d8bd-4865-b316-148afe4ae970)

### English · Prove identity welcome (existing session)

![existing-english](https://github.com/alphagov/di-authentication-frontend/assets/101639632/f2e9518a-3b9c-4367-947b-3657394ac521)

### Welsh · Prove identity welcome (existing session)

![existing-welsh](https://github.com/alphagov/di-authentication-frontend/assets/101639632/f5cf7071-5ba2-400d-988b-d083dfcd3e72)

