### PR TITLE
AUT-1435: Add govuk-link class to Privacy notice links

### DIFF
--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -17,7 +17,7 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.about.paragraph_two.part_one' | translate }}
-        <a href="{{ "pages.privacy.sections.about.paragraph_two.part_two.link_href" | translate }}">{{ "pages.privacy.sections.about.paragraph_two.part_two.link_text" | translate }}</a>{{ 'pages.privacy.sections.about.paragraph_two.part_three' | translate }}
+        <a class="govuk-link" href="{{ "pages.privacy.sections.about.paragraph_two.part_two.link_href" | translate }}">{{ "pages.privacy.sections.about.paragraph_two.part_two.link_text" | translate }}</a>{{ 'pages.privacy.sections.about.paragraph_two.part_three' | translate }}
     </p>
 
     <p class="govuk-body">
@@ -68,9 +68,9 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_one.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_one.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_one.link_text' | translate }}</a>
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_one.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_one.link_text' | translate }}</a>
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_one.part_two' | translate }}
-        <a href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_two.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_two.link_text' | translate }}</a>
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_two.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_two.link_text' | translate }}</a>
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_one.part_three' | translate }}
     </p>
 
@@ -162,7 +162,7 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.link.link_text' | translate }}</a>.
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.link.link_text' | translate }}</a>.
     </p>
 
     <p class="govuk-body">
@@ -203,7 +203,7 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_five.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_five.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_five.link.link_text' | translate }}</a>.
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_five.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_five.link.link_text' | translate }}</a>.
     </p>
 
     <p class="govuk-body">
@@ -352,10 +352,10 @@
 
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.privacy.sections.legal_basis.list_two.item_one.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.legal_basis.list_two.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.legal_basis.list_two.item_one.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.legal_basis.list_two.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.legal_basis.list_two.item_one.link_text' | translate }}</a>
         </li>
         <li>{{ 'pages.privacy.sections.legal_basis.list_two.item_two.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.legal_basis.list_two.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.legal_basis.list_two.item_two.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.legal_basis.list_two.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.legal_basis.list_two.item_two.link_text' | translate }}</a>
         </li>
     </ul>
 
@@ -461,16 +461,16 @@
 
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.privacy.sections.who_we_share_with.list_four.item_one.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_one.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_one.link_text' | translate }}</a>
         </li>
         <li>{{ 'pages.privacy.sections.who_we_share_with.list_four.item_two.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_two.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_two.link_text' | translate }}</a>
         </li>
         <li>{{ 'pages.privacy.sections.who_we_share_with.list_four.item_three.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_three.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_three.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_three.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_three.link_text' | translate }}</a>
         </li>
         <li>{{ 'pages.privacy.sections.who_we_share_with.list_four.item_four.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_four.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_four.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_four.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_four.link_text' | translate }}</a>
         </li>
         <li>{{ 'pages.privacy.sections.who_we_share_with.list_four.item_five' | translate }}</li>
     </ul>
@@ -593,10 +593,10 @@
 
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.link_text' | translate }}</a>
         </li>
         <li>
-            <a href="{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_two.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_two.link_text' | translate }}</a>
         </li>
     </ul>
 
@@ -640,7 +640,7 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.your_rights.paragraph_one.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.your_rights.paragraph_one.link_href' | translate }}">{{ 'pages.privacy.sections.your_rights.paragraph_one.link_text' | translate }}</a>.
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.your_rights.paragraph_one.link_href' | translate }}">{{ 'pages.privacy.sections.your_rights.paragraph_one.link_text' | translate }}</a>.
     </p>
 
     <p class="govuk-body">
@@ -662,7 +662,7 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.link_text' | translate }}</a>
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.link_text' | translate }}</a>
         {{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.part_three' | translate }}
     </p>
 
@@ -679,7 +679,7 @@
     <div class="contact">
         <p class="govuk-body">{{ 'pages.privacy.sections.contact_us_or_make_complaint.data_protection_officer.title' | translate }}
             <br>
-            <a href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.data_protection_officer.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.data_protection_officer.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.data_protection_officer.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.data_protection_officer.link_text' | translate }}</a>
         </p>
     </div>
 
@@ -700,13 +700,13 @@
             {{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.address_five' | translate }}
             <br>
             {{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.email.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.email.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.email.link_text' | translate }}</a><br>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.email.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.email.link_text' | translate }}</a><br>
             {{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.telephone' | translate }}
             <br>
             {{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.textphone' | translate }}
             <br>
             {{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.hours' | translate }}<br>
-            <a href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.call_charges.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.call_charges.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.call_charges.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.call_charges.link_text' | translate }}</a>
         </p>
     </div>
 


### PR DESCRIPTION
## What?

Adds `govuk-link` class to links in the privacy notice

## Why?

So they reflect the link focus states (for hover, focus, visited etc.) set out in the Design System.

### Screenshots

#### Link focus display before change

<img width="668" alt="Screenshot 2023-07-18 at 11 58 37" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/e15e92d8-0c08-4726-911f-f4a12b61fc90">

#### Link focus display after change

<img width="673" alt="Screenshot 2023-07-18 at 11 58 55" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/4bbf20ee-6b20-459e-9b98-615722d60a30">

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
