### PR TITLE
AUT-1678: Add signing public key to build tfvars

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -18,3 +18,5 @@ code_entered_wrong_blocked_minutes                  = "0.5"
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
+
+orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPr\nCBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA==\n-----END PUBLIC KEY-----"


### PR DESCRIPTION
## What?
- Add signing public key to build tfvars

## Why?
- This is the public counterpart to the private signing key used to sign the JWT sent from OIDC API to Auth frontend
- The JWT is encrypted and signed as part of the `/authorize` endpoint

## Related PRs
- Extends work to get the auth orch split journey working in build:
    - https://github.com/alphagov/di-authentication-frontend/pull/1148
 
