### PR TITLE
AUT-1357: Add missing Welsh translation

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -477,8 +477,8 @@
         "sendCodeLinkText": "anfon y cod eto",
         "sendCodeLinkHref": "/resend-code",
         "text 2": " os nad yw’r cod yn gweithio neu ni wnaethoch ei dderbyn.",
-        "changeGetSecurityCodesText": "If you cannot access the phone number for your GOV.UK One Login, you can securely ",
-        "changeGetSecurityCodesLinkText": "change how you get security codes"
+        "changeGetSecurityCodesText": "Os na allwch gyrchu’r rhif ffôn ar gyfer eich GOV.UK One Login, gallwch ",
+        "changeGetSecurityCodesLinkText": "newid yn ddiogel sut rydych yn cael codau diogelwch"
       },
       "upliftRequired": {
         "title": "Mae angen i chi roi cod diogelwch",


### PR DESCRIPTION
## What?

Adds a missing Welsh translation "Check your phone" page

### Before
Before this change, some English text was included within the "Problems with the code" disclosure element
<img width="688" alt="Screenshot 2023-06-19 at 12 56 03" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/d14bb819-c362-4887-9be2-53cfeeda776a">

### After
<img width="707" alt="Screenshot 2023-06-19 at 12 59 59" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/656b0853-e674-43e2-b549-f7302ad09365">


## Why?

So that all content on the page is presented in Welsh when the user has selected Welsh as their language preference. 

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [ ] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
