### PR TITLE
AUT-1648: validate the jwt claim object and set in the session

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -88,9 +88,15 @@ export function authorizeGet(
 
     req.session.client.prompt = loginPrompt;
 
+    if (claims.claim !== undefined) {
+      const claim = JSON.parse(claims.claim);
+      if (claim.userinfo !== undefined) {
+        req.session.client.claim = Object.keys(claim.userinfo);
+      }
+    }
+
     req.session.client.serviceType = claims.service_type;
     req.session.client.name = claims.client_name;
-    req.session.client.scopes = claims.scope.split(" ");
     req.session.client.cookieConsentEnabled = claims.cookie_consent_shared;
     req.session.client.redirectUri = claims.redirect_uri;
     req.session.client.state = claims.state;

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -25,7 +25,6 @@ export type Claims = {
   confidence: string;
   state: string;
   client_id: string;
-  scope: string;
   redirect_uri: string;
   claim?: string;
 };
@@ -46,6 +45,5 @@ export const requiredClaimsKeys = [
   "confidence",
   "state",
   "client_id",
-  "scope",
   "redirect_uri",
 ];

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -9,30 +9,43 @@ export function getKnownClaims(): {
   };
 }
 
-// Single source of truth for claims type and claims object keys
+export type Claims = {
+  iss: string;
+  aud: string;
+  exp: number;
+  iat: number;
+  nbf: number;
+  jti: string;
+  client_name: string;
+  cookie_consent_shared: boolean;
+  consent_required: boolean;
+  is_one_login_service: boolean;
+  service_type: string;
+  govuk_signin_journey_id: string;
+  confidence: string;
+  state: string;
+  client_id: string;
+  scope: string;
+  redirect_uri: string;
+  claim?: string;
+};
 
-export type Claims = typeof claimsInstance;
-// construct object for type
-const claimsInstance = getClaimsObject();
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function getClaimsObject() {
-  return {
-    iss: "",
-    aud: "",
-    exp: NaN,
-    iat: NaN,
-    nbf: NaN,
-    jti: "",
-    client_name: "",
-    cookie_consent_shared: false,
-    consent_required: false,
-    is_one_login_service: false,
-    service_type: "",
-    govuk_signin_journey_id: "",
-    confidence: "",
-    state: "",
-    client_id: "",
-    scope: "",
-    redirect_uri: "",
-  };
-}
+export const requiredClaimsKeys = [
+  "iss",
+  "aud",
+  "exp",
+  "iat",
+  "nbf",
+  "jti",
+  "client_name",
+  "cookie_consent_shared",
+  "consent_required",
+  "is_one_login_service",
+  "service_type",
+  "govuk_signin_journey_id",
+  "confidence",
+  "state",
+  "client_id",
+  "scope",
+  "redirect_uri",
+];

--- a/src/components/authorize/jwt-service.ts
+++ b/src/components/authorize/jwt-service.ts
@@ -1,7 +1,7 @@
 import { JwtServiceInterface } from "./types";
 import { getOrchToAuthSigningPublicKey } from "../../config";
 import { JwtClaimsValueError, JwtValidationError } from "../../utils/error";
-import { Claims, getClaimsObject, getKnownClaims } from "./claims-config";
+import { Claims, requiredClaimsKeys, getKnownClaims } from "./claims-config";
 import * as jose from "jose";
 
 export class JwtService implements JwtServiceInterface {
@@ -17,7 +17,7 @@ export class JwtService implements JwtServiceInterface {
       const tempkey = await jose.importSPKI(this.publicKey, "ES256");
       claims = (
         await jose.jwtVerify(jwt, tempkey, {
-          requiredClaims: Object.keys(getClaimsObject()),
+          requiredClaims: requiredClaimsKeys,
           clockTolerance: 30,
         })
       ).payload;

--- a/src/components/authorize/jwt-service.ts
+++ b/src/components/authorize/jwt-service.ts
@@ -25,6 +25,10 @@ export class JwtService implements JwtServiceInterface {
       throw new JwtValidationError(error.message);
     }
 
+    if (claims["claim"] !== undefined) {
+      this.validateClaimObject(claims["claim"] as string);
+    }
+
     return this.validateCustomClaims(claims);
   }
 
@@ -37,5 +41,14 @@ export class JwtService implements JwtServiceInterface {
       }
     });
     return claims;
