### PR TITLE
AUT-1367: Change duration on "Sorry, the page has expired"

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -112,7 +112,7 @@
       "title": "Mae’n ddrwg gennym, mae’r dudalen wedi dod i ben",
       "header": "Mae’n ddrwg gennym, mae’r dudalen wedi dod i ben",
       "content": {
-        "paragraph1": "Mae hyn oherwydd na wnaethoch unrhyw beth am fwy na 2 awr. ",
+        "paragraph1": "Mae hyn oherwydd nad ydych wedi defnyddio GOV.UK One Login am fwy nag awr. ",
         "whatYouCanDo": "Beth allwch chi ei wneud",
         "paragraph2": "Ewch yn ôl i’r gwasanaeth roeddech chi’n ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio eich peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.",
         "govUKHomepageButtonHref": "https://www.gov.uk/",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -112,7 +112,7 @@
       "title": "Sorry, the page has expired",
       "header": "Sorry, the page has expired",
       "content": {
-        "paragraph1": "This is because you did not do anything for more than 2 hours. ",
+        "paragraph1": "This is because you have not used GOV.UK One Login for more than an hour. ",
         "whatYouCanDo": "What you can do",
         "paragraph2": "Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.",
         "govUKHomepageButtonHref": "https://www.gov.uk/",


### PR DESCRIPTION
## What?

Updates content on "Sorry, the page has expired" page to reflect change in session duration from 2 hours to 1 hour.

## Before

### English
<img width="415" alt="Screenshot 2023-06-22 at 17 45 21" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/0402e530-32f9-4ba2-9556-27eb6f436eda">

### Welsh
<img width="417" alt="Screenshot 2023-06-23 at 09 53 19" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/aa2a0d39-d169-480f-960f-2edc1fbbec23">

## After

### English
<img width="427" alt="Screenshot 2023-06-26 at 10 53 25" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/244ef90d-8afd-4afa-bb5f-48a2a22615f3">

### Welsh
<img width="424" alt="Screenshot 2023-06-26 at 10 53 39" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/8e9972f8-5eff-4ea9-93ea-e9baa12281c8">

## Why?
Session duration is being reduced from 2 hours to 1 hour.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Several PRs combine to introduce this change in functionality and content
* https://github.com/alphagov/di-authentication-frontend/pull/1078
* https://github.com/alphagov/di-authentication-frontend/pull/1077
* https://github.com/alphagov/di-authentication-frontend/pull/1076
* https://github.com/alphagov/di-authentication-api/pull/3109
