### PR TITLE
AUT-1274: Replace Password Reset error pages with security-code-error page when user is blocked from requesting OTP

### DIFF
--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -46,8 +46,8 @@ export function resetPasswordCheckEmailGet(
     ) {
       const errorTemplate =
         result.data.code === ERROR_CODES.RESET_PASSWORD_LINK_MAX_RETRIES_REACHED
-          ? "reset-password-check-email/index-exceeded-request-count.njk"
-          : "reset-password-check-email/index-request-attempt-blocked.njk";
+          ? "security-code-error/index-too-many-requests.njk"
+          : "security-code-error/index-wait.njk";
 
       return res.render(errorTemplate);
     } else {


### PR DESCRIPTION
## What?

Currently in prod, when a user is blocked from requesting OTP during password reset journey, that is they have clicked on the 'Send the code again' CTA they are redirected to the pages below which the makes references to password reset and not OTP timeout request. 

![image](https://github.com/alphagov/di-authentication-frontend/assets/110528805/80b3c8fb-fe72-4efc-a0fa-b5cf27df086f)

![image](https://github.com/alphagov/di-authentication-frontend/assets/110528805/ebde2dbb-8436-4826-88a2-2a16ace5b476)

The change is to redirect the user to the following pages instead:

![image](https://github.com/alphagov/di-authentication-frontend/assets/110528805/b4cca119-0490-4962-bcfa-1cba6f673147)


## Why?

Ensure the right content is displayed to user, in order to give a better understanding of why they are blocked from progressing through the password reset journey

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated