### PR TITLE
AUT-1412: Override Password Reset code blocked minutes env in build

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -5,10 +5,11 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
-support_international_numbers        = "1"
-support_language_cy                  = "1"
-support_account_recovery             = "1"
-support_auth_support_auth_orch_split = "1"
+support_international_numbers                     = "1"
+support_language_cy                               = "1"
+support_account_recovery                          = "1"
+support_auth_support_auth_orch_split              = "1"
+password_reset_code_entered_wrong_blocked_minutes = 0.5
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -108,6 +108,10 @@ locals {
         name  = "SERVICE_DOMAIN"
         value = local.service_domain
       },
+      {
+        name  = "PASSWORD_RESET_CODE_ENTERED_WRONG_BLOCKED_MINUTES"
+        value = var.password_reset_code_entered_wrong_blocked_minutes
+      },
     ]
 
     mountPoints = [

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -182,3 +182,9 @@ variable "basic_auth_bypass_cidr_blocks" {
   type        = list(string)
   description = "The list of CIDR blocks allowed to bypass basic auth (if enabled)"
 }
+
+variable "password_reset_code_entered_wrong_blocked_minutes" {
+  default     = 15
+  description = "The duration, in minutes, for which a user is blocked after entering the wrong password reset code multiple times"
+}
+


### PR DESCRIPTION
## What?

- Set `PASSWORD_RESET_CODE_ENTERED_WRONG_BLOCKED_MINUTES` env variable in build to 3000 (30 seconds)
- In order to be consistent with the frontend API

## Why?

Currently in build, when a user is blocked is blocked from entering code, the default elapsed time is set to 15 minutes in build environment. It should rather be set to 30 seconds to be consistent with the Frontend API.
