### PR TITLE
AUT-1688: Add 2 fields to auth code lambda call

### DIFF
--- a/src/components/auth-code/auth-code-controller.ts
+++ b/src/components/auth-code/auth-code-controller.ts
@@ -21,7 +21,8 @@ export function authCodeGet(
       clientSessionId,
       req.ip,
       persistentSessionId,
-      req.session.client
+      req.session.client,
+      req.session.user
     );
 
     if (!result.success) {

--- a/src/components/auth-code/auth-code-service.ts
+++ b/src/components/auth-code/auth-code-service.ts
@@ -1,4 +1,4 @@
-import { ApiResponseResult, UserSessionClient } from "../../types";
+import { ApiResponseResult, UserSession, UserSessionClient } from "../../types";
 import { API_ENDPOINTS } from "../../app.constants";
 import {
   createApiResponse,
@@ -20,7 +20,8 @@ export function authCodeService(axios: Http = http): AuthCodeServiceInterface {
     clientSessionId: string,
     sourceIp: string,
     persistentSessionId: string,
-    clientSession: UserSessionClient
+    clientSession: UserSessionClient,
+    userSession: UserSession
   ): Promise<ApiResponseResult<AuthCodeResponse>> {
     const baseUrl = supportAuthOrchSplit()
       ? getFrontendApiBaseUrl()
@@ -40,6 +41,8 @@ export function authCodeService(axios: Http = http): AuthCodeServiceInterface {
         claim: clientSession.claim,
         state: clientSession.state,
         "redirect-uri": clientSession.redirectUri,
+        "rp-sector-uri": clientSession.rpSectorHost,
+        "is-new-account": userSession?.isAccountCreationJourney ?? false,
       };
       response = await axios.client.post(
         API_ENDPOINTS.ORCH_AUTH_CODE,

--- a/src/components/auth-code/tests/auth-code-service.test.ts
+++ b/src/components/auth-code/tests/auth-code-service.test.ts
@@ -10,6 +10,8 @@ import { Http } from "../../../utils/http";
 
 describe("authentication auth code service", () => {
   const redirectUriSentToAuth = "/redirect-uri";
+  const rpSectorHostSentToAuth = "https://rp.redirect.uri";
+  const isAccountCreationJourneyUserSession = true;
   const redirectUriReturnedFromResponse =
     "/redirect-here?with-some-params=added-by-the-endpoint";
   const apiBaseUrl = "/base-url";
@@ -55,6 +57,11 @@ describe("authentication auth code service", () => {
         claim: claim,
         state: state,
         redirectUri: redirectUriSentToAuth,
+        rpSectorHost: rpSectorHostSentToAuth,
+      };
+
+      const userSessionClient = {
+        isAccountCreationJourney: isAccountCreationJourneyUserSession,
       };
 
       const result = await service.getAuthCode(
@@ -62,13 +69,16 @@ describe("authentication auth code service", () => {
         "clientSessionId",
         "sourceIp",
         "persistentSessionId",
-        sessionClient
+        sessionClient,
+        userSessionClient
       );
 
       const expectedBody = {
         claim: claim,
         state: state,
         "redirect-uri": redirectUriSentToAuth,
+        "rp-sector-uri": rpSectorHostSentToAuth,
+        "is-new-account": isAccountCreationJourneyUserSession,
       };
 
       expect(
@@ -96,6 +106,7 @@ describe("authentication auth code service", () => {
         "clientSessionId",
         "sourceIp",
         "persistentSessionId",
+        {},
         {}
       );
 

--- a/src/components/auth-code/types.ts
+++ b/src/components/auth-code/types.ts
@@ -1,6 +1,7 @@
 import {
   ApiResponseResult,
   DefaultApiResponse,
+  UserSession,
   UserSessionClient,
 } from "../../types";
 
@@ -14,6 +15,7 @@ export interface AuthCodeServiceInterface {
     clientSessionId: string,
     sourceIp: string,
     persistentSessionId: string,
-    clientSession: UserSessionClient
+    clientSession: UserSessionClient,
+    userSession: UserSession
   ) => Promise<ApiResponseResult<AuthCodeResponse>>;
 }

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -101,6 +101,7 @@ export function authorizeGet(
     req.session.client.redirectUri = claims.redirect_uri;
     req.session.client.state = claims.state;
     req.session.client.isOneLoginService = claims.is_one_login_service;
+    req.session.client.rpSectorHost = claims.rp_sector_host;
 
     req.session.client.consentEnabled =
       startAuthResponse.data.user.consentRequired;

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -26,6 +26,7 @@ export type Claims = {
   state: string;
   client_id: string;
   redirect_uri: string;
+  rp_sector_host: string;
   claim?: string;
 };
 
@@ -46,4 +47,5 @@ export const requiredClaimsKeys = [
   "state",
   "client_id",
   "redirect_uri",
+  "rp_sector_host",
 ];

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -19,6 +19,7 @@ export function createmockclaims(): any {
     iat: timestamp,
     client_name: "di-auth-stub-relying-party-sandpit",
     is_one_login_service: false,
+    rp_sector_host: "https://rp.sector.uri",
     jti: "fvvMWAladDtl35O_xyBTRLwwojA",
     claim:
       '{"userinfo": {"email_verified": null, "public_subject_id": null, "email": null}}',

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,4 +89,5 @@ export interface UserSessionClient {
   state?: string;
   isOneLoginService?: boolean;
   claim?: string[];
+  rpSectorHost?: string;
 }


### PR DESCRIPTION
## What?
- Add `is-new-account` and `rp-sector-uri` to auth code lambda call (new lambda that will only be used once auth-orch split is enabled)

## Why?
- These fields relate only to post-orch auth split
- This is because the lamdba that receives these fields is not currently used
- It will only get used once the auth-orch split flag is turned on
- The fields are needed ultimately so that the auth userinfo lambda can populate all of the required information

## Related PRs
- There is a backend change to consume these fields here: https://github.com/alphagov/di-authentication-api/pull/3348
