### PR TITLE
AUT-1368: Update Cookie Policy and Accessibility Statement

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -666,19 +666,19 @@
             },
             "rows": {
               "row1": {
-                "col2": "2 awr"
+                "col2": "1 awr"
               },
               "row2": {
                 "col2": "Pan fyddwch yn cau eich porwr gwe"
               },
               "row3": {
-                "col2": "2 awr"
+                "col2": "1 awr"
               },
               "row4": {
                 "col2": "13 mis"
               },
               "row5": {
-                "col2": "2 awr"
+                "col2": "1 awr"
               },
               "row6": {
                 "col2": "Pan fyddwch yn cau eich porwr gwe"
@@ -844,7 +844,7 @@
         "header": "Cynnwys anhygyrch",
         "paragraph1": "Nid yw’r cynnwys a restrir isod yn hygyrch am y rhesymau canlynol.",
         "subHeader": "Diffyg cydymffurfio â’r rheoliadau hygyrchedd",
-        "paragraph2": "Pan fyddwch yn creu GOV.UK One Login neu fewngofnodi, os nad ydych yn gwneud unrhyw beth am 2 awr, bydd y broses yn stopio (amseru allan) neu byddwch yn cael eich allgofnodi. Nid yw’n bosibl addasu, ymestyn na diffodd yr amseru allan. Mae hyn yn methu maen prawf llwyddiant WCAG 2.1  2.2.1 (Addasu Amseru)."
+        "paragraph2": "Pan fyddwch yn creu GOV.UK One Login neu fewngofnodi, os nad ydych yn gwneud unrhyw beth am 1 awr, bydd y broses yn stopio (amseru allan) neu byddwch yn cael eich allgofnodi. Nid yw’n bosibl addasu, ymestyn na diffodd yr amseru allan. Mae hyn yn methu maen prawf llwyddiant WCAG 2.1  2.2.1 (Addasu Amseru)."
       },
       "section8": {
         "header": "Beth rydym yn ei wneud i wella hygyrchedd",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -666,19 +666,19 @@
             },
             "rows": {
               "row1": {
-                "col2": "2 hours"
+                "col2": "1 hour"
               },
               "row2": {
                 "col2": "When you close your web browser"
               },
               "row3": {
-                "col2": "2 hours"
+                "col2": "1 hour"
               },
               "row4": {
                 "col2": "13 months"
               },
               "row5": {
-                "col2": "2 hours"
+                "col2": "1 hour"
               },
               "row6": {
                 "col2": "When you close your web browser"
@@ -844,7 +844,7 @@
         "header": "Non-accessible content",
         "paragraph1": "The content listed below is non-accessible for the following reasons.",
         "subHeader": "Non compliance with the accessibility regulations",
-        "paragraph2": "When you create a GOV.UK One Login or sign in, if you do not do anything for 2 hours, the process will stop (time out) or you’ll be signed out. It’s not possible to adjust, extend or turn off the time out. This fails WCAG 2.1 success criterion 2.2.1 (Timing Adjustable)."
+        "paragraph2": "When you create a GOV.UK One Login or sign in, if you do not do anything for 1 hour, the process will stop (time out) or you’ll be signed out. It’s not possible to adjust, extend or turn off the time out. This fails WCAG 2.1 success criterion 2.2.1 (Timing Adjustable)."
       },
       "section8": {
         "header": "What we’re doing to improve accessibility",


### PR DESCRIPTION
## What?

Changes relate to the reduced session duration from 2 hours to 1.

### Accessibility Statement screenshots

#### Before
<img width="954" alt="Screenshot 2023-06-23 at 10 51 43" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/f586c51f-ba27-41ab-9724-be463fd67555">

#### After
<img width="952" alt="Screenshot 2023-06-23 at 10 53 07" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/641239df-bba4-4220-a255-e52af86cc86e">

### Cookie Policy screenshots 

#### Before
<img width="932" alt="Screenshot 2023-06-23 at 10 40 08" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/ec4b0c3a-31b2-4fde-bed3-05481b844657">

#### After
<img width="957" alt="Screenshot 2023-06-23 at 10 35 28" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/34d36383-52ff-4618-b4e8-ac7d4e2ee159">

## Why?

Session duration is being reduced from 2 hours to 1 hour.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Several PRs combine to introduce this change in functionality and content
* https://github.com/alphagov/di-authentication-frontend/pull/1078
* https://github.com/alphagov/di-authentication-frontend/pull/1077
* https://github.com/alphagov/di-authentication-frontend/pull/1076
* https://github.com/alphagov/di-authentication-api/pull/3109
