### PR TITLE
AUT-1299: Differentiate show and hide labels on password component

### DIFF
--- a/src/components/create-password/ab-tests/index-variant.njk
+++ b/src/components/create-password/ab-tests/index-variant.njk
@@ -44,12 +44,12 @@
             "confirm-password",
             errors,
             {
-                show: 'general.showPassword.show' | translate,
-                hide: 'general.showPassword.hide' | translate,
-                showFullText: 'general.showPassword.showFullText' | translate,
-                hideFullText: 'general.showPassword.hideFullText' | translate,
-                announceShown: 'general.showPassword.announceShown' | translate,
-                announceHidden: 'general.showPassword.announceHidden' | translate
+                show: 'general.showRetypedPassword.show' | translate,
+                hide: 'general.showRetypedPassword.hide' | translate,
+                showFullText: 'general.showRetypedPassword.showFullText' | translate,
+                hideFullText: 'general.showRetypedPassword.hideFullText' | translate,
+                announceShown: 'general.showRetypedPassword.announceShown' | translate,
+                announceHidden: 'general.showRetypedPassword.announceHidden' | translate
             },
             'new-password'
         ) }}

--- a/src/components/create-password/index.njk
+++ b/src/components/create-password/index.njk
@@ -37,12 +37,12 @@
         "confirm-password",
         errors,
         {
-            show: 'general.showPassword.show' | translate,
-            hide: 'general.showPassword.hide' | translate,
-            showFullText: 'general.showPassword.showFullText' | translate,
-            hideFullText: 'general.showPassword.hideFullText' | translate,
-            announceShown: 'general.showPassword.announceShown' | translate,
-            announceHidden: 'general.showPassword.announceHidden' | translate
+            show: 'general.showRetypedPassword.show' | translate,
+            hide: 'general.showRetypedPassword.hide' | translate,
+            showFullText: 'general.showRetypedPassword.showFullText' | translate,
+            hideFullText: 'general.showRetypedPassword.hideFullText' | translate,
+            announceShown: 'general.showRetypedPassword.announceShown' | translate,
+            announceHidden: 'general.showRetypedPassword.announceHidden' | translate
         },
         'new-password'
     ) }}

--- a/src/components/reset-password/index.njk
+++ b/src/components/reset-password/index.njk
@@ -50,12 +50,12 @@
         "confirm-password",
         errors,
         {
-            show: 'general.showPassword.show' | translate,
-            hide: 'general.showPassword.hide' | translate,
-            showFullText: 'general.showPassword.showFullText' | translate,
-            hideFullText: 'general.showPassword.hideFullText' | translate,
-            announceShown: 'general.showPassword.announceShown' | translate,
-            announceHidden: 'general.showPassword.announceHidden' | translate
+            show: 'general.showRetypedPassword.show' | translate,
+            hide: 'general.showRetypedPassword.hide' | translate,
+            showFullText: 'general.showRetypedPassword.showFullText' | translate,
+            hideFullText: 'general.showRetypedPassword.hideFullText' | translate,
+            announceShown: 'general.showRetypedPassword.announceShown' | translate,
+            announceHidden: 'general.showRetypedPassword.announceHidden' | translate
         }
     )  }}
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -85,6 +85,14 @@
       "hideFullText": "Cuddio cyfrinair",
       "announceShown": "Mae eich cyfrinair wedi’i ddangos",
       "announceHidden": "Mae eich cyfrinair wedi’i guddio"
+    },
+    "showRetypedPassword": {
+      "show": "Dangos",
+      "hide": "Cuddio",
+      "showFullText": "Dangos cyfrinair wedi’i aildeipio",
+      "hideFullText": "Cuddio cyfrinair wedi’i aildeipio",
+      "announceShown": "Mae eich cyfrinair wedi’i aildeipio wedi cael ei ddangos",
+      "announceHidden": "Mae eich cyfrinair wedi’i aildeipio wedi cael ei guddio"
     }
   },
   "error": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -85,6 +85,14 @@
       "hideFullText": "Hide password",
       "announceShown": "Your password is shown",
       "announceHidden": "Your password is hidden"
+    },
+    "showRetypedPassword": {
+      "show": "Show",
+      "hide": "Hide",
+      "showFullText": "Show retyped password",
+      "hideFullText": "Hide retyped password",
+      "announceShown": "Your retyped password is shown",
+      "announceHidden": "Your retyped password is hidden"
     }
   },
   "error": {


### PR DESCRIPTION
## What?

This uses the same approach as has been implemented by Accounts Home in OLH-869 updating the programmatically associated label (as implemented with `aria-label`) and text that is announced to assistive technology (via a `<span>` with `aria-live="polite"`). There are no changes to the visual presentation. 

## Why?

Please include reason for the change and any other relevant context.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

## Related PRs

The Accounts Home PR is https://github.com/alphagov/di-account-management-frontend/pull/930
