### PR TITLE
AUT-1335: Add radios to an ID Check app form

### DIFF
--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -17,7 +17,7 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.about.paragraph_two.part_one' | translate }}
-        <a href="{{ "pages.privacy.sections.about.paragraph_two.part_two.link_href" | translate }}">{{ "pages.privacy.sections.about.paragraph_two.part_two.link_text" | translate }}</a>{{ 'pages.privacy.sections.about.paragraph_two.part_three' | translate }}
+        <a class="govuk-link" href="{{ "pages.privacy.sections.about.paragraph_two.part_two.link_href" | translate }}">{{ "pages.privacy.sections.about.paragraph_two.part_two.link_text" | translate }}</a>{{ 'pages.privacy.sections.about.paragraph_two.part_three' | translate }}
     </p>
 
     <p class="govuk-body">
@@ -68,9 +68,9 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_one.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_one.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_one.link_text' | translate }}</a>
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_one.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_one.link_text' | translate }}</a>
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_one.part_two' | translate }}
-        <a href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_two.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_two.link_text' | translate }}</a>
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_two.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_one.link_two.link_text' | translate }}</a>
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_one.part_three' | translate }}
     </p>
 
@@ -162,7 +162,7 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.link.link_text' | translate }}</a>.
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_id_check_app.paragraph_sixteen.link.link_text' | translate }}</a>.
     </p>
 
     <p class="govuk-body">
@@ -203,7 +203,7 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_five.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_five.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_five.link.link_text' | translate }}</a>.
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_five.link.link_href' | translate }}">{{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_five.link.link_text' | translate }}</a>.
     </p>
 
     <p class="govuk-body">
@@ -352,10 +352,10 @@
 
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.privacy.sections.legal_basis.list_two.item_one.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.legal_basis.list_two.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.legal_basis.list_two.item_one.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.legal_basis.list_two.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.legal_basis.list_two.item_one.link_text' | translate }}</a>
         </li>
         <li>{{ 'pages.privacy.sections.legal_basis.list_two.item_two.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.legal_basis.list_two.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.legal_basis.list_two.item_two.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.legal_basis.list_two.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.legal_basis.list_two.item_two.link_text' | translate }}</a>
         </li>
     </ul>
 
@@ -461,16 +461,16 @@
 
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.privacy.sections.who_we_share_with.list_four.item_one.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_one.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_one.link_text' | translate }}</a>
         </li>
         <li>{{ 'pages.privacy.sections.who_we_share_with.list_four.item_two.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_two.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_two.link_text' | translate }}</a>
         </li>
         <li>{{ 'pages.privacy.sections.who_we_share_with.list_four.item_three.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_three.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_three.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_three.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_three.link_text' | translate }}</a>
         </li>
         <li>{{ 'pages.privacy.sections.who_we_share_with.list_four.item_four.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_four.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_four.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.who_we_share_with.list_four.item_four.link_href' | translate }}">{{ 'pages.privacy.sections.who_we_share_with.list_four.item_four.link_text' | translate }}</a>
         </li>
         <li>{{ 'pages.privacy.sections.who_we_share_with.list_four.item_five' | translate }}</li>
     </ul>
