### PR TITLE
AUT-1634: DO NOT MERGE UNTIL WED 13 SEP 23: Content changes for privacy notice version 1.9

### DIFF
--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -173,6 +173,10 @@
         {{ 'pages.privacy.sections.using_id_check_app.paragraph_eighteen' | translate }}
     </p>
 
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.using_id_check_app.paragraph_nineteen' | translate }}
+    </p>
+
     <h2 class="govuk-heading-m">
         {{ 'pages.privacy.sections.using_web_to_prove_identity.header' | translate }}
     </h2>
@@ -248,6 +252,10 @@
         {{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_thirteen' | translate }}
     </p>
 
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.using_web_to_prove_identity.paragraph_fourteen' | translate }}
+    </p>
+
     <h2 class="govuk-heading-m">
         {{ 'pages.privacy.sections.proving_identity_at_post_office.header' | translate }}
     </h2>
@@ -280,6 +288,10 @@
 
     <p class="govuk-body">
         {{ 'pages.privacy.sections.proving_identity_at_post_office.paragraph_five' | translate }}
+    </p>
+
+    <p class="govuk-body">
+        {{ 'pages.privacy.sections.proving_identity_at_post_office.paragraph_five_one' | translate }}
     </p>
 
     <h3 class="govuk-heading-s">

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1062,7 +1062,8 @@
             }
           },
           "paragraph_seventeen": "Pan fyddwch wedi cwblhau’r gwiriadau uchod gan ddefnyddio’r Ap, byddwch yn cael eich dychwelyd i wefan GOV.UK One Login lle byddwn yn casglu eich enw, eich dyddiad geni a’ch cyfeiriad. Rydym yn anfon y rhain i Experian er mwyn iddynt allu cynnal gwiriad gwrth-dwyll.",
-          "paragraph_eighteen": "Pan mae Experian wedi cwblhau’r gwiriad, maent yn anfon sgôr twyll atom, ynghyd â manylion am unrhyw weithgaredd twyllodrus cysylltiedig."
+          "paragraph_eighteen": "Pan mae Experian wedi cwblhau’r gwiriad, maent yn anfon sgôr twyll atom, ynghyd â manylion am unrhyw weithgaredd twyllodrus cysylltiedig.",
+          "paragraph_nineteen": "Ni fydd y gwiriad twyll hwn yn effeithio ar eich sgôr credyd, gan ei fod yn ’chwiliad meddal’. Bydd cofnod amdano yn cael ei ychwanegu at eich cofnod credyd, ond dim ond i chi y bydd yn weladwy. Ni fydd sefydliadau eraill sy’n defnyddio Experian i gynnal eu gwiriadau credyd eu hunain yn gallu ei weld."
         },
         "using_web_to_prove_identity": {
           "header": "Defnyddio eich porwr gwe i brofi eich hunaniaeth",
@@ -1082,7 +1083,7 @@
           "paragraph_six": "Ar gyfer y gwiriad hwn rydym yn defnyddio eich enw, dyddiad geni a chyfeiriad i adfer cwestiynau perthnasol gan Experian. Rydym yn casglu eich atebion ac yn eu hanfon i Experian i wirio eu bod yn cyd-fynd â’r wybodaeth sydd ganddynt amdanoch chi yn barod.",
           "paragraph_seven": "Pan mae Experian wedi cwblhau’r gwiriad maent yn ymateb i ni gyda chanlyniad Pasio / Methu.",
           "paragraph_eight": "Nid yw GDS yn storio nac yn cadw’r cwestiynau na’ch atebion.",
-          "paragraph_nine": "Mae’r gwiriad hwn yn gyfystyr â ’chwiliad meddal’ sy’n golygu y bydd cofnod o’r gwiriad yn bodoli ar eich cofnodion credyd fel ’GOV.UK One Login’. Dim ond i chi y bydd yn weladwy ac nid i unrhyw sefydliadau eraill sy’n defnyddio Experian i gynnal eu gwiriadau credyd eu hunain. O ganlyniad, ni fydd yn cael effaith ar eich sgôr credyd.",
+          "paragraph_nine": "Ni fydd y gwiriad twyll hwn yn effeithio ar eich sgôr credyd, gan ei fod yn ’chwiliad meddal’. Bydd cofnod amdano yn cael ei ychwanegu at eich cofnod credyd, ond dim ond i chi y bydd yn weladwy. Ni fydd sefydliadau eraill sy’n defnyddio Experian i gynnal eu gwiriadau credyd eu hunain yn gallu ei weld.",
           "sub_header_three": "Gwiriad twyll",
           "paragraph_ten": "Rydym yn defnyddio darparwr gwasanaeth gwirio hunaniaeth o’r enw Experian i gynnal archwiliad twyll i:",
           "list": {
@@ -1097,7 +1098,8 @@
             }
           },
           "paragraph_twelve": "Pan fyddwch wedi cwblhau’r gwiriadau uchod, byddwn yn casglu eich enw, dyddiad geni a chyfeiriad. Rydym yn anfon y rhain at Experian fel y gallant gynnal y gwiriad.",
