### PR TITLE
BAU: Add missing semi-colon

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1030,7 +1030,7 @@
           "paragraph_four": "We need to check your identity document security features to prove that they are genuine documents.",
           "paragraph_five": "For driving licences, you will need to take a photo of the front and back of your licence with your phone camera. The app will require permission to access your camera and photos for this.",
           "paragraph_six": "For e-passports and biometric residence permits, the app will read your document information from its near field communication (NFC) chip.",
-          "paragraph_seven": "We collect the following information",
+          "paragraph_seven": "We collect the following information:",
           "list_two": {
             "item_one": "name",
             "item_two": "date of birth",


### PR DESCRIPTION
## What?

Adds missing semi-colon to the English version of the privacy notice

### Screenshot

<details open>

<summary>English screenshot (with semi-colon added to sentence before list)</summary>

<img width="630" alt="Screenshot 2023-08-17 at 13 15 48" src="https://github.com/alphagov/di-authentication-frontend/assets/16000203/bbcaf589-34b2-4d8f-8f96-552f05263ff1">


</details>

## Why?

While reviewing the content for AUT-1493, colleagues noticed that a semi-colon was missing from the English version of the privacy notice.
