### PR TITLE
AUT-1368: Revert am duration in Cookie Policy

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -678,7 +678,7 @@
                 "col2": "13 mis"
               },
               "row5": {
-                "col2": "1 awr"
+                "col2": "2 awr"
               },
               "row6": {
                 "col2": "Pan fyddwch yn cau eich porwr gwe"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -678,7 +678,7 @@
                 "col2": "13 months"
               },
               "row5": {
-                "col2": "1 hour"
+                "col2": "2 hours"
               },
               "row6": {
                 "col2": "When you close your web browser"


### PR DESCRIPTION
## What?

Sets `am` cookie duration description in Cookie Notice back to 2 hours.

## Why?

Reverts part of change made in #1077. This issue was identified during testing before the change was released. 

## Screenshots 

### Before
<img width="1066" alt="Screenshot 2023-06-26 at 15 00 39" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/2eeeeb66-5068-4709-a8c3-f18f8ee559de">


### After
<img width="1062" alt="Screenshot 2023-06-26 at 14 57 51" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/b0649b44-a811-4c48-a42e-1f5ae3033189">


## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [ ] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
