### PR TITLE
AUTH1248: Add claim validation to jwt-service.

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "i18next": "^21.6.5",
     "i18next-fs-backend": "^1.1.1",
     "i18next-http-middleware": "^3.2.0",
+    "jose": "^4.14.4",
     "jsdom": "^19.0.0",
     "libphonenumber-js": "^1.9.44",
     "nunjucks": "^3.2.3",

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -59,9 +59,7 @@ export function authorizeGet(
     const claims = await jwtService.getPayloadWithSigCheck(
       authRequestJweDecryptedAsJwt
     );
-    const validateClaims = jwtService.validateClaims(claims);
-
-    validateQueryParamsAgainstClaims(clientId, validateClaims.client_id);
+    jwtService.validateClaims(claims);
 
     const startAuthResponse = await authService.start(
       sessionId,
@@ -169,16 +167,5 @@ function validateQueryParams(clientId: string, responseType: string) {
 
   if (clientId !== expectedClientId) {
     throw new QueryParamsError("Client ID value is incorrect");
-  }
-}
-
-function validateQueryParamsAgainstClaims(
-  requestClientId: string,
-  claimsClientId: string
-) {
-  if (requestClientId !== claimsClientId) {
-    throw new QueryParamsError(
-      "Request Client ID does not equal Claims Client ID"
-    );
   }
 }

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -57,10 +57,11 @@ export function authorizeGet(
       encryptedAuthRequestJWE
     );
 
-    const claims = await jwtService.getPayloadWithSigCheck(
+    const claims = await jwtService.getPayloadWithValidation(
       authRequestJweDecryptedAsJwt
     );
-    jwtService.validateClaims(claims);
+
+    jwtService.validateCustomClaims(claims);
 
     const startAuthResponse = await authService.start(
       sessionId,

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -24,7 +24,7 @@ import {
 } from "./types";
 import { KmsDecryptionService } from "./kms-decryption-service";
 import { JwtService } from "./jwt-service";
-import { expectedClientId } from "./claims-config";
+import { EXPECTED_CLIENT_ID } from "./claims-config";
 
 function createConsentCookie(
   res: Response,
@@ -167,7 +167,7 @@ function validateQueryParams(clientId: string, responseType: string) {
     throw new QueryParamsError("Response type does not exist");
   }
 
-  if (clientId !== expectedClientId) {
+  if (clientId !== EXPECTED_CLIENT_ID) {
     throw new QueryParamsError("Client ID value is incorrect");
   }
 }

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -56,6 +56,7 @@ export function authorizeGet(
     const authRequestJweDecryptedAsJwt = await kmsService.decrypt(
       encryptedAuthRequestJWE
     );
+
     const claims = await jwtService.getPayloadWithSigCheck(
       authRequestJweDecryptedAsJwt
     );
@@ -76,7 +77,7 @@ export function authorizeGet(
       if (
         startAuthResponse.data.code &&
         startAuthResponse.data.code ===
-        API_ERROR_CODES.SESSION_ID_MISSING_OR_INVALID
+          API_ERROR_CODES.SESSION_ID_MISSING_OR_INVALID
       ) {
         startError.level = ERROR_LOG_LEVEL.INFO;
       }

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -62,7 +62,9 @@ export function authorizeGet(
         authRequestJweDecryptedAsJwt
       );
 
-      jwtService.validateClaims(claims);
+      const validateClaims = jwtService.validateClaims(claims);
+
+      validateQueryParamsAgainstClaims(clientId, validateClaims.client_id);
     }
 
     const startAuthResponse = await authService.start(
@@ -160,16 +162,27 @@ export function authorizeGet(
   };
 }
 
-function validateQueryParams(client_id: string, response_type: string) {
-  if (client_id === undefined) {
+function validateQueryParams(clientId: string, responseType: string) {
+  if (clientId === undefined) {
     throw new QueryParamsError("Client ID does not exist");
   }
 
-  if (response_type ===  undefined) {
+  if (responseType === undefined) {
     throw new QueryParamsError("Response type does not exist");
   }
 
-  if (client_id !== expectedClientId) {
+  if (clientId !== expectedClientId) {
     throw new QueryParamsError("Client ID value is incorrect");
+  }
+}
+
+function validateQueryParamsAgainstClaims(
+  requestClientId: string,
+  claimsClientId: string
+) {
+  if (requestClientId !== claimsClientId) {
+    throw new QueryParamsError(
+      "Request Client ID does not equal Claims Client ID"
+    );
   }
 }

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -52,20 +52,16 @@ export function authorizeGet(
 
     validateQueryParams(clientId, responseType);
 
-    if (req.query.request !== undefined) {
-      const encryptedAuthRequestJWE = req.query.request as string;
-      const authRequestJweDecryptedAsJwt = await kmsService.decrypt(
-        encryptedAuthRequestJWE
-      );
+    const encryptedAuthRequestJWE = req.query.request as string;
+    const authRequestJweDecryptedAsJwt = await kmsService.decrypt(
+      encryptedAuthRequestJWE
+    );
+    const claims = await jwtService.getPayloadWithSigCheck(
+      authRequestJweDecryptedAsJwt
+    );
+    const validateClaims = jwtService.validateClaims(claims);
 
-      const claims = await jwtService.getPayloadWithSigCheck(
-        authRequestJweDecryptedAsJwt
-      );
-
-      const validateClaims = jwtService.validateClaims(claims);
-
-      validateQueryParamsAgainstClaims(clientId, validateClaims.client_id);
-    }
+    validateQueryParamsAgainstClaims(clientId, validateClaims.client_id);
 
     const startAuthResponse = await authService.start(
       sessionId,
@@ -82,7 +78,7 @@ export function authorizeGet(
       if (
         startAuthResponse.data.code &&
         startAuthResponse.data.code ===
-          API_ERROR_CODES.SESSION_ID_MISSING_OR_INVALID
+        API_ERROR_CODES.SESSION_ID_MISSING_OR_INVALID
       ) {
         startError.level = ERROR_LOG_LEVEL.INFO;
       }

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -159,12 +159,8 @@ export function authorizeGet(
 }
 
 function validateQueryParams(clientId: string, responseType: string) {
-  if (clientId === undefined) {
-    throw new QueryParamsError("Client ID does not exist");
-  }
-
-  if (responseType === undefined) {
-    throw new QueryParamsError("Response type does not exist");
+  if (responseType == null) {
+    throw new QueryParamsError("Response type is not set");
   }
 
   if (clientId !== EXPECTED_CLIENT_ID) {

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -7,6 +7,11 @@ export function getKnownClaims(): {
   };
 }
 
+// Single source of truth for claims type and claims object keys
+
+export type Claims = typeof claimsInstance;
+// construct object for type
+const claimsInstance = getClaimsObject();
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function getClaimsObject() {
   return {

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -1,0 +1,31 @@
+export function getKnownClaims(): {
+  [key: string]: string | boolean | number;
+} {
+  return {
+    client_id: "UNKNOWN",
+    aud: "UNKNOWN",
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function getClaimsObject() {
+  return {
+    iss: "",
+    aud: "",
+    exp: NaN,
+    iat: NaN,
+    nbf: NaN,
+    jti: "",
+    client_name: "",
+    cookie_consent_shared: false,
+    consent_required: false,
+    is_one_login_service: false,
+    service_type: "",
+    govuk_signin_journey_id: "",
+    confidence: "",
+    state: "",
+    client_id: "",
+    scope: "",
+    redirect_uri: "",
+  };
+}

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -1,4 +1,4 @@
-export const expectedClientId = "orchestrationAuth";
+export const EXPECTED_CLIENT_ID = "orchestrationAuth";
 
 export function getKnownClaims(): {
   [key: string]: string | boolean | number;

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -1,3 +1,5 @@
+export const expectedClientId = "orchestrationAuth";
+
 export function getKnownClaims(): {
   [key: string]: string | boolean | number;
 } {

--- a/src/components/authorize/jwt-service.ts
+++ b/src/components/authorize/jwt-service.ts
@@ -3,6 +3,7 @@ import crypto from "crypto";
 import format from "ecdsa-sig-formatter";
 import { getOrchToAuthSigningPublicKey } from "../../config";
 import {
+  ClaimsError,
   JwtPayloadParseError,
   JwtSignatureVerificationError,
 } from "../../utils/error";
@@ -14,7 +15,7 @@ export class JwtService implements JwtServiceInterface {
     this.publicKey = publicKey;
   }
 
-  async verify(urlEncodedJwt: string): Promise<boolean> {
+  async signatureCheck(urlEncodedJwt: string): Promise<boolean> {
     try {
       const [header, payload, signature] = urlEncodedJwt.split(".");
       const derSignature = format.joseToDer(signature, "ES256");
@@ -29,13 +30,55 @@ export class JwtService implements JwtServiceInterface {
     }
   }
 
-  getPayload(jwt: string): AuthorizeRequestPayload {
+  async getPayloadWithSigCheck(jwt: string): Promise<AuthorizeRequestPayload> {
     const jwtElements = jwt.split(".");
     if (jwtElements.length !== 3) {
       throw new JwtPayloadParseError("JWT was not three elements");
     }
+
+    if ((await this.signatureCheck(jwt)) === false) {
+      throw new JwtSignatureVerificationError("Jwt Signature is not valid");
+    }
     const payload = jwtElements[1];
     const buffer = Buffer.from(payload, "base64url");
+
     return JSON.parse(buffer.toString());
+  }
+
+  validateClaims(claims: AuthorizeRequestPayload): AuthorizeRequestPayload {
+    const expectedkeys = [
+      "iss",
+      "aud",
+      "exp",
+      "iat",
+      "nbf",
+      "jti",
+      "client_name",
+      "cookie_consent_shared",
+      "consent_required",
+      "is_one_login_service",
+      "service_type",
+      "govuk_signin_journey_id",
+      "confidence",
+      "state",
+      "client_id",
+      "scope",
+      "redirect_uri",
+    ];
+    expectedkeys.forEach((claim) => {
+      if (!Object.prototype.hasOwnProperty.call(claims, claim)) {
+        throw new ClaimsError(`${claim} claim missing`);
+      }
+    });
+
+    if (claims.exp <= Math.floor(new Date().getTime() / 1000)) {
+      throw new ClaimsError("Token expired (exp)");
+    }
+
+    if (claims.nbf > Math.floor(new Date().getTime() / 1000)) {
+      throw new ClaimsError("Token not yet valid (nbf)");
+    }
+
+    return claims;
   }
 }

--- a/src/components/authorize/jwt-service.ts
+++ b/src/components/authorize/jwt-service.ts
@@ -7,7 +7,7 @@ import {
   JwtPayloadParseError,
   JwtSignatureVerificationError,
 } from "../../utils/error";
-import { getClaimsObject, getKnownClaims } from "./claims-config";
+import { Claims, getClaimsObject, getKnownClaims } from "./claims-config";
 
 export class JwtService implements JwtServiceInterface {
   private readonly publicKey;
@@ -46,7 +46,7 @@ export class JwtService implements JwtServiceInterface {
     return JSON.parse(buffer.toString());
   }
 
-  validateClaims(claims: any): any {
+  validateClaims(claims: any): Claims {
     const errors = [];
 
     const claimsfields = getClaimsObject();

--- a/src/components/authorize/jwt-service.ts
+++ b/src/components/authorize/jwt-service.ts
@@ -47,14 +47,36 @@ export class JwtService implements JwtServiceInterface {
   }
 
   validateClaims(claims: any): Claims {
-    const errors = [];
+    this.checkClaimsShapeAndType(claims);
 
-    const claimsfields = getClaimsObject();
-    const expectedkeys = Object.keys(claimsfields);
+    this.checkClaimsProperties(claims);
 
-    expectedkeys.forEach((claim) => {
+    return claims;
+  }
+
+  checkClaimsShapeAndType(claims: any): void {
+    const errors: string[] = [];
+
+    Object.entries(getClaimsObject()).forEach(([claim, claimValue]) => {
       if (!Object.prototype.hasOwnProperty.call(claims, claim)) {
         errors.push(`${claim} claim missing`);
+      } else if (typeof claims[claim] !== typeof claimValue) {
+        errors.push(`${claim} claim type is incorrect`);
+      }
+    });
+
+    if (errors.length > 0) {
+      throw new ClaimsError(errors.join("\r\n"));
+    }
+  }
+
+  checkClaimsProperties(claims: any): void {
+    const errors: string[] = [];
+    const requiredclaims = getKnownClaims();
+
+    Object.keys(requiredclaims).forEach((claim) => {
+      if (requiredclaims[claim] !== claims[claim]) {
+        errors.push(`${claim} has incorrect value`);
       }
     });
 
@@ -69,19 +91,5 @@ export class JwtService implements JwtServiceInterface {
     if (errors.length > 0) {
       throw new ClaimsError(errors.join("\r\n"));
     }
-
-    const requiredclaims = getKnownClaims();
-
-    Object.keys(requiredclaims).forEach((claim) => {
-      if (requiredclaims[claim] !== claims[claim]) {
-        errors.push(`${claim} has incorrect value`);
-      }
-    });
-
-    if (errors.length > 0) {
-      throw new ClaimsError(errors.join("\r\n"));
-    }
-
-    return claims;
   }
 }

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -37,8 +37,8 @@ describe("authorize controller", () => {
       i18n: { language: "en" },
       query: {
         client_id: "orchestrationAuth",
-        response_type: "code"
-      }
+        response_type: "code",
+      },
     });
     res = mockResponse();
   });
@@ -483,7 +483,9 @@ describe("authorize controller", () => {
         decrypt: sinon.fake.returns(Promise.resolve("jwt")),
       };
       const fakejwt: JwtServiceInterface = {
-        getPayloadWithSigCheck: sinon.fake.returns(Promise.resolve({ test: "test" })),
+        getPayloadWithSigCheck: sinon.fake.returns(
+          Promise.resolve({ client_id: req.query.client_id } as any)
+        ),
         signatureCheck: sinon.fake.returns(Promise.resolve(true)),
         validateClaims: sinon.stub().returnsArg(0),
       };
@@ -493,7 +495,9 @@ describe("authorize controller", () => {
         fakeKms,
         fakejwt
       )(req as Request, res as Response);
-      expect(fakejwt.validateClaims).to.have.returned({ test: "test" });
+      expect(fakejwt.validateClaims).to.have.returned({
+        client_id: "orchestrationAuth",
+      });
     });
 
     describe("Query parameters validation", () => {
@@ -515,36 +519,50 @@ describe("authorize controller", () => {
             success: true,
           }),
         } as unknown as AuthorizeServiceInterface;
-  
+
         fakeCookieConsentService = {
           getCookieConsent: sinon.fake(),
           createConsentCookieValue: sinon.fake(),
         };
       });
 
-
-      it("should throw an error if client_id does not exist in the query params" , async () => {
+      it("should throw an error if client_id does not exist in the query params", async () => {
         delete req.query.client_id;
-  
-        await expect(authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(req as Request, res as Response))
-        .to.eventually.be.rejectedWith("Client ID does not exist")
-        .and.be.an.instanceOf(QueryParamsError);
+
+        await expect(
+          authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+            req as Request,
+            res as Response
+          )
+        )
+          .to.eventually.be.rejectedWith("Client ID does not exist")
+          .and.be.an.instanceOf(QueryParamsError);
       });
 
-      it("should throw an error if response_type does not exist in the query params" , async () => {
+      it("should throw an error if response_type does not exist in the query params", async () => {
         delete req.query.response_type;
-  
-        await expect(authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(req as Request, res as Response))
-        .to.eventually.be.rejectedWith("Response type does not exist")
-        .and.be.an.instanceOf(QueryParamsError);
+
+        await expect(
+          authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+            req as Request,
+            res as Response
+          )
+        )
+          .to.eventually.be.rejectedWith("Response type does not exist")
+          .and.be.an.instanceOf(QueryParamsError);
       });
 
-      it("should throw an error if client_id value is incorrect in the query params" , async () => {
-        req.query.client_id = "wrong_client id"
-  
-        await expect(authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(req as Request, res as Response))
-        .to.eventually.be.rejectedWith("Client ID value is incorrect")
-        .and.be.an.instanceOf(QueryParamsError);
+      it("should throw an error if client_id value is incorrect in the query params", async () => {
+        req.query.client_id = "wrong_client id";
+
+        await expect(
+          authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+            req as Request,
+            res as Response
+          )
+        )
+          .to.eventually.be.rejectedWith("Client ID value is incorrect")
+          .and.be.an.instanceOf(QueryParamsError);
       });
     });
   });

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -51,11 +51,10 @@ describe("authorize controller", () => {
       decrypt: sinon.fake.returns(Promise.resolve("jwt")),
     };
     fakeJwtService = {
-      getPayloadWithSigCheck: sinon.fake.returns(
+      getPayloadWithValidation: sinon.fake.returns(
         Promise.resolve({ client_id: req.query.client_id } as any)
       ),
-      signatureCheck: sinon.fake.returns(Promise.resolve(true)),
-      validateClaims: sinon.stub().returnsArg(0),
+      validateCustomClaims: sinon.stub().returnsArg(0),
     };
   });
 
@@ -394,7 +393,7 @@ describe("authorize controller", () => {
         fakeKmsDecryptionService,
         fakeJwtService
       )(req as Request, res as Response);
-      expect(fakeJwtService.validateClaims).to.have.returned({
+      expect(fakeJwtService.validateCustomClaims).to.have.returned({
         client_id: "orchestrationAuth",
       });
     });

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -27,6 +27,8 @@ import { BadRequestError, QueryParamsError } from "../../../utils/error";
 describe("authorize controller", () => {
   let req: RequestOutput;
   let res: ResponseOutput;
+  let authServiceResponseData: any;
+  let fakeAuthorizeService: AuthorizeServiceInterface;
 
   beforeEach(() => {
     req = mockRequest({
@@ -41,6 +43,7 @@ describe("authorize controller", () => {
       },
     });
     res = mockResponse();
+    authServiceResponseData = createAuthServiceReponseData();
   });
 
   afterEach(() => {
@@ -49,20 +52,7 @@ describe("authorize controller", () => {
 
   describe("authorizeGet", () => {
     it("should redirect to /sign-in-or-create page when no existing session for user", async () => {
-      const fakeAuthorizeService: AuthorizeServiceInterface = {
-        start: sinon.fake.returns({
-          data: {
-            client: {
-              scopes: ["openid", "profile"],
-              serviceType: "MANDATORY",
-              clientName: "Test client",
-              cookieConsentShared: true,
-            },
-            user: {},
-          },
-          success: true,
-        }),
-      } as unknown as AuthorizeServiceInterface;
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
         getCookieConsent: sinon.fake(),
@@ -78,20 +68,8 @@ describe("authorize controller", () => {
     });
 
     it("should redirect to /sign-in-or-create page with cookie preferences set", async () => {
-      const fakeAuthorizeService: AuthorizeServiceInterface = {
-        start: sinon.fake.returns({
-          data: {
-            client: {
-              scopes: ["openid", "profile"],
-              serviceType: "MANDATORY",
-              clientName: "Test client",
-              cookieConsentShared: true,
-            },
-            user: { cookieConsent: COOKIE_CONSENT.ACCEPT },
-          },
-          success: true,
-        }),
-      } as unknown as AuthorizeServiceInterface;
+      authServiceResponseData.data.user = { cookieConsent: COOKIE_CONSENT.ACCEPT }
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
         getCookieConsent: sinon.fake(),
@@ -111,24 +89,12 @@ describe("authorize controller", () => {
     });
 
     it("should redirect to /uplift page when uplift query param set and MfaType is SMS", async () => {
-      const fakeAuthorizeService: AuthorizeServiceInterface = {
-        start: sinon.fake.returns({
-          data: {
-            client: {
-              scopes: ["openid", "profile"],
-              serviceType: "MANDATORY",
-              clientName: "Test client",
-              cookieConsentShared: true,
-            },
-            user: {
-              upliftRequired: true,
-              authenticated: true,
-              mfaMethodType: "SMS",
-            },
-          },
-          success: true,
-        }),
-      } as unknown as AuthorizeServiceInterface;
+      authServiceResponseData.data.user = {
+        upliftRequired: true,
+        authenticated: true,
+        mfaMethodType: "SMS",
+      }
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
         getCookieConsent: sinon.fake(),
@@ -144,24 +110,12 @@ describe("authorize controller", () => {
     });
 
     it("should redirect to /enter-authenticator-app-code page when uplift query param set and MfaMethodType is AUTH_APP", async () => {
-      const fakeAuthorizeService: AuthorizeServiceInterface = {
-        start: sinon.fake.returns({
-          data: {
-            client: {
-              scopes: ["openid", "profile"],
-              serviceType: "MANDATORY",
-              clientName: "Test client",
-              cookieConsentShared: true,
-            },
-            user: {
-              upliftRequired: true,
-              authenticated: true,
-              mfaMethodType: "AUTH_APP",
-            },
-          },
-          success: true,
-        }),
-      } as unknown as AuthorizeServiceInterface;
+      authServiceResponseData.data.user = {
+        upliftRequired: true,
+        authenticated: true,
+        mfaMethodType: "AUTH_APP",
+      }
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
         getCookieConsent: sinon.fake(),
@@ -180,26 +134,13 @@ describe("authorize controller", () => {
 
     it("should redirect to /auth-code when existing session", async () => {
       req.session.user.isAuthenticated = true;
-
-      const fakeAuthorizeService: AuthorizeServiceInterface = {
-        start: sinon.fake.returns({
-          data: {
-            client: {
-              scopes: ["openid", "profile"],
-              serviceType: "MANDATORY",
-              clientName: "Test client",
-              cookieConsentShared: true,
-            },
-            user: {
-              consentRequired: false,
-              identityRequired: false,
-              upliftRequired: false,
-              authenticated: true,
-            },
-          },
-          success: true,
-        }),
-      } as unknown as AuthorizeServiceInterface;
+      authServiceResponseData.data.user = {
+        consentRequired: false,
+        identityRequired: false,
+        upliftRequired: false,
+        authenticated: true,
+      }
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
         getCookieConsent: sinon.fake(),
@@ -215,25 +156,13 @@ describe("authorize controller", () => {
     });
 
     it("should redirect to /share-info when consent required", async () => {
-      const fakeAuthorizeService: AuthorizeServiceInterface = {
-        start: sinon.fake.returns({
-          data: {
-            client: {
-              scopes: ["openid", "profile"],
-              serviceType: "MANDATORY",
-              clientName: "Test client",
-              cookieConsentShared: true,
-            },
-            user: {
-              consentRequired: true,
-              identityRequired: false,
-              upliftRequired: false,
-              authenticated: true,
-            },
-          },
-          success: true,
-        }),
-      } as unknown as AuthorizeServiceInterface;
+      authServiceResponseData.data.user = {
+        consentRequired: true,
+        identityRequired: false,
+        upliftRequired: false,
+        authenticated: true,
+      }
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
         getCookieConsent: sinon.fake(),
@@ -249,25 +178,13 @@ describe("authorize controller", () => {
     });
 
     it("should redirect to /identity page when identity check required", async () => {
-      const fakeAuthorizeService: AuthorizeServiceInterface = {
-        start: sinon.fake.returns({
-          data: {
-            client: {
-              scopes: ["openid", "profile"],
-              serviceType: "MANDATORY",
-              clientName: "Test client",
-              cookieConsentShared: true,
-            },
-            user: {
-              consentRequired: false,
-              identityRequired: true,
-              upliftRequired: false,
-              authenticated: true,
-            },
-          },
-          success: true,
-        }),
-      } as unknown as AuthorizeServiceInterface;
+      authServiceResponseData.data.user = {
+        consentRequired: false,
+        identityRequired: true,
+        upliftRequired: false,
+        authenticated: true,
+      }
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
         getCookieConsent: sinon.fake(),
@@ -286,26 +203,13 @@ describe("authorize controller", () => {
 
     it("should redirect to /enter-password page when prompt is login", async () => {
       req.query.prompt = OIDC_PROMPT.LOGIN;
-
-      const fakeAuthorizeService: AuthorizeServiceInterface = {
-        start: sinon.fake.returns({
-          data: {
-            client: {
-              scopes: ["openid", "profile"],
-              serviceType: "MANDATORY",
-              clientName: "Test client",
-              cookieConsentShared: true,
-            },
-            user: {
-              consentRequired: false,
-              identityRequired: false,
-              upliftRequired: false,
-              authenticated: true,
-            },
-          },
-          success: true,
-        }),
-      } as unknown as AuthorizeServiceInterface;
+      authServiceResponseData.data.user = {
+        consentRequired: false,
+        identityRequired: false,
+        upliftRequired: false,
+        authenticated: true,
+      };
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
         getCookieConsent: sinon.fake(),
@@ -322,27 +226,15 @@ describe("authorize controller", () => {
 
     it("should redirect to /sign-in-or-create page with _ga query param when present", async () => {
       const gaTrackingId = "2.172053219.3232.1636392870-444224.1635165988";
-      const fakeAuthorizeService: AuthorizeServiceInterface = {
-        start: sinon.fake.returns({
-          data: {
-            client: {
-              scopes: ["openid", "profile"],
-              serviceType: "MANDATORY",
-              clientName: "Test client",
-              cookieConsentShared: true,
-              consentEnabled: true,
-            },
-            user: {
-              consentRequired: false,
-              identityRequired: false,
-              upliftRequired: false,
-              cookieConsent: COOKIE_CONSENT.ACCEPT,
-              gaCrossDomainTrackingId: gaTrackingId,
-            },
-          },
-          success: true,
-        }),
-      } as unknown as AuthorizeServiceInterface;
+      authServiceResponseData.data.client.consentEnabled = true;
+      authServiceResponseData.data.user = {
+        consentRequired: false,
+        identityRequired: false,
+        upliftRequired: false,
+        cookieConsent: COOKIE_CONSENT.ACCEPT,
+        gaCrossDomainTrackingId: gaTrackingId,
+      };
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
         getCookieConsent: sinon.fake(),
@@ -364,25 +256,14 @@ describe("authorize controller", () => {
     });
 
     it("should redirect to /doc-checking-app when doc check app user", async () => {
-      const fakeAuthorizeService: AuthorizeServiceInterface = {
-        start: sinon.fake.returns({
-          data: {
-            client: {
-              scopes: ["openid", "profile"],
-              serviceType: "MANDATORY",
-              clientName: "Test client",
-              cookieConsentShared: false,
-              consentEnabled: false,
-            },
-            user: {
-              authenticated: false,
-              consentRequired: false,
-              docCheckingAppUser: true,
-            },
-          },
-          success: true,
-        }),
-      } as unknown as AuthorizeServiceInterface;
+      authServiceResponseData.data.client.cookieConsentShared = false;
+      authServiceResponseData.data.client.consentEnabled = false;
+      authServiceResponseData.data.user = {
+        authenticated: false,
+        consentRequired: false,
+        docCheckingAppUser: true,
+      };
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
         getCookieConsent: sinon.fake(),
@@ -456,29 +337,17 @@ describe("authorize controller", () => {
 
     it("should get claims when jwe passed in", async () => {
       req.query.request = "JWE";
+      authServiceResponseData.data.user = {
+        consentRequired: false,
+        identityRequired: false,
+        upliftRequired: false,
+        authenticated: true,
+      };
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
       const fakeCookieConsentService: CookieConsentServiceInterface = {
         getCookieConsent: sinon.fake(),
         createConsentCookieValue: sinon.fake(),
       };
-      const fakeAuthorizeService: AuthorizeServiceInterface = {
-        start: sinon.fake.returns({
-          data: {
-            client: {
-              scopes: ["openid", "profile"],
-              serviceType: "MANDATORY",
-              clientName: "Test client",
-              cookieConsentShared: true,
-            },
-            user: {
-              consentRequired: false,
-              identityRequired: false,
-              upliftRequired: false,
-              authenticated: true,
-            },
-          },
-          success: true,
-        }),
-      } as unknown as AuthorizeServiceInterface;
       const fakeKms: KmsDecryptionServiceInterface = {
         decrypt: sinon.fake.returns(Promise.resolve("jwt")),
       };
@@ -489,6 +358,7 @@ describe("authorize controller", () => {
         signatureCheck: sinon.fake.returns(Promise.resolve(true)),
         validateClaims: sinon.stub().returnsArg(0),
       };
+
       await authorizeGet(
         fakeAuthorizeService,
         fakeCookieConsentService,
@@ -499,71 +369,79 @@ describe("authorize controller", () => {
         client_id: "orchestrationAuth",
       });
     });
+  });
 
-    describe("Query parameters validation", () => {
-      let fakeAuthorizeService: AuthorizeServiceInterface;
-      let fakeCookieConsentService: CookieConsentServiceInterface;
+  describe("Query parameters validation", () => {
+    let fakeCookieConsentService: CookieConsentServiceInterface;
 
-      beforeEach(() => {
-        fakeAuthorizeService = {
-          start: sinon.fake.returns({
-            data: {
-              client: {
-                scopes: ["openid", "profile"],
-                serviceType: "MANDATORY",
-                clientName: "Test client",
-                cookieConsentShared: true,
-              },
-              user: {},
-            },
-            success: true,
-          }),
-        } as unknown as AuthorizeServiceInterface;
+    beforeEach(() => {
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
+      fakeCookieConsentService = {
+        getCookieConsent: sinon.fake(),
+        createConsentCookieValue: sinon.fake(),
+      };
+    });
 
-        fakeCookieConsentService = {
-          getCookieConsent: sinon.fake(),
-          createConsentCookieValue: sinon.fake(),
-        };
-      });
+    it("should throw an error if client_id does not exist in the query params", async () => {
+      delete req.query.client_id;
 
-      it("should throw an error if client_id does not exist in the query params", async () => {
-        delete req.query.client_id;
-
-        await expect(
-          authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-            req as Request,
-            res as Response
-          )
+      await expect(
+        authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+          req as Request,
+          res as Response
         )
-          .to.eventually.be.rejectedWith("Client ID does not exist")
-          .and.be.an.instanceOf(QueryParamsError);
-      });
+      )
+        .to.eventually.be.rejectedWith("Client ID does not exist")
+        .and.be.an.instanceOf(QueryParamsError);
+    });
 
-      it("should throw an error if response_type does not exist in the query params", async () => {
-        delete req.query.response_type;
+    it("should throw an error if response_type does not exist in the query params", async () => {
+      delete req.query.response_type;
 
-        await expect(
-          authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-            req as Request,
-            res as Response
-          )
+      await expect(
+        authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+          req as Request,
+          res as Response
         )
-          .to.eventually.be.rejectedWith("Response type does not exist")
-          .and.be.an.instanceOf(QueryParamsError);
-      });
+      )
+        .to.eventually.be.rejectedWith("Response type does not exist")
+        .and.be.an.instanceOf(QueryParamsError);
+    });
 
-      it("should throw an error if client_id value is incorrect in the query params", async () => {
-        req.query.client_id = "wrong_client id";
+    it("should throw an error if client_id value is incorrect in the query params", async () => {
+      req.query.client_id = "wrong_client id";
 
-        await expect(
-          authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-            req as Request,
-            res as Response
-          )
+      await expect(
+        authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+          req as Request,
+          res as Response
         )
-          .to.eventually.be.rejectedWith("Client ID value is incorrect")
-          .and.be.an.instanceOf(QueryParamsError);
-      });
+      )
+        .to.eventually.be.rejectedWith("Client ID value is incorrect")
+        .and.be.an.instanceOf(QueryParamsError);
     });
   });
+
+  function mockAuthService(authResponseData: any): AuthorizeServiceInterface {
+    return {
+      start: sinon.fake.returns({
+        ...authResponseData,
+      }),
+    } as unknown as AuthorizeServiceInterface;
+  }
+
+  function createAuthServiceReponseData(): any {
+    return {
+      data: {
+        client: {
+          scopes: ["openid", "profile"],
+          serviceType: "MANDATORY",
+          clientName: "Test client",
+          cookieConsentShared: true,
+        },
+        user: {},
+      },
+      success: true,
+    }
+  }
 });

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -476,11 +476,11 @@ describe("authorize controller", () => {
         }),
       } as unknown as AuthorizeServiceInterface;
       const fakeKms: KmsDecryptionServiceInterface = {
-        decrypt: sinon.fake.returns("jwt"),
+        decrypt: sinon.fake.returns(Promise.resolve("jwt")),
       };
       const fakejwt: JwtServiceInterface = {
-        getPayloadWithSigCheck: sinon.fake.returns({ test: "test" }),
-        signatureCheck: sinon.fake.returns(true),
+        getPayloadWithSigCheck: sinon.fake.returns(Promise.resolve({ test: "test" })),
+        signatureCheck: sinon.fake.returns(Promise.resolve(true)),
         validateClaims: sinon.stub().returnsArg(0),
       };
       await authorizeGet(

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -29,6 +29,8 @@ describe("authorize controller", () => {
   let res: ResponseOutput;
   let authServiceResponseData: any;
   let fakeAuthorizeService: AuthorizeServiceInterface;
+  let fakeKmsDecryptionService: KmsDecryptionServiceInterface;
+  let fakeJwtService: JwtServiceInterface;
 
   beforeEach(() => {
     req = mockRequest({
@@ -44,6 +46,17 @@ describe("authorize controller", () => {
     });
     res = mockResponse();
     authServiceResponseData = createAuthServiceReponseData();
+
+    fakeKmsDecryptionService = {
+      decrypt: sinon.fake.returns(Promise.resolve("jwt")),
+    };
+    fakeJwtService = {
+      getPayloadWithSigCheck: sinon.fake.returns(
+        Promise.resolve({ client_id: req.query.client_id } as any)
+      ),
+      signatureCheck: sinon.fake.returns(Promise.resolve(true)),
+      validateClaims: sinon.stub().returnsArg(0),
+    };
   });
 
   afterEach(() => {
@@ -59,8 +72,7 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-        req as Request,
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
         res as Response
       );
 
@@ -79,7 +91,7 @@ describe("authorize controller", () => {
         }),
       } as unknown as CookieConsentServiceInterface;
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(
         req as Request,
         res as Response
       );
@@ -101,8 +113,7 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-        req as Request,
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
         res as Response
       );
 
@@ -122,8 +133,7 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-        req as Request,
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
         res as Response
       );
 
@@ -147,8 +157,7 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-        req as Request,
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
         res as Response
       );
 
@@ -169,8 +178,7 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-        req as Request,
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
         res as Response
       );
 
@@ -191,8 +199,7 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-        req as Request,
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
         res as Response
       );
 
@@ -216,8 +223,7 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-        req as Request,
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
         res as Response
       );
 
@@ -244,8 +250,7 @@ describe("authorize controller", () => {
         }),
       } as unknown as CookieConsentServiceInterface;
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-        req as Request,
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
         res as Response
       );
 
@@ -273,8 +278,7 @@ describe("authorize controller", () => {
         }),
       } as unknown as CookieConsentServiceInterface;
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-        req as Request,
+      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
         res as Response
       );
 
@@ -298,8 +302,7 @@ describe("authorize controller", () => {
       };
 
       await expect(
-        authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-          req as Request,
+        authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
           res as Response
         )
       )
@@ -325,8 +328,7 @@ describe("authorize controller", () => {
       };
 
       await expect(
-        authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-          req as Request,
+        authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
           res as Response
         )
       )
@@ -348,24 +350,14 @@ describe("authorize controller", () => {
         getCookieConsent: sinon.fake(),
         createConsentCookieValue: sinon.fake(),
       };
-      const fakeKms: KmsDecryptionServiceInterface = {
-        decrypt: sinon.fake.returns(Promise.resolve("jwt")),
-      };
-      const fakejwt: JwtServiceInterface = {
-        getPayloadWithSigCheck: sinon.fake.returns(
-          Promise.resolve({ client_id: req.query.client_id } as any)
-        ),
-        signatureCheck: sinon.fake.returns(Promise.resolve(true)),
-        validateClaims: sinon.stub().returnsArg(0),
-      };
 
       await authorizeGet(
         fakeAuthorizeService,
         fakeCookieConsentService,
-        fakeKms,
-        fakejwt
+        fakeKmsDecryptionService,
+        fakeJwtService
       )(req as Request, res as Response);
-      expect(fakejwt.validateClaims).to.have.returned({
+      expect(fakeJwtService.validateClaims).to.have.returned({
         client_id: "orchestrationAuth",
       });
     });
@@ -386,8 +378,7 @@ describe("authorize controller", () => {
       delete req.query.client_id;
 
       await expect(
-        authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-          req as Request,
+        authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
           res as Response
         )
       )
@@ -399,8 +390,7 @@ describe("authorize controller", () => {
       delete req.query.response_type;
 
       await expect(
-        authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-          req as Request,
+        authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
           res as Response
         )
       )
@@ -412,8 +402,7 @@ describe("authorize controller", () => {
       req.query.client_id = "wrong_client id";
 
       await expect(
-        authorizeGet(fakeAuthorizeService, fakeCookieConsentService)(
-          req as Request,
+        authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
           res as Response
         )
       )

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -72,15 +72,20 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-        res as Response
-      );
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.SIGN_IN_OR_CREATE);
     });
 
     it("should redirect to /sign-in-or-create page with cookie preferences set", async () => {
-      authServiceResponseData.data.user = { cookieConsent: COOKIE_CONSENT.ACCEPT }
+      authServiceResponseData.data.user = {
+        cookieConsent: COOKIE_CONSENT.ACCEPT,
+      };
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
@@ -91,10 +96,12 @@ describe("authorize controller", () => {
         }),
       } as unknown as CookieConsentServiceInterface;
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(
-        req as Request,
-        res as Response
-      );
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
 
       expect(res.cookie).to.have.been.called;
       expect(res.redirect).to.have.calledWith(PATH_NAMES.SIGN_IN_OR_CREATE);
@@ -105,7 +112,7 @@ describe("authorize controller", () => {
         upliftRequired: true,
         authenticated: true,
         mfaMethodType: "SMS",
-      }
+      };
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
@@ -113,9 +120,12 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-        res as Response
-      );
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.UPLIFT_JOURNEY);
     });
@@ -125,7 +135,7 @@ describe("authorize controller", () => {
         upliftRequired: true,
         authenticated: true,
         mfaMethodType: "AUTH_APP",
-      }
+      };
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
@@ -133,9 +143,12 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-        res as Response
-      );
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
         PATH_NAMES.ENTER_AUTHENTICATOR_APP_CODE
@@ -149,7 +162,7 @@ describe("authorize controller", () => {
         identityRequired: false,
         upliftRequired: false,
         authenticated: true,
-      }
+      };
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
@@ -157,9 +170,12 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-        res as Response
-      );
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.AUTH_CODE);
     });
@@ -170,7 +186,7 @@ describe("authorize controller", () => {
         identityRequired: false,
         upliftRequired: false,
         authenticated: true,
-      }
+      };
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
@@ -178,9 +194,12 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-        res as Response
-      );
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.SHARE_INFO);
     });
@@ -191,7 +210,7 @@ describe("authorize controller", () => {
         identityRequired: true,
         upliftRequired: false,
         authenticated: true,
-      }
+      };
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
       const fakeCookieConsentService: CookieConsentServiceInterface = {
@@ -199,9 +218,12 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-        res as Response
-      );
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
         PATH_NAMES.PROVE_IDENTITY_WELCOME
@@ -223,9 +245,12 @@ describe("authorize controller", () => {
         createConsentCookieValue: sinon.fake(),
       };
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-        res as Response
-      );
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_PASSWORD);
     });
@@ -250,9 +275,12 @@ describe("authorize controller", () => {
         }),
       } as unknown as CookieConsentServiceInterface;
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-        res as Response
-      );
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
 
       expect(res.cookie).to.have.been.called;
       expect(res.redirect).to.have.calledWith(
@@ -278,9 +306,12 @@ describe("authorize controller", () => {
         }),
       } as unknown as CookieConsentServiceInterface;
 
-      await authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-        res as Response
-      );
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.DOC_CHECKING_APP);
     });
@@ -302,9 +333,12 @@ describe("authorize controller", () => {
       };
 
       await expect(
-        authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-          res as Response
-        )
+        authorizeGet(
+          fakeAuthorizeService,
+          fakeCookieConsentService,
+          fakeKmsDecryptionService,
+          fakeJwtService
+        )(req as Request, res as Response)
       )
         .to.eventually.be.rejectedWith("1000:Session-Id is missing or invalid")
         .and.be.an.instanceOf(BadRequestError)
@@ -328,9 +362,12 @@ describe("authorize controller", () => {
       };
 
       await expect(
-        authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-          res as Response
-        )
+        authorizeGet(
+          fakeAuthorizeService,
+          fakeCookieConsentService,
+          fakeKmsDecryptionService,
+          fakeJwtService
+        )(req as Request, res as Response)
       )
         .to.eventually.be.rejectedWith("1001:Request is missing parameters")
         .and.be.an.instanceOf(BadRequestError)
@@ -378,9 +415,12 @@ describe("authorize controller", () => {
       delete req.query.client_id;
 
       await expect(
-        authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-          res as Response
-        )
+        authorizeGet(
+          fakeAuthorizeService,
+          fakeCookieConsentService,
+          fakeKmsDecryptionService,
+          fakeJwtService
+        )(req as Request, res as Response)
       )
         .to.eventually.be.rejectedWith("Client ID does not exist")
         .and.be.an.instanceOf(QueryParamsError);
@@ -390,9 +430,12 @@ describe("authorize controller", () => {
       delete req.query.response_type;
 
       await expect(
-        authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-          res as Response
-        )
+        authorizeGet(
+          fakeAuthorizeService,
+          fakeCookieConsentService,
+          fakeKmsDecryptionService,
+          fakeJwtService
+        )(req as Request, res as Response)
       )
         .to.eventually.be.rejectedWith("Response type does not exist")
         .and.be.an.instanceOf(QueryParamsError);
@@ -402,9 +445,12 @@ describe("authorize controller", () => {
       req.query.client_id = "wrong_client id";
 
       await expect(
-        authorizeGet(fakeAuthorizeService, fakeCookieConsentService, fakeKmsDecryptionService, fakeJwtService)(req as Request,
-          res as Response
-        )
+        authorizeGet(
+          fakeAuthorizeService,
+          fakeCookieConsentService,
+          fakeKmsDecryptionService,
+          fakeJwtService
+        )(req as Request, res as Response)
       )
         .to.eventually.be.rejectedWith("Client ID value is incorrect")
         .and.be.an.instanceOf(QueryParamsError);
@@ -431,6 +477,6 @@ describe("authorize controller", () => {
         user: {},
       },
       success: true,
-    }
+    };
   }
 });

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -410,21 +410,6 @@ describe("authorize controller", () => {
       };
     });
 
-    it("should throw an error if client_id does not exist in the query params", async () => {
-      delete req.query.client_id;
-
-      await expect(
-        authorizeGet(
-          fakeAuthorizeService,
-          fakeCookieConsentService,
-          fakeKmsDecryptionService,
-          fakeJwtService
-        )(req as Request, res as Response)
-      )
-        .to.eventually.be.rejectedWith("Client ID does not exist")
-        .and.be.an.instanceOf(QueryParamsError);
-    });
-
     it("should throw an error if response_type does not exist in the query params", async () => {
       delete req.query.response_type;
 
@@ -436,7 +421,22 @@ describe("authorize controller", () => {
           fakeJwtService
         )(req as Request, res as Response)
       )
-        .to.eventually.be.rejectedWith("Response type does not exist")
+        .to.eventually.be.rejectedWith("Response type is not set")
+        .and.be.an.instanceOf(QueryParamsError);
+    });
+
+    it("should throw an error if response_type is null in the query params", async () => {
+      req.query.response_type = null as unknown as string;
+
+      await expect(
+        authorizeGet(
+          fakeAuthorizeService,
+          fakeCookieConsentService,
+          fakeKmsDecryptionService,
+          fakeJwtService
+        )(req as Request, res as Response)
+      )
+        .to.eventually.be.rejectedWith("Response type is not set")
         .and.be.an.instanceOf(QueryParamsError);
     });
 

--- a/src/components/authorize/tests/authorize-integration.test.ts
+++ b/src/components/authorize/tests/authorize-integration.test.ts
@@ -12,9 +12,13 @@ import {
 } from "../types";
 import { createApiResponse } from "../../../utils/http";
 import { AxiosResponse } from "axios";
-import { createmockclaims, getPrivateKey, getPublicKey } from "./test-data";
+import {
+  createJwt,
+  createmockclaims,
+  getPrivateKey,
+  getPublicKey,
+} from "./test-data";
 import { JwtService } from "../jwt-service";
-import { createJwt } from "./test-data";
 
 describe("Integration:: authorize", () => {
   let app: any;

--- a/src/components/authorize/tests/authorize-integration.test.ts
+++ b/src/components/authorize/tests/authorize-integration.test.ts
@@ -64,6 +64,7 @@ describe("Integration:: authorize", () => {
   it("should redirect to /sign-in-or-create", (done) => {
     request(app)
       .get(PATH_NAMES.AUTHORIZE)
+      .query({ client_id: "orchestrationAuth", response_type: "code" })
       .expect("Location", PATH_NAMES.SIGN_IN_OR_CREATE)
       .expect(302, done);
   });

--- a/src/components/authorize/tests/jwt-service.test.ts
+++ b/src/components/authorize/tests/jwt-service.test.ts
@@ -6,7 +6,6 @@ import {
   JwtSignatureVerificationError,
   ClaimsError,
 } from "../../../utils/error";
-import { AuthorizeRequestPayload } from "../types";
 
 const validJwt =
   "eyJhbGciOiJFUzI1NiJ9.eyJjbGllbnQtbmFtZSI6ImRpLWF1dGgtc3R1Yi1yZWx5aW5nLXBhcnR5LXNhbmRwaXQifQ.FFNDcj3znW5JPillhEIgCvWFCinlX0PMdvfVxgDArYueiVH6VDvlhaZyS70ocm9eOXBlB8pe449vpJrcKllBBg";
@@ -119,7 +118,7 @@ describe("JWT service", () => {
   });
 
   describe("validateClaims", () => {
-    let claims: AuthorizeRequestPayload;
+    let claims: any;
     beforeEach(() => {
       claims = createmockclaims();
     });
@@ -132,13 +131,25 @@ describe("JWT service", () => {
       Object.keys(claims).forEach((claim) => {
         try {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { claim, ...payloadWithoutIss } = claims as any;
-          jwtService.validateClaims(payloadWithoutIss);
+          const { claim, ...payloadWithoutClaim } = claims as any;
+          jwtService.validateClaims(payloadWithoutClaim);
         } catch (error) {
           expect(error).to.be.an.instanceOf(ClaimsError);
           expect(error.message).to.equal(`${claim} claim missing`);
         }
       });
+    });
+
+    it("Check that multiple errors return in one message", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { aud, iss, ...payloadWithoutClaim } = claims as any;
+      try {
+        jwtService.validateClaims(payloadWithoutClaim);
+      } catch (error) {
+        expect(error).to.be.an.instanceOf(ClaimsError);
+        expect(error.message).to.contain("iss claim missing");
+        expect(error.message).to.contain("aud claim missing");
+      }
     });
 
     it("Should throw ClaimsError if Token expired", () => {
@@ -166,7 +177,7 @@ describe("JWT service", () => {
     });
   });
 
-  function createmockclaims(): AuthorizeRequestPayload {
+  function createmockclaims(): any {
     const timestamp = Math.floor(new Date().getTime() / 1000);
     return {
       confidence: "Cl.Cm",

--- a/src/components/authorize/tests/jwt-service.test.ts
+++ b/src/components/authorize/tests/jwt-service.test.ts
@@ -209,27 +209,27 @@ describe("JWT service", () => {
       }
     });
   });
-
-  function createmockclaims(): any {
-    const timestamp = Math.floor(new Date().getTime() / 1000);
-    return {
-      confidence: "Cl.Cm",
-      iss: "UNKNOWN",
-      consent_required: false,
-      client_id: "UNKNOWN",
-      govuk_signin_journey_id: "QOFzoB3o-9gGplMgdT1dJfH4vaI",
-      aud: "UNKNOWN",
-      service_type: "MANDATORY",
-      nbf: timestamp,
-      cookie_consent_shared: true,
-      scope: "openid email phone",
-      state: "WLUNPYv0RPdVjhBsG4QMHYYMhGaOc8X-t83Y1XsVh1w",
-      redirect_uri: "UNKNOWN",
-      exp: timestamp + 1000,
-      iat: timestamp,
-      client_name: "di-auth-stub-relying-party-sandpit",
-      is_one_login_service: false,
-      jti: "fvvMWAladDtl35O_xyBTRLwwojA",
-    };
-  }
 });
+
+export function createmockclaims(): any {
+  const timestamp = Math.floor(new Date().getTime() / 1000);
+  return {
+    confidence: "Cl.Cm",
+    iss: "UNKNOWN",
+    consent_required: false,
+    client_id: "UNKNOWN",
+    govuk_signin_journey_id: "QOFzoB3o-9gGplMgdT1dJfH4vaI",
+    aud: "UNKNOWN",
+    service_type: "MANDATORY",
+    nbf: timestamp,
+    cookie_consent_shared: true,
+    scope: "openid email phone",
+    state: "WLUNPYv0RPdVjhBsG4QMHYYMhGaOc8X-t83Y1XsVh1w",
+    redirect_uri: "UNKNOWN",
+    exp: timestamp + 1000,
+    iat: timestamp,
+    client_name: "di-auth-stub-relying-party-sandpit",
+    is_one_login_service: false,
+    jti: "fvvMWAladDtl35O_xyBTRLwwojA",
+  };
+}

--- a/src/components/authorize/tests/jwt-service.test.ts
+++ b/src/components/authorize/tests/jwt-service.test.ts
@@ -130,7 +130,7 @@ describe("JWT service", () => {
 
     it("Should throw ClaimsError if missing claim", () => {
       Object.keys(claims).forEach((claim) => {
-        const withoutClaim = {...claims};
+        const withoutClaim = { ...claims };
         try {
           delete withoutClaim[claim];
           jwtService.validateClaims(withoutClaim);
@@ -142,17 +142,22 @@ describe("JWT service", () => {
       });
     });
 
-    it("should throw a claims error if incorrect value for claim", () => {
-      const knowClaim = Object.keys(getKnownClaims())[0];
-      claims[knowClaim] = "Incorrect value";
+    it("Should throw ClaimsError if type of claim is incorrect", () => {
+      type nonExisitngType = { notatype: null };
 
-      try {
-        jwtService.validateClaims(claims);
-        assert.fail("Expected error to be thrown");
-      } catch (error) {
-        expect(error).to.be.an.instanceOf(ClaimsError);
-        expect(error.message).to.equal(`${knowClaim} has incorrect value`)
-      }
+      Object.keys(claims).forEach((claim) => {
+        const incorrectTypeClaim = { ...claims };
+        try {
+          delete incorrectTypeClaim[claim];
+          incorrectTypeClaim[claim] = {} as nonExisitngType;
+
+          jwtService.validateClaims(incorrectTypeClaim);
+          assert.fail("Expected error to be thrown");
+        } catch (error) {
+          expect(error).to.be.an.instanceOf(ClaimsError);
+          expect(error.message).to.equal(`${claim} claim type is incorrect`);
+        }
+      });
     });
 
     it("should check that multiple errors return in one message", () => {
@@ -164,6 +169,19 @@ describe("JWT service", () => {
         expect(error).to.be.an.instanceOf(ClaimsError);
         expect(error.message).to.contain("iss claim missing");
         expect(error.message).to.contain("aud claim missing");
+      }
+    });
+
+    it("should throw a claims error if incorrect value for claim", () => {
+      const knowClaim = Object.keys(getKnownClaims())[0];
+      claims[knowClaim] = "Incorrect value";
+
+      try {
+        jwtService.validateClaims(claims);
+        assert.fail("Expected error to be thrown");
+      } catch (error) {
+        expect(error).to.be.an.instanceOf(ClaimsError);
+        expect(error.message).to.equal(`${knowClaim} has incorrect value`);
       }
     });
 

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -1,0 +1,54 @@
+import * as jose from "jose";
+
+export function createmockclaims(): any {
+  const timestamp = Math.floor(new Date().getTime() / 1000);
+  return {
+    confidence: "Cl.Cm",
+    iss: "UNKNOWN",
+    consent_required: false,
+    client_id: "UNKNOWN",
+    govuk_signin_journey_id: "QOFzoB3o-9gGplMgdT1dJfH4vaI",
+    aud: "UNKNOWN",
+    service_type: "MANDATORY",
+    nbf: timestamp,
+    cookie_consent_shared: true,
+    scope: "openid email phone",
+    state: "WLUNPYv0RPdVjhBsG4QMHYYMhGaOc8X-t83Y1XsVh1w",
+    redirect_uri: "UNKNOWN",
+    exp: timestamp + 1000,
+    iat: timestamp,
+    client_name: "di-auth-stub-relying-party-sandpit",
+    is_one_login_service: false,
+    jti: "fvvMWAladDtl35O_xyBTRLwwojA",
+  };
+}
+
+export function getPublicKey(): string {
+  return "-----BEGIN PUBLIC KEY-----MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEn8HvZP5umARULT+kFlJMC+djrruj4jnfQ0dzrAty0YKF4NPR/WV2QrpCRKQyBwbJk7dcGfW1HpafH78+T8bC9Q==-----END PUBLIC KEY-----";
+}
+
+export async function getPrivateKey(): Promise<jose.KeyLike> {
+  const key = await jose.importPKCS8(
+    "-----BEGIN PRIVATE KEY-----MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg7KK6gFv7hs2DImXpBaaD1ytDX0MJdh/pTK5LDyUzckWhRANCAASfwe9k/m6YBFQtP6QWUkwL52Ouu6PiOd9DR3OsC3LRgoXg09H9ZXZCukJEpDIHBsmTt1wZ9bUelp8fvz5PxsL1-----END PRIVATE KEY-----",
+    "ES256"
+  );
+  return key;
+}
+
+export async function getWrongPrivateKey(): Promise<jose.KeyLike> {
+  const key = await jose.importPKCS8(
+    "-----BEGIN PRIVATE KEY-----MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg+SgpFc3oo6bRHAOhpI6pv85fPm4ehgOPCQM0cEcwIK+hRANCAAS8u0WXxvx2N6bSFtfTggvnkGJvCsYo3jBYvCKJY5m87BcmwcgyFTDbedBbDnOC0OO0xdjLKu8577NnXPvE/jyd-----END PRIVATE KEY-----",
+    "ES256"
+  );
+  return key;
+}
+
+export async function createJwt(
+  jwtObject: any,
+  privateKey: jose.KeyLike
+): Promise<string> {
+  const jwt = await new jose.SignJWT(jwtObject)
+    .setProtectedHeader({ alg: "ES256" })
+    .sign(privateKey);
+  return jwt;
+}

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -41,10 +41,27 @@ export interface KmsDecryptionServiceInterface {
 }
 
 export interface JwtServiceInterface {
-  verify(jwt: string): Promise<boolean>;
-  getPayload(jwt: string): AuthorizeRequestPayload;
+  signatureCheck(jwt: string): Promise<boolean>;
+  getPayloadWithSigCheck(jwt: string): Promise<AuthorizeRequestPayload>;
+  validateClaims(claims: AuthorizeRequestPayload): AuthorizeRequestPayload;
 }
 
 export interface AuthorizeRequestPayload {
-  "client-name": string;
+  iss: string;
+  aud: string;
+  exp: number;
+  iat: number;
+  nbf: number;
+  jti: string;
+  client_name: string;
+  cookie_consent_shared: boolean;
+  consent_required: boolean;
+  is_one_login_service: boolean;
+  service_type: string;
+  govuk_signin_journey_id: string;
+  confidence: string;
+  state: string;
+  client_id: string;
+  scope: string;
+  redirect_uri: string;
 }

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -42,26 +42,6 @@ export interface KmsDecryptionServiceInterface {
 
 export interface JwtServiceInterface {
   signatureCheck(jwt: string): Promise<boolean>;
-  getPayloadWithSigCheck(jwt: string): Promise<AuthorizeRequestPayload>;
-  validateClaims(claims: AuthorizeRequestPayload): AuthorizeRequestPayload;
-}
-
-export interface AuthorizeRequestPayload {
-  iss: string;
-  aud: string;
-  exp: number;
-  iat: number;
-  nbf: number;
-  jti: string;
-  client_name: string;
-  cookie_consent_shared: boolean;
-  consent_required: boolean;
-  is_one_login_service: boolean;
-  service_type: string;
-  govuk_signin_journey_id: string;
-  confidence: string;
-  state: string;
-  client_id: string;
-  scope: string;
-  redirect_uri: string;
+  getPayloadWithSigCheck(jwt: string): Promise<any>;
+  validateClaims(claims: any): any;
 }

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -1,4 +1,5 @@
 import { ApiResponseResult, DefaultApiResponse } from "../../types";
+import { Claims } from "./claims-config";
 
 export interface StartAuthResponse extends DefaultApiResponse {
   client: ClientInfo;
@@ -43,5 +44,5 @@ export interface KmsDecryptionServiceInterface {
 export interface JwtServiceInterface {
   signatureCheck(jwt: string): Promise<boolean>;
   getPayloadWithSigCheck(jwt: string): Promise<any>;
-  validateClaims(claims: any): any;
+  validateClaims(claims: any): Claims;
 }

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -42,7 +42,6 @@ export interface KmsDecryptionServiceInterface {
 }
 
 export interface JwtServiceInterface {
-  signatureCheck(jwt: string): Promise<boolean>;
-  getPayloadWithSigCheck(jwt: string): Promise<any>;
-  validateClaims(claims: any): Claims;
+  getPayloadWithValidation(jwt: string): Promise<any>;
+  validateCustomClaims(claims: any): Claims;
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -51,6 +51,13 @@ export class JwtPayloadParseError extends Error {
   }
 }
 
+export class QueryParamsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QueryParamsError";
+  }
+}
+
 export class ClaimsError extends Error {
   constructor(message: string) {
     super(message);

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -51,6 +51,13 @@ export class JwtPayloadParseError extends Error {
   }
 }
 
+export class ClaimsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClaimsError";
+  }
+}
+
 export class ErrorWithLevel extends Error {
   level: string;
   constructor(message: string, level: string) {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -27,12 +27,12 @@ export class DecryptionError extends Error {
   }
 }
 
-export class JwtSignatureVerificationError extends Error {
+export class JwtValidationError extends Error {
   cause: Error | undefined;
 
   constructor(message: string, cause?: Error) {
     super(message);
-    this.name = "JwtSignatureVerificationError";
+    this.name = "JwtValidationError";
     this.cause = cause;
   }
 }
@@ -44,13 +44,6 @@ export class InvalidBase64Error extends Error {
   }
 }
 
-export class JwtPayloadParseError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "JwtPayloadParseError";
-  }
-}
-
 export class QueryParamsError extends Error {
   constructor(message: string) {
     super(message);
@@ -58,7 +51,7 @@ export class QueryParamsError extends Error {
   }
 }
 
-export class ClaimsError extends Error {
+export class JwtClaimsValueError extends Error {
   constructor(message: string) {
     super(message);
     this.name = "ClaimsError";


### PR DESCRIPTION
Add jwt-service tests.
Add AuthorizeRequestPayload interface.

## What?

- Added basic validation of JWE and claims if contained in the query request.

## Why?

- This will remove the dependency of the start API endpoint in the frontend API on client registry (DB) access
- This is a pre-requisite for splitting the orchestration and authentication APIs

## Related PRs
Builds on backend changes - Pass client registry fields to auth front end via JWE: https://github.com/alphagov/di-authentication-api/pull/3159
