### PR TITLE
AUT-1223: Enable account recovery in production

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -9,7 +9,7 @@ frontend_auto_scaling_min_count = 4
 frontend_auto_scaling_max_count = 12
 ecs_desired_count               = 4
 support_international_numbers   = "1"
-support_account_recovery        = "0"
+support_account_recovery        = "1"
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]


### PR DESCRIPTION
## What?
- Enable account recovery block in all environments (all except prod were already enabled)

## Why?
- This is part of putting account recovery journeys live in production

## Related PRs
- Corresponding PR for back end must be merged first: https://github.com/alphagov/di-authentication-api/pull/3218