### PR TITLE
BAU - Override lock duration for the build environment

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -11,6 +11,8 @@ support_account_recovery                            = "1"
 support_auth_orch_split                             = "1"
 password_reset_code_entered_wrong_blocked_minutes   = "0.5"
 account_recovery_code_entered_wrong_blocked_minutes = "0.5"
+code_request_blocked_minutes                        = "0.5"
+code_entered_wrong_blocked_minutes                  = "0.5"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -124,6 +124,14 @@ locals {
         name  = "ACCOUNT_RECOVERY_CODE_ENTERED_WRONG_BLOCKED_MINUTES"
         value = var.account_recovery_code_entered_wrong_blocked_minutes
       },
+      {
+        name  = "CODE_REQUEST_BLOCKED_MINUTES"
+        value = var.code_request_blocked_minutes
+      },
+      {
+        name  = "CODE_ENTERED_WRONG_BLOCKED_MINUTES"
+        value = var.code_entered_wrong_blocked_minutes
+      },
     ]
 
     mountPoints = [

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -193,6 +193,16 @@ variable "account_recovery_code_entered_wrong_blocked_minutes" {
   description = "The duration, in minutes, for which a user is blocked after entering the wrong account recovery code multiple times"
 }
 
+variable "code_request_blocked_minutes" {
+  default     = "15"
+  description = "The duration, in minutes, for which a user is blocked after requesting the wrong code multiple times"
+}
+
+variable "code_entered_wrong_blocked_minutes" {
+  default     = "15"
+  description = "The duration, in minutes, for which a user is blocked after entering the wrong code multiple times"
+}
+
 variable "orch_to_auth_signing_public_key" {
   description = "Public key counterpart for KMS key created in Orchestration/OIDC API"
   type        = string


### PR DESCRIPTION

## What?

- By default, the lock duration is 15 mins. Override this for 30 seconds in the build environment. 

## Why?

- So functionality can be tested easier 
