### PR TITLE
BAU - Add account recovery URLs to GA tracking

### DIFF
--- a/src/assets/javascript/cookies.js
+++ b/src/assets/javascript/cookies.js
@@ -247,6 +247,8 @@ var cookies = function (trackingId, analyticsCookieDomain) {
         "password reset",
         "end"
       ),
+      "/check-email-change-security-codes": generateSessionJourney("change security codes", "start"),
+      "/change-codes-confirmed": generateSessionJourney("change security codes", "end"),
     };
 
     return JOURNEY_DATA_LAYER_PATHS[url];


### PR DESCRIPTION
## What?

- Add account recovery URLs to GA tracking

## Why?

- We have added 2 new pages for the account recovery journey. We need to add the data layers so that they are present for the GA (Universal Analytics)
