### PR TITLE
BAU - Update account management URL

### DIFF
--- a/ci/terraform/dns.tf
+++ b/ci/terraform/dns.tf
@@ -1,6 +1,6 @@
 locals {
   service_domain          = var.environment == "production" ? "account.gov.uk" : "${var.environment}.account.gov.uk"
-  account_management_fqdn = local.service_domain
+  account_management_fqdn = var.environment == "production" ? "home.account.gov.uk" : "home.${var.environment}.account.gov.uk"
   frontend_fqdn           = "signin.${local.service_domain}"
   frontend_api_fqdn       = "auth.${local.service_domain}"
   oidc_api_fqdn           = "oidc.${local.service_domain}"


### PR DESCRIPTION
## What?

- Update account management URL

## Why?

- It should now be home.account.gov.uk instead of account.gov.uk to ensure we take users to account management