+  }
+
+  validateClaimObject(claim: string): string {
+    try {
+      JSON.parse(claim);
+      return claim;
+    } catch {
+      throw new JwtValidationError("claim object is not a valid json object");
+    }
   }
 }

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -31,6 +31,7 @@ describe("authorize controller", () => {
   let res: ResponseOutput;
   let authServiceResponseData: any;
   let fakeAuthorizeService: AuthorizeServiceInterface;
+  let fakeCookieConsentService: CookieConsentServiceInterface;
   let fakeKmsDecryptionService: KmsDecryptionServiceInterface;
   let fakeJwtService: JwtServiceInterface;
   let mockClaims: Claims;
@@ -51,9 +52,27 @@ describe("authorize controller", () => {
     res = mockResponse();
     authServiceResponseData = createAuthServiceReponseData();
 
+    fakeAuthorizeService = mockAuthService({
+      data: {
+        user: {
+          consentRequired: false,
+          identityRequired: false,
+          upliftRequired: false,
+          authenticated: true,
+        },
+      },
+      success: true,
+    });
+
+    fakeCookieConsentService = {
+      getCookieConsent: sinon.fake(),
+      createConsentCookieValue: sinon.fake(),
+    };
+
     fakeKmsDecryptionService = {
       decrypt: sinon.fake.returns(Promise.resolve("jwt")),
     };
+
     fakeJwtService = {
       getPayloadWithValidation: sinon.fake.returns(Promise.resolve(mockClaims)),
     };
@@ -66,11 +85,6 @@ describe("authorize controller", () => {
   describe("authorizeGet", () => {
     it("should redirect to /sign-in-or-create page when no existing session for user", async () => {
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
-
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
 
       await authorizeGet(
         fakeAuthorizeService,
@@ -115,11 +129,6 @@ describe("authorize controller", () => {
       };
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
-
       await authorizeGet(
         fakeAuthorizeService,
         fakeCookieConsentService,
@@ -138,11 +147,6 @@ describe("authorize controller", () => {
       };
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
-
       await authorizeGet(
         fakeAuthorizeService,
         fakeCookieConsentService,
@@ -157,18 +161,6 @@ describe("authorize controller", () => {
 
     it("should redirect to /auth-code when existing session", async () => {
       req.session.user.isAuthenticated = true;
-      authServiceResponseData.data.user = {
-        consentRequired: false,
-        identityRequired: false,
-        upliftRequired: false,
-        authenticated: true,
-      };
-      fakeAuthorizeService = mockAuthService(authServiceResponseData);
-
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
 
       await authorizeGet(
         fakeAuthorizeService,
@@ -189,11 +181,6 @@ describe("authorize controller", () => {
       };
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
-
       await authorizeGet(
         fakeAuthorizeService,
         fakeCookieConsentService,
@@ -213,11 +200,6 @@ describe("authorize controller", () => {
       };
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
-
       await authorizeGet(
         fakeAuthorizeService,
         fakeCookieConsentService,
@@ -232,18 +214,6 @@ describe("authorize controller", () => {
 
     it("should redirect to /enter-password page when prompt is login", async () => {
       req.query.prompt = OIDC_PROMPT.LOGIN;
-      authServiceResponseData.data.user = {
-        consentRequired: false,
-        identityRequired: false,
-        upliftRequired: false,
-        authenticated: true,
-      };
-      fakeAuthorizeService = mockAuthService(authServiceResponseData);
-
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
 
       await authorizeGet(
         fakeAuthorizeService,
@@ -295,14 +265,6 @@ describe("authorize controller", () => {
       };
       fakeAuthorizeService = mockAuthService(authServiceResponseData);
 
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake.returns({
-          value: JSON.stringify("cookieValue"),
-          expiry: "cookieExpires",
-        }),
-      } as unknown as CookieConsentServiceInterface;
-
       await authorizeGet(
         fakeAuthorizeService,
         fakeCookieConsentService,
@@ -323,11 +285,6 @@ describe("authorize controller", () => {
           success: false,
         }),
       } as unknown as AuthorizeServiceInterface;
-
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
 
       await expect(
         authorizeGet(
@@ -353,11 +310,6 @@ describe("authorize controller", () => {
         }),
       } as unknown as AuthorizeServiceInterface;
 
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
-
       await expect(
         authorizeGet(
           fakeAuthorizeService,
@@ -373,17 +325,6 @@ describe("authorize controller", () => {
 
     it("should set session fields from jwt claims", async () => {
       req.query.request = "JWE";
-      authServiceResponseData.data.user = {
-        consentRequired: false,
-        identityRequired: false,
-        upliftRequired: false,
-        authenticated: true,
-      };
-      fakeAuthorizeService = mockAuthService(authServiceResponseData);
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
 
       await authorizeGet(
         fakeAuthorizeService,
@@ -409,17 +350,6 @@ describe("authorize controller", () => {
 
     it("claims should be undefined when optional claims missing", async () => {
       req.query.request = "JWE";
-      authServiceResponseData.data.user = {
-        consentRequired: false,
-        identityRequired: false,
-        upliftRequired: false,
-        authenticated: true,
-      };
-      fakeAuthorizeService = mockAuthService(authServiceResponseData);
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
 
       delete mockClaims.claim;
 
@@ -440,18 +370,6 @@ describe("authorize controller", () => {
 
     it("claim should be undefined when json empty", async () => {
       req.query.request = "JWE";
-      authServiceResponseData.data.user = {
-        consentRequired: false,
-        identityRequired: false,
-        upliftRequired: false,
-        authenticated: true,
-      };
-      fakeAuthorizeService = mockAuthService(authServiceResponseData);
-      const fakeCookieConsentService: CookieConsentServiceInterface = {
-        getCookieConsent: sinon.fake(),
-        createConsentCookieValue: sinon.fake(),
-      };
-
       mockClaims.claim = "{}";
 
       fakeJwtService = {

--- a/src/components/authorize/tests/authorize-integration.test.ts
+++ b/src/components/authorize/tests/authorize-integration.test.ts
@@ -45,7 +45,6 @@ describe("Integration:: authorize", () => {
               client: {
                 serviceType: "MANDATORY",
                 clientName: "test-client",
-                scopes: ["openid"],
                 cookieConsentEnabled: true,
                 consentEnabled: true,
                 redirectUri: "http://test-redirect.gov.uk/callback",

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -20,6 +20,8 @@ export function createmockclaims(): any {
     client_name: "di-auth-stub-relying-party-sandpit",
     is_one_login_service: false,
     jti: "fvvMWAladDtl35O_xyBTRLwwojA",
+    claim:
+      '{"userinfo": {"email_verified": null, "public_subject_id": null, "email": null}}',
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,4 +88,5 @@ export interface UserSessionClient {
   redirectUri?: string;
   state?: string;
   isOneLoginService?: boolean;
+  claim?: string[];
 }


### PR DESCRIPTION
## What?

Orchestration currently passes scopes and claims to authentication. We decided to simplify this, by only passing claims when the auth/orch split feature flag is on.  There, we need to parse this claims object and set it in the session, in order to forward the request on (this will be done in a subsequent PR).

This should not affect current behaviour, so we still parse scopes.

[PR](https://github.com/alphagov/di-authentication-api/pull/3313) to pass only claims through on the backend