### PR TITLE
AUT-1282: Override code blocked minutes in build from 15 mins to 30 secs

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -5,11 +5,12 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
-support_international_numbers                     = "1"
-support_language_cy                               = "1"
-support_account_recovery                          = "1"
-support_auth_support_auth_orch_split              = "1"
-password_reset_code_entered_wrong_blocked_minutes = "0.5"
+support_international_numbers                       = "1"
+support_language_cy                                 = "1"
+support_account_recovery                            = "1"
+support_auth_support_auth_orch_split                = "1"
+password_reset_code_entered_wrong_blocked_minutes   = "0.5"
+account_recovery_code_entered_wrong_blocked_minutes = "0.5"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -112,6 +112,10 @@ locals {
         name  = "PASSWORD_RESET_CODE_ENTERED_WRONG_BLOCKED_MINUTES"
         value = var.password_reset_code_entered_wrong_blocked_minutes
       },
+      {
+        name  = "ACCOUNT_RECOVERY_CODE_ENTERED_WRONG_BLOCKED_MINUTES"
+        value = var.account_recovery_code_entered_wrong_blocked_minutes
+      },
     ]
 
     mountPoints = [

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -188,3 +188,8 @@ variable "password_reset_code_entered_wrong_blocked_minutes" {
   description = "The duration, in minutes, for which a user is blocked after entering the wrong password reset code multiple times"
 }
 
+variable "account_recovery_code_entered_wrong_blocked_minutes" {
+  default     = "15"
+  description = "The duration, in minutes, for which a user is blocked after entering the wrong account recovery code multiple times"
+}
+


### PR DESCRIPTION
## What?

Instead of setting the default elapsed time to 15 minutes when a user is blocked from entering code during the account recovery journey in the build environment, it should be set to 30 seconds.
