### PR TITLE
AUT-1427: Validation on enter auth app code screen (account creation or recovery)

### DIFF
--- a/src/components/setup-authenticator-app/setup-authenticator-app-validation.ts
+++ b/src/components/setup-authenticator-app/setup-authenticator-app-validation.ts
@@ -2,6 +2,7 @@ import { body } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import { Request } from "express";
+import { containsNumbersOnly } from "../../utils/strings";
 
 export function validateSetupAuthAppRequest(): ValidationChainFunc {
   return [
@@ -18,11 +19,21 @@ export function validateSetupAuthAppRequest(): ValidationChainFunc {
       .isLength({ min: 6, max: 6 })
       .withMessage((value, { req }) => {
         return req.t(
-          "pages.setupAuthenticatorApp.code.validationError.length",
+          "pages.setupAuthenticatorApp.code.validationError.invalidFormat",
           {
             value,
           }
         );
+      })
+      .custom((value, { req }) => {
+        if (!containsNumbersOnly(value)) {
+          throw new Error(
+            req.t(
+              "pages.setupAuthenticatorApp.code.validationError.invalidFormat"
+            )
+          );
+        }
+        return true;
       }),
     validateBodyMiddleware(
       "setup-authenticator-app/index.njk",

--- a/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
+++ b/src/components/setup-authenticator-app/tests/setup-authenticator-app-integration.test.ts
@@ -113,6 +113,25 @@ describe("Integration::setup-authenticator-app", () => {
       .expect(400, done);
   });
 
+  it("should return validation error when code has non-digit characters", (done) => {
+    request(app)
+      .post(PATH_NAMES.CREATE_ACCOUNT_SETUP_AUTHENTICATOR_APP)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "asdfgh",
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("#code-error").text()).to.contains(
+          "Enter the security code using only 6 digits"
+        );
+        expect($("#secret-key").text()).to.not.be.empty;
+      })
+      .expect(400, done);
+  });
+
   it("should redirect to /account-created page when successful validation of code", (done) => {
     nock(baseApi)
       .post(API_ENDPOINTS.VERIFY_MFA_CODE)

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1948,7 +1948,7 @@
         "validationError": {
           "required": "Rhowch y cod diogelwch a ddangosir yn eich ap dilysydd",
           "invalidCode": "Nid yw’r cod diogelwch rydych wedi’i roi yn gywir, ceisiwch ei roi i mewn eto neu aros i’ch ap dilysydd roi cod newydd i chi",
-          "length": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig"
+          "invalidFormat": "Rhowch y cod diogelwch gan ddefnyddio 6 digid yn unig"
         }
       },
       "continueButtonText": "Parhau",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1948,7 +1948,7 @@
         "validationError": {
           "required": "Enter the security code shown in your authenticator app",
           "invalidCode": "The security code you entered is not correct, try entering it again or wait for for your authenticator app to give you a new code",
-          "length": "Enter the security code using only 6 digits"
+          "invalidFormat": "Enter the security code using only 6 digits"
         }
       },
       "continueButtonText": "Continue",


### PR DESCRIPTION
## What?
- Bugfix validation on enter auth app code screen (account creation/recovery)

## Why?
- Handle scenario where user enters non-digit characters

## Change have been demonstrated
This is already the expected behaviour