### PR TITLE
FIX: Prevent account recovery link display where not permitted

### DIFF
--- a/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
+++ b/src/components/enter-authenticator-app-code/index-2fa-service-uplift-auth-app.njk
@@ -54,7 +54,7 @@
 
     </form>
 
-    {% if isAccountRecoveryPermitted %}
+    {% if isAccountRecoveryPermitted === true %}
         {% set detailsHTML %}
             <p class="govuk-body">
                 {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}

--- a/src/components/enter-authenticator-app-code/index.njk
+++ b/src/components/enter-authenticator-app-code/index.njk
@@ -40,7 +40,7 @@
 
   </form>
 
-  {% if isAccountRecoveryPermitted %}
+  {% if isAccountRecoveryPermitted === true %}
     {% set detailsHTML %}
       <p class="govuk-body">
         {{'pages.enterAuthenticatorAppCode.details.text1' | translate}}

--- a/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
+++ b/src/components/enter-authenticator-app-code/tests/enter-authenticator-app-code-integration.test.ts
@@ -172,6 +172,25 @@ describe("Integration:: enter authenticator app code", () => {
       .expect(400, done);
   });
 
+  it("following a validation error it should not include link to change security codes where account recovery is not permitted", (done) => {
+    request(app)
+      .post(PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "12ert-",
+        isAccountRecoveryPermitted: false,
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("body").text()).to.not.contains(
+          "You can securely change how you get security codes"
+        );
+      })
+      .expect(400, done);
+  });
+
   it("should redirect to /auth-code when valid code entered", (done) => {
     nock(baseApi)
       .post(API_ENDPOINTS.VERIFY_MFA_CODE)

--- a/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
+++ b/src/components/enter-mfa/index-2fa-service-uplift-mobile-phone.njk
@@ -51,7 +51,7 @@
                 </a>
                 {{'pages.enterMfa.details.text 2' | translate}}
             </p>
-            {% if supportAccountRecovery %}
+            {% if supportAccountRecovery === true %}
                 <p class="govuk-body">
                     {{ 'pages.enterMfa.details.changeGetSecurityCodesText' | translate }}
                     <a href={{ checkEmailLink }} class="govuk-link"

--- a/src/components/enter-mfa/index.njk
+++ b/src/components/enter-mfa/index.njk
@@ -49,12 +49,13 @@
       <a href="{{'pages.enterMfa.details.sendCodeLinkHref' | translate}}" class="govuk-link" rel="noreferrer noopener">{{'pages.enterMfa.details.sendCodeLinkText'| translate}}</a>
       {{'pages.enterMfa.details.text 2' | translate}}
     </p>
-    <p class="govuk-body">
-      {% if supportAccountRecovery %}
-        {{'pages.enterMfa.details.changeGetSecurityCodesText' | translate}}
-        <a href={{checkEmailLink}} class="govuk-link" rel="noreferrer noopener">{{'pages.enterMfa.details.changeGetSecurityCodesLinkText'| translate}}</a>.
-      {% endif %}
-    </p>
+    {% if supportAccountRecovery === true %}
+        <p class="govuk-body">
+            {{ 'pages.enterMfa.details.changeGetSecurityCodesText' | translate }}
+            <a href={{ checkEmailLink }} class="govuk-link"
+               rel="noreferrer noopener">{{ 'pages.enterMfa.details.changeGetSecurityCodesLinkText'| translate }}</a>.
+        </p>
+    {% endif %}
     {% endset %}
 
     {{ govukButton({

--- a/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
+++ b/src/components/enter-mfa/tests/enter-mfa-integration.test.ts
@@ -89,6 +89,26 @@ describe("Integration:: enter mfa", () => {
     request(app).get(PATH_NAMES.ENTER_MFA).expect(200, done);
   });
 
+  it("following a validation error it should not include link to change security codes where account recovery is not permitted", (done) => {
+    request(app)
+      .get(PATH_NAMES.ENTER_MFA)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        code: "123456",
+        phoneNumber: PHONE_NUMBER,
+        supportAccountRecovery: false,
+      })
+      .expect(function (res) {
+        const $ = cheerio.load(res.text);
+        expect($("body").text()).to.not.contains(
+          "You can securely change how you get security codes"
+        );
+      })
+      .expect(200, done);
+  });
+
   it("should return error when csrf not present", (done) => {
     request(app)
       .post(PATH_NAMES.ENTER_MFA)


### PR DESCRIPTION
## What?

Amends Nunjucks templates for entering Auth App and SMS codes during sign in. The change strengthens conditional to require strict equality. Also introduces some associated integration tests.

## Why?

Bug identified where the a non-functional "You can securely change how you get security codes" link is presented to users (if users click on this link they are presented with the "Sorry, there is a problem" page). 