### PR TITLE
AUT-1347: Include journey type in sendNotification calls

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -106,7 +106,8 @@ export const checkYourPhonePost = (
       notificationType,
       req.ip,
       res.locals.persistentSessionId,
-      xss(req.cookies.lng as string)
+      xss(req.cookies.lng as string),
+      journeyType
     );
 
     return res.redirect(

--- a/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-controller.ts
@@ -113,7 +113,8 @@ export function setupAuthenticatorAppPost(
       notificationType,
       req.ip,
       res.locals.persistentSessionId,
-      xss(req.cookies.lng as string)
+      xss(req.cookies.lng as string),
+      journeyType
     );
 
     return res.redirect(


### PR DESCRIPTION
## What?

Include journey type in sendNotification calls.

## Why?

Journey type will become a mandatory parameter.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/3076
