### PR TITLE
AUT-1412: Fix unmarshal number terraform error by redefining the variable to string value

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -9,7 +9,7 @@ support_international_numbers                     = "1"
 support_language_cy                               = "1"
 support_account_recovery                          = "1"
 support_auth_support_auth_orch_split              = "1"
-password_reset_code_entered_wrong_blocked_minutes = 0.5
+password_reset_code_entered_wrong_blocked_minutes = "0.5"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -184,7 +184,7 @@ variable "basic_auth_bypass_cidr_blocks" {
 }
 
 variable "password_reset_code_entered_wrong_blocked_minutes" {
-  default     = 15
+  default     = "15"
   description = "The duration, in minutes, for which a user is blocked after entering the wrong password reset code multiple times"
 }
 


### PR DESCRIPTION
## What?

Fixes the error below:

`│ Error: ECS Task Definition container_definitions is invalid: Error decoding JSON: json: cannot unmarshal number into Go struct field KeyValuePair.Environment.Value of type string`

 - redefine the variable to string value
 
