### PR TITLE
AUT-1622: Add query param passthrough from landing to sign in

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -24,6 +24,7 @@ import {
 import { KmsDecryptionService } from "./kms-decryption-service";
 import { JwtService } from "./jwt-service";
 import { EXPECTED_CLIENT_ID } from "./claims-config";
+import { appendQueryParamIfHasValue } from "../../utils/url";
 
 function createConsentCookie(
   res: Response,
@@ -153,7 +154,18 @@ export function authorizeGet(
       }
     }
 
-    return res.redirect(redirectPath);
+    const faceToFaceRpGoogleAnalyticsParamKey = "result";
+    const faceToFaceRpGoogleAnalyticsParamValue = sanitize(
+      req.query[faceToFaceRpGoogleAnalyticsParamKey] as string
+    );
+
+    return res.redirect(
+      appendQueryParamIfHasValue(
+        redirectPath,
+        faceToFaceRpGoogleAnalyticsParamKey,
+        faceToFaceRpGoogleAnalyticsParamValue
+      )
+    );
   };
 }
 

--- a/src/components/landing/landing-controller.ts
+++ b/src/components/landing/landing-controller.ts
@@ -17,6 +17,7 @@ import { sanitize } from "../../utils/strings";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
 import { landingService } from "./landing-service";
 import { LandingServiceInterface } from "./types";
+import { appendQueryParamIfHasValue } from "../../utils/url";
 
 function createConsentCookie(
   res: Response,
@@ -127,6 +128,17 @@ export function landingGet(
       }
     }
 
-    return res.redirect(redirectPath);
+    const faceToFaceRpGoogleAnalyticsParamKey = "result";
+    const faceToFaceRpGoogleAnalyticsParamValue = sanitize(
+      req.query[faceToFaceRpGoogleAnalyticsParamKey] as string
+    );
+
+    return res.redirect(
+      appendQueryParamIfHasValue(
+        redirectPath,
+        faceToFaceRpGoogleAnalyticsParamKey,
+        faceToFaceRpGoogleAnalyticsParamValue
+      )
+    );
   };
 }

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,0 +1,13 @@
+export function appendQueryParamIfHasValue(
+  existingUrl: string,
+  queryParamKey: string,
+  queryParamValue: string
+): string {
+  if (!queryParamValue) {
+    return existingUrl;
+  }
+  if (existingUrl.includes("?")) {
+    return existingUrl + `&${queryParamKey}=${queryParamValue}`;
+  }
+  return existingUrl + `?${queryParamKey}=${queryParamValue}`;
+}


### PR DESCRIPTION
## What?
- Pass through an additional query parameter called `result` through the redirect from the landing page (i.e. the route that is redirected to by the OIDC API on receipt of an authorize request)
- This query param will always have the key 'result'
- It is expected that it will always have the value 'sign-in' although the code does not assume this
- Note: this is done in two handlers. Landing (`/`) is currently the active path for landing, but Authorize (`/authorize`) will play the same role when authentication and orchestration are split. So effectively the Authorize handler does nothing at the moment in production, but this is future proofing for this particular change.

## Why?
- The `result` parameter originates in an email sent to end users as part of the face to face journey
- When the user clicks the link, they will hit some kind of callback within the IPV return (F2F) RP (i.e. not something 'owned' by Authentication/Orchestration team)
- That RP will initiate an `/authorize` request to OIDC API (part of Orchestration) with the extra parameter attached alongside the 'standard' parameters e.g. client ID
- The OIDC API will pass it along to the landing endpoint of Auth frontend via 302 redirect (the back end is not performing validation of the client currently - only of the key name i.e. "result")
- At this points, the frontend has received the parameter. However, it then needs to be passed through one more redirect (`/` to `/sign-in-or-create`) in order to be picked up by Google Analytics as the landing route is not directly visible in GA.

## Related PRs
- Gives effect to a change already made in the back end here: https://github.com/alphagov/di-authentication-api/pull/3289
