### PR TITLE
AUT-1371: Create problem screen for timed out IPV sessions

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -53,6 +53,8 @@ export const PATH_NAMES = {
   DOC_CHECKING_APP: "/doc-checking-app",
   DOC_CHECKING_APP_CALLBACK: "/doc-app-callback",
   PROVE_IDENTITY_CALLBACK: "/ipv-callback",
+  PROVE_IDENTITY_CALLBACK_SESSION_EXPIRY_ERROR:
+    "/ipv-callback-session-expiry-error",
   HEALTHCHECK: "/healthcheck",
   PROVE_IDENTITY_WELCOME: "/prove-identity-welcome",
   GET_SECURITY_CODES: "/get-security-codes",

--- a/src/components/prove-identity-callback/prove-identity-callback-controller.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-controller.ts
@@ -54,3 +54,10 @@ export function proveIdentityCallbackGet(
     return res.redirect(redirectPath);
   };
 }
+
+export function proveIdentityCallbackSessionExpiryError(
+  req: Request,
+  res: Response
+): void {
+  res.render("prove-identity-callback/session-expiry-error.njk");
+}

--- a/src/components/prove-identity-callback/prove-identity-callback-routes.ts
+++ b/src/components/prove-identity-callback/prove-identity-callback-routes.ts
@@ -3,7 +3,10 @@ import { PATH_NAMES } from "../../app.constants";
 import * as express from "express";
 import { validateSessionMiddleware } from "../../middleware/session-middleware";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware";
-import { proveIdentityCallbackGet } from "./prove-identity-callback-controller";
+import {
+  proveIdentityCallbackGet,
+  proveIdentityCallbackSessionExpiryError,
+} from "./prove-identity-callback-controller";
 import { asyncHandler } from "../../utils/async";
 import { processIdentityRateLimitMiddleware } from "../../middleware/process-identity-rate-limit-middleware";
 
@@ -15,6 +18,11 @@ router.get(
   allowUserJourneyMiddleware,
   processIdentityRateLimitMiddleware,
   asyncHandler(proveIdentityCallbackGet())
+);
+
+router.get(
+  PATH_NAMES.PROVE_IDENTITY_CALLBACK_SESSION_EXPIRY_ERROR,
+  proveIdentityCallbackSessionExpiryError
 );
 
 export { router as proveIdentityCallbackRouter };

--- a/src/components/prove-identity-callback/session-expiry-error.njk
+++ b/src/components/prove-identity-callback/session-expiry-error.njk
@@ -1,0 +1,14 @@
+{% extends "common/layout/base.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitleName = 'error.proveIdentityCallbackSessionExpiryError.title' | translate %}
+
+{% block content %}
+
+    <h1 class="govuk-heading-l">{{ 'error.proveIdentityCallbackSessionExpiryError.header' | translate }}</h1>
+    <p class="govuk-body">{{ 'error.proveIdentityCallbackSessionExpiryError.content.paragraph' | translate }}</p>
+    <p class="govuk-heading-m">{{ 'error.proveIdentityCallbackSessionExpiryError.content.section1.header' | translate }}</p>
+    <p class="govuk-body">{{ 'error.proveIdentityCallbackSessionExpiryError.content.section1.paragraph1' | translate }}</p>
+    <p class="govuk-body">{{ 'error.proveIdentityCallbackSessionExpiryError.content.section1.paragraph2' | translate }}</p>
+
+{% endblock %}

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -130,6 +130,18 @@
         },
         "govUKHomepageButtonHref": "https://www.gov.uk/"
       }
+    },
+    "proveIdentityCallbackSessionExpiryError": {
+      "title": "Mae’n ddrwg gennym, mae problem",
+      "header": "Mae’n ddrwg gennym, mae problem",
+      "content": {
+        "paragraph": "Ni allwn eich dychwelyd i’r gwasanaeth ar hyn o bryd.",
+        "section1": {
+          "header": "Beth allwch chi ei wneud",
+          "paragraph1": "Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio. Gallwch chwilio am y gwasanaeth gan ddefnyddio eich peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.",
+          "paragraph2": "Ni fydd angen i chi brofi eich hunaniaeth eto."
+        }
+      }
     }
   },
   "pages": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -130,6 +130,18 @@
         },
         "govUKHomepageButtonHref": "https://www.gov.uk/"
       }
+    },
+    "proveIdentityCallbackSessionExpiryError": {
+      "title": "Sorry, there is a problem",
+      "header": "Sorry, there is a problem",
+      "content": {
+        "paragraph": "We cannot return you to the service at the moment.",
+        "section1": {
+          "header": "What you can do",
+          "paragraph1": "Go back to the service you were trying to use. You can look for the service using your search engine or find it from the GOV.UK homepage.",
+          "paragraph2": "You will not need to prove your identity again."
+        }
+      }
     }
   },
   "pages": {


### PR DESCRIPTION
## What?

Creates a "Sorry, there is a problem" screen specifically for users whose auth session has expired during their IPV journey.

## Why?

This is part of the work to reduce the session timeout from 2 hours to 1 hour. 

### Screenshot English
<img width="422" alt="Screenshot 2023-06-27 at 09 18 53" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/a77b0371-f795-4f7a-b55d-bffcb99835a8">

### Screenshot Welsh
<img width="426" alt="Screenshot 2023-07-04 at 10 59 51" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/ade91978-bdfe-47ea-b0bd-579bc2295071">

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
