### PR TITLE
AUT-1547: Apply spellcheck attribute consistently

### DIFF
--- a/src/components/contact-us/questions/_proving-identity-problem-questions.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-questions.njk
@@ -50,6 +50,7 @@
     id: "serviceTryingToUse",
     name: "serviceTryingToUse",
     value: serviceTryingToUse,
+    spellcheck: false,
     hint: {
         text: 'pages.contactUsQuestions.serviceTryingToUse.hint' | translateEnOnly
     },

--- a/src/components/contact-us/questions/_service-trying-to-use.njk
+++ b/src/components/contact-us/questions/_service-trying-to-use.njk
@@ -6,6 +6,7 @@
     id: "serviceTryingToUse",
     name: "serviceTryingToUse",
     value: serviceTryingToUse,
+    spellcheck: false,
     hint: {
         text: 'pages.contactUsQuestions.serviceTryingToUse.hint' | translateEnOnly
     },

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -56,6 +56,7 @@
     id: "optionalDescription",
     name: "optionalDescription",
     value: optionalDescription,
+    spellcheck: false,
     errorMessage: {
         text: errors['optionalDescription'].text
     } if (errors['optionalDescription'])


### PR DESCRIPTION
## What?

Updates all instances of `govukInput` that have a 'checkable' type as defined by [the HTML specification](https://html.spec.whatwg.org/multipage/interaction.html#attr-spellcheck) to include a `spellcheck=false` attribute. These types are `text`, `search`, URL and `email`. It does not include inputs with a type of `tel`, because `tel` is not a checkable type under the spec.

User agents can also conduct spellchecking on other fields, such as `<textarea>` which is rendered extensively throughout the support forms through the use of `govukCharacterCount`. Having searched the code I can see that all rendered `<textarea>` components are shown with a warning to:

> Do not include personal or financial information, for example your passport or credit card details

Because the application of `spellcheck=false` to these `<textarea>` fields will impact the user experience for these longer form fields, I have not changed them without seeking UCD/product input. I'll seek advice on this and will raise a separate PR if necessary. 

## Why?

To ensure consistency across the Authentication frontend and to mitigate a [security / privacy concern](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck#security_and_privacy_concerns) associated with the specification not stipulating how spellchecking is done (allowing user agents to send user entered text to a third-party).
