### PR TITLE
AUT-1635: Add variables to support SmartAgent

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -5,6 +5,7 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
+support_smart_agent                                 = "1"
 support_international_numbers                       = "1"
 support_language_cy                                 = "1"
 support_account_recovery                            = "1"

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -113,6 +113,22 @@ locals {
         value = var.zendesk_username
       },
       {
+        name  = "SUPPORT_SMART_AGENT"
+        value = var.support_smart_agent
+      },
+      {
+        name  = "SMARTAGENT_API_KEY"
+        value = var.smartagent_api_key
+      },
+      {
+        name  = "SMARTAGENT_API_URL"
+        value = var.smartagent_api_url
+      },
+      {
+        name  = "SMARTAGENT_WEBFORM_ID"
+        value = var.smartagent_webform_id
+      },
+      {
         name  = "SERVICE_DOMAIN"
         value = local.service_domain
       },

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -8,6 +8,7 @@ frontend_task_definition_memory = 1024
 support_international_numbers = "1"
 support_language_cy           = "1"
 support_account_recovery      = "1"
+support_smart_agent           = "0"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -10,6 +10,8 @@ frontend_auto_scaling_max_count = 12
 ecs_desired_count               = 4
 support_international_numbers   = "1"
 support_account_recovery        = "1"
+support_smart_agent             = "0"
+
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -11,6 +11,7 @@ ecs_desired_count               = 4
 support_language_cy             = "1"
 support_international_numbers   = "1"
 support_account_recovery        = "1"
+support_smart_agent             = "0"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -38,6 +38,11 @@ variable "support_auth_orch_split" {
   default = "0"
 }
 
+variable "support_smart_agent" {
+  type    = string
+  default = "0"
+}
+
 variable "image_uri" {
   type = string
 }
@@ -122,6 +127,18 @@ variable "logging_endpoint_arns" {
   type        = list(string)
   default     = []
   description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
+}
+
+variable "smartagent_webform_id" {
+  type = string
+}
+
+variable "smartagent_api_key" {
+  type = string
+}
+
+variable "smartagent_api_url" {
+  type = string
 }
 
 variable "zendesk_username" {


### PR DESCRIPTION
## What?

Introduces the variables to support SmartAgent. Values will be picked up from Secrets Manager.

## Why?

To enable SmartAgent support in lower environments.

## Related PRs

Code to introduce SmartAgent support was introduced in https://github.com/alphagov/di-authentication-frontend/pull/1140
