### PR TITLE
AUT-1282: Create new code request lock for account recovery journey

### DIFF
--- a/src/components/resend-email-code/resend-email-code-controller.ts
+++ b/src/components/resend-email-code/resend-email-code-controller.ts
@@ -94,11 +94,17 @@ export function resendEmailCodePost(
 export function securityCodeCheckTimeLimit(): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const { sessionId } = res.locals;
-    const isAccountRecoveryJourney = req.session.user?.isAccountRecoveryJourney;
+    const {
+      isAccountRecoveryJourney,
+      codeRequestLock,
+      codeRequestAccountRecoveryLock,
+    } = req.session.user;
+    const currentTime = new Date().getTime();
+
     if (
-      req.session.user.codeRequestLock &&
-      new Date().getTime() <
-        new Date(req.session.user.codeRequestLock).getTime()
+      (codeRequestLock && currentTime < new Date(codeRequestLock).getTime()) ||
+      (codeRequestAccountRecoveryLock &&
+        currentTime < new Date(codeRequestAccountRecoveryLock).getTime())
     ) {
       const newCodeLink = req.query?.isResendCodeRequest
         ? "/security-code-check-time-limit?isResendCodeRequest=true"

--- a/src/components/security-code-error/security-code-error-controller.ts
+++ b/src/components/security-code-error/security-code-error-controller.ts
@@ -8,6 +8,7 @@ import { PATH_NAMES } from "../../app.constants";
 import {
   getAccountRecoveryCodeEnteredWrongBlockDurationInMinutes,
   getCodeEnteredWrongBlockDurationInMinutes,
+  getCodeRequestAccountRecoveryBlockDurationInMinutes,
   getCodeRequestBlockDurationInMinutes,
 } from "../../config";
 
@@ -47,9 +48,18 @@ export function securityCodeTriesExceededGet(
   req: Request,
   res: Response
 ): void {
-  req.session.user.codeRequestLock = new Date(
-    Date.now() + getCodeRequestBlockDurationInMinutes() * 60000
-  ).toUTCString();
+  switch (req.query.actionType) {
+    case SecurityCodeErrorType.ChangeSecurityCodesEmailMaxCodesSent:
+      req.session.user.codeRequestAccountRecoveryLock = new Date(
+        Date.now() +
+          getCodeRequestAccountRecoveryBlockDurationInMinutes() * 60000
+      ).toUTCString();
+      break;
+    default:
+      req.session.user.codeRequestLock = new Date(
+        Date.now() + getCodeRequestBlockDurationInMinutes() * 60000
+      ).toUTCString();
+  }
   return res.render("security-code-error/index-too-many-requests.njk", {
     newCodeLink: getNewCodePath(req.query.actionType as SecurityCodeErrorType),
     isResendCodeRequest: req.query.isResendCodeRequest,

--- a/src/config.ts
+++ b/src/config.ts
@@ -125,6 +125,12 @@ export function getCodeRequestBlockDurationInMinutes(): number {
   return Number(process.env.CODE_REQUEST_BLOCKED_MINUTES) || 15;
 }
 
+export function getCodeRequestAccountRecoveryBlockDurationInMinutes(): number {
+  return (
+    Number(process.env.CODE_REQUEST_ACCOUNT_RECOOVERY_BLOCKED_MINUTES) || 15
+  );
+}
+
 export function getCodeEnteredWrongBlockDurationInMinutes(): number {
   return Number(process.env.CODE_ENTERED_WRONG_BLOCKED_MINUTES) || 15;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface UserSession {
   isAccountRecoveryJourney?: boolean;
   isAccountRecoveryCodeResent?: boolean;
   accountRecoveryVerifiedMfaType?: string;
+  codeRequestAccountRecoveryLock?: string;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What?

Initiate a 15 minutes block for a user in account recovery journey when attempting to request an OTP

- Create a new `codeRequestAccountRecoveryLock` session when user has maxed out call for OTP code request (i.e. user clicks the 'send the code again' CTA)
- Return the user to 'You cannot get a new security code at the moment’ whilst the 15 mins code request block period has not elapsed

## Why?

To block users from requesting a new code multiple times.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated
