### PR TITLE
AUT-1421: Implement redirection to error page for excessive invalid Email OTP attempts

### DIFF
--- a/src/components/reset-password-check-email/reset-password-check-email-controller.ts
+++ b/src/components/reset-password-check-email/reset-password-check-email-controller.ts
@@ -58,6 +58,7 @@ export function resetPasswordCheckEmailGet(
       [
         ERROR_CODES.RESET_PASSWORD_LINK_MAX_RETRIES_REACHED,
         ERROR_CODES.RESET_PASSWORD_LINK_BLOCKED,
+        ERROR_CODES.ENTERED_INVALID_PASSWORD_RESET_CODE_MAX_TIMES,
       ].includes(result.data.code)
     ) {
       const errorTemplate =


### PR DESCRIPTION
## What?

This is a change to supplement API change which will return `1039` error code when a user has entered too many invalid Email OTPs.

## Why?

This update rectifies a bug regarding inconsistency where a blocked user could initiate a new session and, incorrectly, be given another chance to enter an OTP.

## Related PRs

API Change (https://github.com/alphagov/di-authentication-api/pull/3161)
