### PR TITLE
AUT-1300: Preserve selected option on return to select MFA option

### DIFF
--- a/src/components/select-mfa-options/index.njk
+++ b/src/components/select-mfa-options/index.njk
@@ -37,6 +37,7 @@
 
 {{ govukRadios({
   name: "mfaOptions",
+  value: selectedMfaOption,
   fieldset: {
     legend: {
       text: radioHeading,

--- a/src/components/select-mfa-options/select-mfa-options-controller.ts
+++ b/src/components/select-mfa-options/select-mfa-options-controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { getNextPathAndUpdateJourney } from "../common/constants";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { generateMfaSecret } from "../../utils/mfa";
+import { MFA_METHOD_TYPE } from "../../app.constants";
 
 export function getSecurityCodesGet(req: Request, res: Response): void {
   req.session.user.isAccountCreationJourney =
@@ -10,10 +11,15 @@ export function getSecurityCodesGet(req: Request, res: Response): void {
   res.render("select-mfa-options/index.njk", {
     isAccountPartCreated: req.session.user.isAccountPartCreated,
     isAccountRecoveryJourney: req.session.user.isAccountRecoveryJourney,
+    selectedMfaOption: req.session.user.selectedMfaOption,
   });
 }
 
 export function getSecurityCodesPost(req: Request, res: Response): void {
+  if (Object.values(MFA_METHOD_TYPE).includes(req.body.mfaOptions)) {
+    req.session.user.selectedMfaOption = req.body.mfaOptions;
+  }
+
   const isAuthApp = req.body.mfaOptions === "AUTH_APP";
 
   if (isAuthApp) {

--- a/src/components/select-mfa-options/tests/select-mfa-options-controller.test.ts
+++ b/src/components/select-mfa-options/tests/select-mfa-options-controller.test.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { describe } from "mocha";
 import { sinon } from "../../../../test/utils/test-utils";
 import { Request, Response } from "express";
-import { PATH_NAMES } from "../../../app.constants";
+import { MFA_METHOD_TYPE, PATH_NAMES } from "../../../app.constants";
 import {
   getSecurityCodesGet,
   getSecurityCodesPost,
@@ -60,6 +60,25 @@ describe("select-mfa-options controller", () => {
       expect(res.redirect).to.have.calledWith(
         PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP
       );
+    });
+
+    describe("setting selectedMfaOption in the session", () => {
+      [MFA_METHOD_TYPE.SMS, MFA_METHOD_TYPE.AUTH_APP].forEach((i) => {
+        it(`req.session.user.selectedMfaOption should be set when req.body.mfaOptions is ${i}`, async () => {
+          req.body.mfaOptions = i;
+
+          getSecurityCodesPost(req as Request, res as Response);
+
+          expect(req.session.user).to.have.property("selectedMfaOption", i);
+        });
+      });
+      it(`req.session.user.selectedMfaOption should not be set when req.body.mfaOptions is not a vaild value`, async () => {
+        req.body.mfaOptions = "NOT_OK";
+
+        getSecurityCodesPost(req as Request, res as Response);
+
+        expect(req.session.user).not.to.have.property("selectedMfaOption");
+      });
     });
   });
 });


### PR DESCRIPTION
## What?

Ensures a user's selected MFA method is pre-selected if they return to the MFA selection page (for example by using the "back" link or navigating back in their browser).

This is achieved by introducing a user session property `selectedMfaOption` that holds the user's last selected MFA option. Where `selectedMfaOption` exists its value is used to set the `checked` state of the relevant radio input when users are presented with the MFA selection form.

## Before
<img width="640" alt="Screenshot 2023-06-20 at 15 46 47" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/be1d1166-cec6-4f59-844c-652042db5440">

## After
<img width="643" alt="Screenshot 2023-06-20 at 15 45 11" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/9c7dc1cd-0890-456a-9dfa-fcfb2f839ab0">


## Why?
The Design System Team [raised an issue](https://github.com/alphagov/govuk-design-system/issues/2802) recently that explains 

> The GOV.UK Design System states that “Make sure it takes users to the previous page they were on; in the state they last saw it”. When a user goes back to the previous page, their chosen option should be still selected. The users selected radio button has been unselected, meaning the user must answer the question again in order to continue in the service.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [ ] Changes to the user interface have been demonstrated

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change