### PR TITLE
AUT-1096: Set default value for orch_to_auth_signing_public_key

### DIFF
--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -196,4 +196,5 @@ variable "account_recovery_code_entered_wrong_blocked_minutes" {
 variable "orch_to_auth_signing_public_key" {
   description = "Public key counterpart for KMS key created in Orchestration/OIDC API"
   type        = string
+  default     = ""
 }


### PR DESCRIPTION

## What?

Set default value for orch_to_auth_signing_public_key

## Why?

Mandatory tf var is causing the build to fail.

## Related PRs

#1096 