### PR TITLE
FIX: Add return statement to next calls in middleware

### DIFF
--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -80,7 +80,7 @@ export function validateSessionMiddleware(
 
   if (isReferrerInternal) {
     req.log.info("request from gov.uk domain");
-    next(
+    return next(
       new ErrorWithLevel(
         ERROR_MESSAGES.INVALID_SESSION_GOV_UK_INTERNAL_REQUEST,
         ERROR_LOG_LEVEL.INFO
@@ -88,7 +88,7 @@ export function validateSessionMiddleware(
     );
   }
 
-  next(
+  return next(
     new ErrorWithLevel(
       ERROR_MESSAGES.INVALID_SESSION_NON_GOV_UK_EXTERNAL_REQUEST,
       ERROR_LOG_LEVEL.INFO


### PR DESCRIPTION
## What?

Adds `return` statements to lines that call `next()` in `session-middleware.ts`

## Why?

During a group debugging session we identified that the absence of a `return` statement was introducing a bug resulting in a 401 being returned where the `gs` cookie had been manually deleted.