### PR TITLE
BAU: Update path logging expression and stop logging query params for 'from' field

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -10,7 +10,7 @@ const logger = pino({
       return {
         id: req.id,
         method: req.method,
-        url: req.url?.path,
+        url: req.path,
         from: getRefererFrom(req.headers.referer),
       };
     },

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -30,7 +30,7 @@ export function getRefererFrom(referer: string): string {
   if (referer) {
     try {
       const refererUrl = new URL(referer);
-      return refererUrl.pathname + refererUrl.search;
+      return refererUrl.pathname;
     } catch (error) {
       return undefined;
     }

--- a/test/unit/utils/logger.test.ts
+++ b/test/unit/utils/logger.test.ts
@@ -26,30 +26,28 @@ describe("logger", () => {
       ).to.equal("/hello/good/morning");
     });
 
-    it("should return path and query from a url", () => {
+    it("should return path but not a query param from a url", () => {
       expect(getRefererFrom("http://localhost:8080/hello?world=true")).to.equal(
-        "/hello?world=true"
+        "/hello"
       );
     });
 
-    it("should return query only from a url", () => {
-      expect(getRefererFrom("http://localhost:8080?world=true")).to.equal(
-        "/?world=true"
-      );
+    it("should not return query only from a url", () => {
+      expect(getRefererFrom("http://localhost:8080?world=true")).to.equal("/");
     });
 
-    it("should return a longer path and query from a url", () => {
+    it("should return a longer path but not a query param from a url", () => {
       expect(
         getRefererFrom("http://localhost:8080/hello/good/morning?world=true")
-      ).to.equal("/hello/good/morning?world=true");
+      ).to.equal("/hello/good/morning");
     });
 
-    it("should return a longer path and two query params from a url", () => {
+    it("should return a longer path but not two query params from a url", () => {
       expect(
         getRefererFrom(
           "http://localhost:8080/hello/good/morning?world=true&morning=good"
         )
-      ).to.equal("/hello/good/morning?world=true&morning=good");
+      ).to.equal("/hello/good/morning");
     });
 
     it("should return empty path from a url", () => {


### PR DESCRIPTION
## What?

Update path logging expression and stop logging query params for 'from' field.

## Why?

The existing expression used to log paths was always empty so nothing was being logged.  'req.path' does not contain query parameters: https://expressjs.com/en/api.html#req.path

URL pathname (used for logging the 'from' field) also does not contain query parameters: https://developer.mozilla.org/en-US/docs/Web/API/URL/pathname

## Related

#1120 