-          "paragraph_thirteen": "Pan fydd Experian wedi cwblhau’r gwiriad, maent yn anfon sgôr twyll atom, ynghyd â manylion unrhyw weithgaredd twyllodrus cysylltiedig."
+          "paragraph_thirteen": "Pan fydd Experian wedi cwblhau’r gwiriad, maent yn anfon sgôr twyll atom, ynghyd â manylion unrhyw weithgaredd twyllodrus cysylltiedig.",
+          "paragraph_fourteen": "Ni fydd y gwiriad twyll hwn yn effeithio ar eich sgôr credyd, gan ei fod yn ’chwiliad meddal’. Bydd cofnod amdano yn cael ei ychwanegu at eich cofnod credyd, ond dim ond i chi y bydd yn weladwy. Ni fydd sefydliadau eraill sy’n defnyddio Experian i gynnal eu gwiriadau credyd eu hunain yn gallu ei weld."
         },
         "proving_identity_at_post_office": {
           "header": "Profi eich hunaniaeth yn y Swyddfa Bost",
@@ -1117,6 +1119,7 @@
           },
           "paragraph_four": "Rydym yn casglu eich enw, dyddiad geni a chyfeiriad ac yn eu hanfon i Experian fel y gallant gynnal y gwiriad.",
           "paragraph_five": "Pan fydd Experian wedi cwblhau’r gwiriad, maent yn anfon sgôr twyll atom, ynghyd â manylion unrhyw weithgaredd twyllodrus cysylltiedig.",
+          "paragraph_five_one": "Ni fydd y gwiriad twyll hwn yn effeithio ar eich sgôr credyd, gan ei fod yn ’chwiliad meddal’. Bydd cofnod amdano yn cael ei ychwanegu at eich cofnod credyd, ond dim ond i chi y bydd yn weladwy. Ni fydd sefydliadau eraill sy’n defnyddio Experian i gynnal eu gwiriadau credyd eu hunain yn gallu ei weld.",
           "sub_header_two": "Gwiriad dogfennau dilys a gwiriad tebygrwydd",
           "paragraph_six": "Mae angen i ni wirio:",
           "list_two": {

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1439,7 +1439,7 @@
           "header": "Newidiadau i’r hysbysiad hwn",
           "paragraph_one": "Efallai y byddwn yn newid yr hysbysiad preifatrwydd hwn. Yn yr achos hynny, bydd dyddiad ’diweddaru olaf’ y ddogfen hon hefyd yn newid. Bydd unrhyw newidiadau i’r hysbysiad preifatrwydd hwn yn berthnasol i chi a’ch gwybodaeth ar unwaith.",
           "paragraph_two": "Os yw’r newidiadau hyn yn effeithio ar sut mae eich gwybodaeth bersonol yn cael ei phrosesu, bydd GDS yn rhoi gwybod i chi.",
-          "paragraph_three": "Diweddarwyd diwethaf: 31 Awst 2023"
+          "paragraph_three": "Diweddarwyd diwethaf: 13 Medi 2023"
         }
       }
     },

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1322,7 +1322,7 @@
         "how_long_we_keep_your_information": {
           "header": "Pa mor hir rydym yn cadw eich gwybodaeth",
           "paragraph_one": "Rydym yn storio eich gwybodaeth bersonol am ddim mwy o amser nag sy’n rhesymol angenrheidiol ac yn gyfreithiol gyfiawn.",
-          "paragraph_two": "Byddwn yn cadw eich GOV.UK One Login cyhyd ag y dymunwch ei ddefnyddio er y byddwn yn ei ddileu os na fyddwch yn ei ddefnyddio am 2 flynedd. ",
+          "paragraph_two": "Byddwn yn cadw eich GOV.UK One Login cyhyd ag y dymunwch ei ddefnyddio er y byddwn yn ei ddileu os na fyddwch yn ei ddefnyddio am 3 flynedd. ",
           "paragraph_three": "Os ydych yn dewis dileu eich GOV.UK One Login, byddwn yn dileu eich cyfrif a’ch gwybodaeth adnabod profedig.",
           "paragraph_four": "Rydym yn dileu eich llun llonydd a gynhyrchir o’ch fideo hunlun, delweddau trwydded yrru a data biometrig y wyneb o systemau Iproov ar ôl 30 diwrnod.",
           "paragraph_five": "Byddwn yn cadw eich data adborth am 2 flynedd.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1322,7 +1322,7 @@
         "how_long_we_keep_your_information": {
           "header": "How long we keep your information",
           "paragraph_one": "We store your personal information for no longer than is reasonably necessary and legally justifiable.",
-          "paragraph_two": "We will keep your GOV.UK One Login for as long as you wish to use it although we will delete it if you do not use it for 2 years. ",
+          "paragraph_two": "We will keep your GOV.UK One Login for as long as you wish to use it although we will delete it if you do not use it for 3 years. ",
           "paragraph_three": "If you choose to delete your GOV.UK One Login, we’ll delete your account and your proven identity information.",
           "paragraph_four": "We delete your still photo generated from your selfie video, driving licence images and biometric facial data from Iproov’s systems after 30 days.",
           "paragraph_five": "The in-person identity check stores your data for 11 days to give you enough time to go to the Post Office to complete your identity check.",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1439,7 +1439,7 @@
           "header": "Changes to this notice",
           "paragraph_one": "We may change this privacy notice. In that case, the ‘last updated’ date of this document will also change. Any changes to this privacy notice will apply to you and your information immediately.",
           "paragraph_two": "If these changes affect how your personal information is processed, GDS will let you know.",
-          "paragraph_three": "Last updated: 31 August 2023"
+          "paragraph_three": "Last updated: 13 September 2023"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1062,7 +1062,8 @@
             }
           },
           "paragraph_seventeen": "When you have completed the checks above using the App, you will be returned to the GOV.UK One Login website where we will collect your name, date of birth and address. We send these to Experian so they can conduct a counter fraud check.",