@@ -593,10 +593,10 @@
 
     <ul class="govuk-list govuk-list--bullet">
         <li>{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.link_text' | translate }}</a>
         </li>
         <li>
-            <a href="{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_two.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_two.link_text' | translate }}</a>
         </li>
     </ul>
 
@@ -640,7 +640,7 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.your_rights.paragraph_one.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.your_rights.paragraph_one.link_href' | translate }}">{{ 'pages.privacy.sections.your_rights.paragraph_one.link_text' | translate }}</a>.
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.your_rights.paragraph_one.link_href' | translate }}">{{ 'pages.privacy.sections.your_rights.paragraph_one.link_text' | translate }}</a>.
     </p>
 
     <p class="govuk-body">
@@ -662,7 +662,7 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.part_one' | translate }}
-        <a href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.link_text' | translate }}</a>
+        <a class="govuk-link" href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.link_text' | translate }}</a>
         {{ 'pages.privacy.sections.contact_us_or_make_complaint.paragraph_one.part_three' | translate }}
     </p>
 
@@ -679,7 +679,7 @@
     <div class="contact">
         <p class="govuk-body">{{ 'pages.privacy.sections.contact_us_or_make_complaint.data_protection_officer.title' | translate }}
             <br>
-            <a href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.data_protection_officer.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.data_protection_officer.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.data_protection_officer.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.data_protection_officer.link_text' | translate }}</a>
         </p>
     </div>
 
@@ -700,13 +700,13 @@
             {{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.address_five' | translate }}
             <br>
             {{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.email.part_one' | translate }}
-            <a href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.email.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.email.link_text' | translate }}</a><br>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.email.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.email.link_text' | translate }}</a><br>
             {{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.telephone' | translate }}
             <br>
             {{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.textphone' | translate }}
             <br>
             {{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.hours' | translate }}<br>
-            <a href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.call_charges.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.call_charges.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.call_charges.link_href' | translate }}">{{ 'pages.privacy.sections.contact_us_or_make_complaint.information_commissioner.call_charges.link_text' | translate }}</a>
         </p>
     </div>
 

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -297,6 +297,7 @@ export function contactUsQuestionsFormPost(
       themeQuestions: themeQuestions,
       referer: validateReferer(req.body.referer),
       securityCodeSentMethod: req.body.securityCodeSentMethod,
+      identityDocumentUsed: req.body.identityDocumentUsed,
     });
 
     logger.info(
@@ -452,6 +453,22 @@ export function getQuestionsFromFormType(
       })}`,
       serviceTryingToUse: req.t(
         "pages.contactUsQuestions.serviceTryingToUse.header",
+        { lng: "en" }
+      ),
+    },
+    idCheckAppPhotoProblem: {
+      issueDescription: `${req.t(
+        "pages.contactUsQuestions.whatHappened.header",
+        { lng: "en" }
+      )} ${req.t("pages.contactUsQuestions.whatHappened.paragraph1", {
+        lng: "en",
+      })}`,
+      serviceTryingToUse: req.t(
+        "pages.contactUsQuestions.serviceTryingToUse.header",
+        { lng: "en" }
+      ),
+      radioButtons: req.t(
+        "pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.header",
         { lng: "en" }
       ),
     },

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -22,6 +22,16 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
           }
         );
       }),
+    body("identityDocumentUsed")
+      .if(body("theme").equals("id_check_app"))
+      .if(body("subtheme").equals("taking_photo_of_id_problem"))
+      .notEmpty()
+      .withMessage((value, { req }) => {
+        return req.t(
+          "pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.errorMessage",
+          { value, lng: "en" }
+        );
+      }),
     body("issueDescription")
       .optional()
       .notEmpty()

--- a/src/components/contact-us/contact-us-service.ts
+++ b/src/components/contact-us/contact-us-service.ts
@@ -20,6 +20,50 @@ export function getZendeskIdentifierTag(theme: string): string {
   return "govuk_sign_in";
 }
 
+export function prepareIdentityDocumentTitleForZendesk(
+  identityDocumentUsed: string
+): string {
+  let documentUsedDescription = "";
+  switch (identityDocumentUsed) {
+    case "passport":
+      documentUsedDescription = "Passport";
+      break;
+    case "biometricResidencePermit":
+      documentUsedDescription = "Biometric residence permit";
+      break;
+    case "drivingLicence":
+      documentUsedDescription = "Driving licence";
+  }
+
+  return documentUsedDescription;
+}
+
+export function prepareSecurityCodeSendMethodTitleForZendesk(
+  securityCodeSentMethod: string
+): string {
+  let securityCodeMethod = "";
+  switch (securityCodeSentMethod) {
+    case "email":
+      securityCodeMethod = "Email";
+      break;
+    case "text_message":
+      securityCodeMethod = "Text message";
+      break;
+    case "text_message_uk_number":
+      securityCodeMethod = "Text message to a UK phone number";
+      break;
+    case "text_message_international_number":
+      securityCodeMethod =
+        "Text message to a phone number from another country";
+      break;
+    case "authenticator_app":
+      securityCodeMethod = "Authenticator app";
+      break;
+  }
+
+  return securityCodeMethod;
+}
+
 export function contactUsService(
   zendeskClient: ZendeskInterface = defaultZendeskClient
 ): ContactUsServiceInterface {
@@ -36,7 +80,8 @@ export function contactUsService(
             contactForm.questions,
             contactForm.themeQuestions,
             contactForm.referer,
-            contactForm.securityCodeSentMethod
+            contactForm.securityCodeSentMethod,
+            contactForm.identityDocumentUsed
           ),
         },
         group_id: getZendeskGroupIdPublic(),
@@ -106,7 +151,8 @@ export function contactUsService(
     questions: Questions,
     themeQuestions: ThemeQuestions,
     referer: string,
-    securityCodeSentMethod: string
+    securityCodeSentMethod: string,
+    identityDocumentUsed: string
   ) {
     const htmlBody = [];
 
@@ -118,28 +164,20 @@ export function contactUsService(
       htmlBody.push(`<p>${themeQuestions.subthemeQuestion}</p>`);
     }
 
-    if (securityCodeSentMethod) {
-      let securityCodeMethod = "";
-      switch (securityCodeSentMethod) {
-        case "email":
-          securityCodeMethod = "Email";
-          break;
-        case "text_message":
-          securityCodeMethod = "Text message";
-          break;
-        case "text_message_uk_number":
-          securityCodeMethod = "Text message to a UK phone number";
-          break;
-        case "text_message_international_number":
-          securityCodeMethod =
-            "Text message to a phone number from another country";
-          break;
-        case "authenticator_app":
-          securityCodeMethod = "Authenticator app";
-          break;
-      }
+    if (identityDocumentUsed) {
       htmlBody.push(`<span>[${questions.radioButtons}]</span>`);
-      htmlBody.push(`<p>${securityCodeMethod}</p>`);
+      htmlBody.push(
+        `<p>${prepareIdentityDocumentTitleForZendesk(identityDocumentUsed)}</p>`
+      );
+    }
+
+    if (securityCodeSentMethod) {
+      htmlBody.push(`<span>[${questions.radioButtons}]</span>`);
+      htmlBody.push(
+        `<p>${prepareSecurityCodeSendMethodTitleForZendesk(
+          securityCodeSentMethod
+        )}</p>`
+      );
     }
 
     if (descriptions.issueDescription) {

--- a/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
@@ -8,9 +8,42 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
-    <input type="hidden" name="formType" value="idCheckApp"/>
+    <input type="hidden" name="formType" value="idCheckAppPhotoProblem"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
+
+    {% set items = [
+        {
+            value: 'passport',
+            checked: identityDocumentUsed === 'passport',
+            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.types.passport' | translateEnOnly
+        },
+        {
+            value: 'biometricResidencePermit',
+            checked: identityDocumentUsed === 'biometricResidencePermit',
+            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.types.biometricResidencePermit' | translateEnOnly
+        },
+        {
+            value: 'drivingLicence',
+            checked: identityDocumentUsed === 'drivingLicence',
+            text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.types.drivingLicence' | translateEnOnly
+        }
+    ] %}
+
+    {{ govukRadios({
+        name: "identityDocumentUsed",
+        fieldset: {
+            legend: {
+                text: 'pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.header' | translateEnOnly,
+                isPageHeading: false,
+                classes: "govuk-fieldset__legend--s"
+            }
+        },
+        items: items,
+        errorMessage: {
+            text: errors['identityDocumentUsed'].text
+        } if (errors['identityDocumentUsed'])
+    }) }}
 
     {% include 'contact-us/questions/_what_happened.njk' %}
 

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -279,6 +279,29 @@ describe("Integration:: contact us - public user", () => {
       .expect(400, done);
   });
 
+  describe("when a user had a problem taking a photo of your identity document using the GOV.UK ID Check app", () => {
+    it("should return validation error when user has not selected which identity document they were using", (done) => {
+      request(app)
+        .post("/contact-us-questions?radio_buttons=true")
+        .type("form")
+        .set("Cookie", cookies)
+        .send({
+          _csrf: token,
+          theme: "id_check_app",
+          subtheme: "taking_photo_of_id_problem",
+          moreDetailDescription: "There was a problem",
+          contact: "false",
+        })
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($("#identityDocumentUsed-error").text()).to.contains(
+            "Select which identity document you were using"
+          );
+        })
+        .expect(400, done);
+    });
+  });
+
   it("should redirect to success page when form submitted", (done) => {
     nock(zendeskApiUrl).post("/tickets.json").once().reply(200);
 

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -10,6 +10,7 @@ export interface ContactForm {
   themeQuestions: ThemeQuestions;
   referer: string;
   securityCodeSentMethod?: string;
+  identityDocumentUsed?: string;
 }
 
 export interface OptionalData {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1822,7 +1822,16 @@
       },
       "takingPhotoOfIdProblem": {
         "title": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
-        "header": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app"
+        "header": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
+        "identityDocument": {
+          "header": "Which identity document were you using?",
+          "errorMessage": "Select which identity document you were using",
+          "types": {
+            "passport": "Passport",
+            "biometricResidencePermit": "Biometric residence permit",
+            "drivingLicence": "Driving licence"
+          }
+        }
       },
       "faceScanningProblem": {
         "title": "You had a problem scanning your face using the GOV.UK ID Check app",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1822,7 +1822,16 @@
       },
       "takingPhotoOfIdProblem": {
         "title": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
-        "header": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app"
+        "header": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
+        "identityDocument": {
+          "header": "Which identity document were you using?",
+          "errorMessage": "Select which identity document you were using",
+          "types": {
+            "passport": "Passport",
+            "biometricResidencePermit": "Biometric residence permit",
+            "drivingLicence": "Driving licence"
+          }
+        }
       },
       "faceScanningProblem": {
         "title": "You had a problem scanning your face using the GOV.UK ID Check app",


### PR DESCRIPTION
## What?

Adds a new required question and radio inputs to the "You had a problem taking a photo of your identity document using the GOV.UK ID Check app" form

## Why?

So the support team have information about the type of document that could not be scanned. 

### Screenshots

<details open>

<summary>Form with new question</summary>

![You-had-a-problem-taking-a-photo-of-your-identity-document-using-the-GOV-UK-ID-Check-app-GOV-UK-One-Login](https://github.com/alphagov/di-authentication-frontend/assets/16000203/ed776805-7d2d-442c-9787-79031e4735de)

</details>

<details open>

<summary>Error messaging when a user has not selected a document type</summary>

![image](https://github.com/alphagov/di-authentication-frontend/assets/16000203/09961529-53c0-4e21-b330-b812f3abefdd)

</details>

<details open>

<summary>Zendesk submission for document type of passport</summary>

<img width="1167" alt="Passport Zendesk" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/6483c480-cffa-4e80-8aaa-2f08803983f7">


</details>

<details open>

<summary>Zendesk submission for document type of biometric residence permit</summary>

<img width="1175" alt="BMR Zendesk" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/d82b8be7-fc22-4392-9a38-f1efbfe4f985">


</details>

<details open>

<summary>Zendesk submission for document type of driving licence</summary>

<img width="1166" alt="Driving licence Zendesk" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/9db4b898-4755-4f85-b50f-ee0adb467bfc">


</details>

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
