### PR TITLE
AUT-1283: Initiate a 15 minutes block in password-reset journey from requesting a new OTP code whilst user is blocked

### DIFF
--- a/src/components/common/constants.ts
+++ b/src/components/common/constants.ts
@@ -18,6 +18,7 @@ export enum SecurityCodeErrorType {
   ChangeSecurityCodesEmailMaxCodesSent = "changeSecurityCodesEmailMaxCodesSent",
   ChangeSecurityCodesEmailBlocked = "changeSecurityCodesEmailBlocked",
   ChangeSecurityCodesEmailMaxRetries = "changeSecurityCodesEmailMaxRetries",
+  InvalidPasswordResetCodeMaxRetries = "invalidPasswordResetCodeMaxRetries",
 }
 
 export const ERROR_CODES = {
@@ -100,7 +101,7 @@ export const ERROR_CODE_MAPPING: { [p: string]: string } = {
     pathWithQueryParam(
       PATH_NAMES["SECURITY_CODE_INVALID"],
       SECURITY_CODE_ERROR,
-      SecurityCodeErrorType.EmailMaxRetries
+      SecurityCodeErrorType.InvalidPasswordResetCodeMaxRetries
     ),
   [ERROR_CODES.VERIFY_EMAIL_MAX_CODES_SENT]: pathWithQueryParam(
     PATH_NAMES["SECURITY_CODE_WAIT"],

--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -13,9 +13,14 @@ import xss from "xss";
 
 export function resendEmailCodeGet(req: Request, res: Response): void {
   if (
-    req.session.user.wrongCodeEnteredAccountRecoveryLock &&
-    new Date().getTime() <
-      new Date(req.session.user.wrongCodeEnteredAccountRecoveryLock).getTime()
+    (req.session.user.wrongCodeEnteredAccountRecoveryLock &&
+      new Date().getTime() <
+        new Date(
+          req.session.user.wrongCodeEnteredAccountRecoveryLock
+        ).getTime()) ||
+    (req.session.user.wrongCodeEnteredPasswordResetLock &&
+      new Date().getTime() <
+        new Date(req.session.user.wrongCodeEnteredPasswordResetLock).getTime())
   ) {
     const newCodeLink = req.query?.isResendCodeRequest
       ? "/security-code-check-time-limit?isResendCodeRequest=true"

--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -32,6 +32,22 @@ export function resetPasswordCheckEmailGet(
       );
     }
 
+    if (
+      req.session.user.wrongCodeEnteredPasswordResetLock &&
+      new Date().getTime() <
+        new Date(req.session.user.wrongCodeEnteredPasswordResetLock).getTime()
+    ) {
+      const newCodeLink = req.query?.isResendCodeRequest
+        ? "/security-code-check-time-limit?isResendCodeRequest=true"
+        : "/security-code-check-time-limit";
+      return res.render(
+        "security-code-error/index-security-code-entered-exceeded.njk",
+        {
+          newCodeLink,
+        }
+      );
+    }
+
     if (!requestCode || result.success) {
       return res.render(TEMPLATE_NAME, {
         email,

--- a/src/config.ts
+++ b/src/config.ts
@@ -135,3 +135,9 @@ export function getAccountRecoveryCodeEnteredWrongBlockDurationInMinutes(): numb
     15
   );
 }
+
+export function getPasswordResetCodeEnteredWrongBlockDurationInMinutes(): number {
+  return (
+    Number(process.env.PASSWORD_RESET_CODE_ENTERED_WRONG_BLOCKED_MINUTES) || 15
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -59,6 +59,7 @@ export interface UserSession {
   wrongCodeEnteredLock?: string;
   codeRequestLock?: string;
   wrongCodeEnteredAccountRecoveryLock?: string;
+  wrongCodeEnteredPasswordResetLock?: string;
   isAccountRecoveryPermitted?: boolean;
   isAccountRecoveryJourney?: boolean;
   isAccountRecoveryCodeResent?: boolean;


### PR DESCRIPTION
## What?

Initiate a 15 mins block when a user attempts to request a new code whilst 15 mins blocked period has not elapsed
- When user clicks on the 'get new code' CTA, they are redirected to 'You cannot get a new security code at the moment' page when 15 mins blocked period is still active
- Create a separate lock session specifically for Password Reset `wrongCodeEnteredPasswordResetLock`

## Why?

To stop users from requesting multiple Password Reset OTP too many times

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated