### PR TITLE
AUT-1369: Change code expiry content on "Check your email"

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -364,7 +364,7 @@
       "info": {
         "paragraph1": "Mae’r e-bost yn cynnwys cod diogelwch 6 digid.",
         "paragraph2": "Efallai y bydd eich e-bost yn cymryd ychydig funudau i gyrraedd. Os na chewch e-bost, edrychwch ar eich ffolder spam.",
-        "paragraph3": "Bydd y cod yn dod i ben ar ôl 2 awr."
+        "paragraph3": "Bydd y cod yn dod i ben ar ôl awr."
       },
       "code": {
         "label": "Rhowch y cod diogelwch 6 digid",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -364,7 +364,7 @@
       "info": {
         "paragraph1": "The email contains a 6 digit security code.",
         "paragraph2": "Your email might take a few minutes to arrive. If you do not get an email, check your spam folder.",
-        "paragraph3": "The code will expire after 2 hours."
+        "paragraph3": "The code will expire after one hour."
       },
       "code": {
         "label": "Enter the 6 digit security code",


### PR DESCRIPTION
## What?

This is to reflect the change in session duration from 2 hour to 1

### Screenshots before
<img width="621" alt="Screenshot 2023-06-23 at 13 03 04" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/e8bb5c7b-01a4-46e9-b696-85196a725d5c">


### Screenshots after
<img width="621" alt="Screenshot 2023-06-23 at 13 02 11" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/cf698af1-b729-46dc-ba5f-a14d657c846d">

## Why?

Please include reason for the change and any other relevant context.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Several PRs combine to introduce this change in functionality and content
* https://github.com/alphagov/di-authentication-frontend/pull/1078
* https://github.com/alphagov/di-authentication-frontend/pull/1077
* https://github.com/alphagov/di-authentication-frontend/pull/1076
* https://github.com/alphagov/di-authentication-api/pull/3109

