### PR TITLE
AUT-1653: Add additional tags requested

### DIFF
--- a/src/components/contact-us/contact-us-service-smart-agent.ts
+++ b/src/components/contact-us/contact-us-service-smart-agent.ts
@@ -8,7 +8,9 @@ import {
   OptionalData,
   Questions,
   SmartAgentCustomAttributes,
+  Themes,
 } from "./types";
+import { ZENDESK_THEMES } from "../../app.constants";
 
 export function prepareSecurityCodeSendMethodTitle(
   securityCodeSentMethod: string
@@ -51,6 +53,30 @@ export function prepareIdentityDocumentTitle(
   }
 
   return documentUsedDescription;
+}
+
+export function getIdentifierTag(theme: string): string {
+  if (theme === ZENDESK_THEMES.ID_CHECK_APP) {
+    return "sign_in_app";
+  }
+  if (theme === ZENDESK_THEMES.PROVING_IDENTITY_FACE_TO_FACE) {
+    return "id_face_to_face";
+  }
+  return "govuk_sign_in";
+}
+
+export function getThemeTag(themes: Themes): string {
+  if (themes.theme !== ZENDESK_THEMES.PROVING_IDENTITY_FACE_TO_FACE) {
+    return `auth_${themes.theme}`;
+  }
+  return "";
+}
+
+export function getSubthemeTag(themes: Themes): string {
+  if (themes.subtheme) {
+    return `auth_${themes.subtheme}`;
+  }
+  return "";
 }
 
 export function contactUsServiceSmartAgent(
@@ -156,6 +182,14 @@ export function contactUsServiceSmartAgent(
     customAttributes["sa-tag-permission-to-email"] = `Permission to email ${
       contactForm.feedbackContact ? "granted" : "denied"
     }`;
+
+    customAttributes["sa-tag-identifier"] = getIdentifierTag(
+      contactForm.themes.theme
+    );
+
+    customAttributes["sa-tag-theme"] = getThemeTag(contactForm.themes);
+
+    customAttributes["sa-tag-subtheme"] = getSubthemeTag(contactForm.themes);
 
     return customAttributes;
   }

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -72,6 +72,9 @@ export interface SmartAgentCustomAttributes {
   "sa-tag-what-gov-service"?: string;
   "sa-tag-permission-to-email"?: string;
   "sa-tag-preferred-language"?: string;
+  "sa-tag-identifier"?: string;
+  "sa-tag-theme"?: string;
+  "sa-tag-subtheme"?: string;
 }
 
 export interface SmartAgentTicket {


### PR DESCRIPTION
## What?

Adds `sa-tag-identifier`, `sa-tag-theme` and `sa-tag-subtheme` to SmartAgent payload.

## Why?

Contact Centre team have requested this additional information to be sent through to the SmartAgent API via a [comment on the Jira ticket](https://govukverify.atlassian.net/browse/AUT-1653?focusedCommentId=89945).

## Related PRs

This PR: 

* Adds to SmartAgent payload introduced in https://github.com/alphagov/di-authentication-frontend/pull/1140
* Will require https://github.com/alphagov/di-authentication-frontend/pull/1144 to be merged for testing in a deployed environment