-          "paragraph_eighteen": "When Experian has completed the check, they send us a fraud score, plus details of any associated fraudulent activity."
+          "paragraph_eighteen": "When Experian has completed the check, they send us a fraud score, plus details of any associated fraudulent activity.",
+          "paragraph_nineteen": "This fraud check will not affect your credit score, as it is a ‘soft search’. An entry about it will be added to your credit record, but it will only be visible to you. Other organisations that use Experian to run their own credit checks will not be able to see it."
         },
         "using_web_to_prove_identity": {
           "header": "Using your web browser to prove your identity",
@@ -1082,7 +1083,7 @@
           "paragraph_six": "For this check we use your name, date of birth and address to retrieve relevant questions from Experian. We collect your answers and send them to Experian to check that they match the information they already have about you.",
           "paragraph_seven": "When Experian has completed the check they respond to us with a Pass / Fail outcome.",
           "paragraph_eight": "GDS does not store or retain the questions or your answers.",
-          "paragraph_nine": "This check constitutes a ‘soft search’ which means that a record of the check will exist on your credit records as ‘GOV.UK One Login’. It will only be visible to you and not to any other organisations that use Experian to conduct their own credit checks. Consequently, it will not have an impact on your credit score.",
+          "paragraph_nine": "This fraud check will not affect your credit score, as it is a ‘soft search’. An entry about it will be added to your credit record, but it will only be visible to you. Other organisations that use Experian to run their own credit checks will not be able to see it.",
           "sub_header_three": "Fraud check",
           "paragraph_ten": "We use an identity checking service provider called Experian to conduct a fraud check to:",
           "list": {
@@ -1097,7 +1098,8 @@
             }
           },
           "paragraph_twelve": "When you have completed the checks above, we will collect your name, date of birth and address. We send these to Experian so they can conduct the check.",
-          "paragraph_thirteen": "When Experian has completed the check, they send us a fraud score, plus details of any associated fraudulent activity."
+          "paragraph_thirteen": "When Experian has completed the check, they send us a fraud score, plus details of any associated fraudulent activity.",
+          "paragraph_fourteen": "This fraud check will not affect your credit score, as it is a ‘soft search’. An entry about it will be added to your credit record, but it will only be visible to you. Other organisations that use Experian to run their own credit checks will not be able to see it."
         },
         "proving_identity_at_post_office": {
           "header": "Proving your identity at a Post Office",
@@ -1117,6 +1119,7 @@
           },
           "paragraph_four": "We collect your name, date of birth and address and send them to Experian so they can conduct the check.",
           "paragraph_five": "When Experian has completed the check, they send us a fraud score, plus details of any associated fraudulent activity.",
+          "paragraph_five_one": "This fraud check will not affect your credit score, as it is a ‘soft search’. An entry about it will be added to your credit record, but it will only be visible to you. Other organisations that use Experian to run their own credit checks will not be able to see it.",
           "sub_header_two": "Genuine document check and likeness check",
           "paragraph_six": "We need to check that:",
           "list_two": {


### PR DESCRIPTION
## What?

Content changes for privacy notice version 1.9

- GOV.UK One Login to be deleted after three years rather than two.
- Addition of statment on fraud check 'soft search' added in four places.

Target deployment date: Wed 13 Sep 2023

## Why?

Account retention period changes to be published in line with planned timelines for bulk email campaign notifying users of the changes.

To publish required privacy notice changes.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [X] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Related PRs

Deploy before:

https://github.com/alphagov/di-authentication-api/pull/3328
