### PR TITLE
Log only path, without query parameters

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -10,7 +10,7 @@ const logger = pino({
       return {
         id: req.id,
         method: req.method,
-        url: req.url,
+        url: req.url?.path,
         from: getRefererFrom(req.headers.referer),
       };
     },


### PR DESCRIPTION
## What?
- Log only path of requests, and not query parameters

## Why?
- We are currently logging full query strings; this is not really required, and means that if a user were to include PII in a query string (deliberately or otherwise) we risk logging it in normal application logs (note: we should never be accepting PII in a query string anyway, so this is 'belt and braces')
- To mitigate this risk, we can log only the path i.e. without query params
- Note also relevant discussion here: https://govukverify.atlassian.net/browse/INCIDENT-373

## Performance Analysis have been informed of the change

- [ ] Performance Analysis have been informed of the change

