### PR TITLE
BAU: Disable library email length validation

### DIFF
--- a/src/components/enter-email/enter-email-validation.ts
+++ b/src/components/enter-email/enter-email-validation.ts
@@ -25,7 +25,7 @@ export function validateEnterEmailRequest(
           }
         );
       })
-      .isEmail()
+      .isEmail({ ignore_max_length: true })
       .withMessage((value, { req }) => {
         return req.t(
           "pages.enterEmailExistingAccount.email.validationError.email",


### PR DESCRIPTION
## What?
- The validation library we use, `express-validator`, wraps `validator.js`.
- This enforces a length limit of 64 characters on the user (part before @ sign) (see source code here: https://github.com/validatorjs/validator.js/blob/63b1e4dc16ad77489745d2b2309431bce16dab60/src/lib/isEmail.js#L136)
- We don't need this as we already validate length, so I turned this library default off
- We also assume that `!isEmail()` means the format is fundamentally invalid, so the error message we currently display is misleading in this scenario, where it's more of a length problem

Before:
<img width="751" alt="image" src="https://github.com/alphagov/di-authentication-frontend/assets/106964077/ee44d718-5ae0-4900-80c4-5d7aca752f7e">

After:
<img width="1030" alt="image" src="https://github.com/alphagov/di-authentication-frontend/assets/106964077/52291d1b-7df9-430f-ae94-628d1bd889db">


## Why?
- To avoid 'hidden' validation rules that conflict with rules we have set explicitly, and to give more accurate error messages
