### PR TITLE
AUT-1426: Fix code resend link SMS account recovery

### DIFF
--- a/src/components/check-your-phone/check-your-phone-controller.ts
+++ b/src/components/check-your-phone/check-your-phone-controller.ts
@@ -25,23 +25,16 @@ import { BadRequestError } from "../../utils/error";
 import { verifyMfaCodeService } from "../common/verify-mfa-code/verify-mfa-code-service";
 
 const TEMPLATE_NAME = "check-your-phone/index.njk";
+const RESEND_CODE_LINK = pathWithQueryParam(
+  PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION,
+  "isResendCodeRequest",
+  "true"
+);
 
 export function checkYourPhoneGet(req: Request, res: Response): void {
-  const resendCodeLink = pathWithQueryParam(
-    PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION,
-    "isResendCodeRequest",
-    "true"
-  );
-
-  if (req.session.user.isAccountCreationJourney) {
-    return res.render(TEMPLATE_NAME, {
-      phoneNumber: req.session.user.redactedPhoneNumber,
-      resendCodeLink,
-    });
-  }
   return res.render(TEMPLATE_NAME, {
     phoneNumber: req.session.user.redactedPhoneNumber,
-    resendCodeLink,
+    resendCodeLink: RESEND_CODE_LINK,
   });
 }
 
@@ -76,7 +69,9 @@ export const checkYourPhonePost = (
           "code",
           req.t("pages.checkYourPhone.code.validationError.invalidCode")
         );
-        return renderBadRequest(res, req, TEMPLATE_NAME, error);
+        return renderBadRequest(res, req, TEMPLATE_NAME, error, {
+          resendCodeLink: RESEND_CODE_LINK,
+        });
       }
 
       const path = getErrorPathByCode(result.data.code);

--- a/src/components/check-your-phone/check-your-phone-validation.ts
+++ b/src/components/check-your-phone/check-your-phone-validation.ts
@@ -1,6 +1,8 @@
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import { validateCode } from "../common/verify-code/verify-code-validation";
+import { pathWithQueryParam } from "../common/constants";
+import { PATH_NAMES } from "../../app.constants";
 
 export function validateSmsCodeRequest(): ValidationChainFunc {
   return [
@@ -10,6 +12,17 @@ export function validateSmsCodeRequest(): ValidationChainFunc {
       minLengthKey: "pages.checkYourPhone.code.validationError.minLength",
       numbersOnlyKey: "pages.checkYourPhone.code.validationError.invalidFormat",
     }),
-    validateBodyMiddleware("check-your-phone/index.njk"),
+    validateBodyMiddleware("check-your-phone/index.njk", postValidationLocals),
   ];
 }
+
+const postValidationLocals = function locals(): Record<string, unknown> {
+  const resendCodeLinkAsPostValidationLocal = pathWithQueryParam(
+    PATH_NAMES.RESEND_MFA_CODE_ACCOUNT_CREATION,
+    "isResendCodeRequest",
+    "true"
+  );
+  return {
+    resendCodeLink: resendCodeLinkAsPostValidationLocal,
+  };
+};


### PR DESCRIPTION
## What?
- When a user submitted an incorrect or invalid code in account recovery, choosing SMS as their new MFA type, they would lose a 'local' in the validation process (this happens because the [renderBadRequest function](https://github.com/alphagov/di-authentication-frontend/blob/1c4dd395ef450977837ce31bd0222e6ba20b6921/src/utils/validation.ts#L82) doesn't pass through the controller and can only access local variables that have been passed explicitly)
- The loss of this 'local' meant that the resend code URL was no longer available to the template, so the `href` would default to the current page i.e. looping the user back to the same place if they tried to click "send the code again"
- This happened through 2 different mechanisms depending on the type of validation error: one mechanism for an _invalid_ code e.g. "1a3" and another for a code that could have been valid but was simply _incorrect_ in the sense of not matching the Redis record on the back end e.g. "111111" when the actual stored value might have been "123456"
- Each mechanism has been fixed separately:
    - For invalid codes, the resend URL will now be passed as a post validation local via the validator ([this](https://github.com/alphagov/di-authentication-frontend/pull/1105/files#diff-60e25930b387db5470d8f277713e70c6bcc41bc7070fc8d2e9a4b84713415876R16)) - in this scenario the code execution never reaches the POST handler; it renders the template before getting that far
    - For incorrect codes, it will also be passed as a post validation local but via a conditional block in the POST handler/controller ([this](https://github.com/alphagov/di-authentication-frontend/pull/1105/files#diff-a5693e2b0b4edf050f58cde126fe84553ded7dfbcf10f4e3f8c71db32502bef0R71))

## Why?
- The existing behaviour was incorrect

## Change have been demonstrated
- N/A - only a front end change in the sense of fixing an incorrect behaviour