### PR TITLE
AUT-1678: Parameterize aud and client_id in config

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -20,3 +20,5 @@ logging_endpoint_arns = [
 ]
 
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPr\nCBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA==\n-----END PUBLIC KEY-----"
+orch_to_auth_client_id          = "orchestrationAuth"
+orch_to_auth_audience           = "https://signin.build.account.gov.uk/"

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -101,6 +101,14 @@ locals {
         value = var.orch_to_auth_signing_public_key
       },
       {
+        name  = "ORCH_TO_AUTH_CLIENT_ID"
+        value = var.orch_to_auth_client_id
+      },
+      {
+        name  = "ORCH_TO_AUTH_AUDIENCE"
+        value = var.orch_to_auth_audience
+      },
+      {
         name  = "ZENDESK_API_TOKEN"
         value = var.zendesk_api_token
       },

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -225,3 +225,15 @@ variable "orch_to_auth_signing_public_key" {
   type        = string
   default     = ""
 }
+
+variable "orch_to_auth_client_id" {
+  description = "Client ID that is used by OIDC API when making authorize redirect to Auth Frontend"
+  type        = string
+  default     = ""
+}
+
+variable "orch_to_auth_audience" {
+  description = "Aud value included in JWT by OIDC API when making authorize redirect to Auth Frontend"
+  type        = string
+  default     = ""
+}

--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -23,8 +23,8 @@ import {
 } from "./types";
 import { KmsDecryptionService } from "./kms-decryption-service";
 import { JwtService } from "./jwt-service";
-import { EXPECTED_CLIENT_ID } from "./claims-config";
 import { appendQueryParamIfHasValue } from "../../utils/url";
+import { getOrchToAuthExpectedClientId } from "../../config";
 
 function createConsentCookie(
   res: Response,
@@ -181,7 +181,7 @@ function validateQueryParams(clientId: string, responseType: string) {
     throw new QueryParamsError("Response type is not set");
   }
 
-  if (clientId !== EXPECTED_CLIENT_ID) {
+  if (clientId !== getOrchToAuthExpectedClientId()) {
     throw new QueryParamsError("Client ID value is incorrect");
   }
 }

--- a/src/components/authorize/claims-config.ts
+++ b/src/components/authorize/claims-config.ts
@@ -1,11 +1,14 @@
-export const EXPECTED_CLIENT_ID = "orchestrationAuth";
+import {
+  getOrchToAuthExpectedAudience,
+  getOrchToAuthExpectedClientId,
+} from "../../config";
 
 export function getKnownClaims(): {
   [key: string]: string | boolean | number;
 } {
   return {
-    client_id: "orchestrationAuth",
-    aud: "UNKNOWN",
+    client_id: getOrchToAuthExpectedClientId(),
+    aud: getOrchToAuthExpectedAudience(),
   };
 }
 

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -25,6 +25,7 @@ import {
 import { BadRequestError } from "../../../utils/error";
 import { createmockclaims } from "./test-data";
 import { Claims } from "../claims-config";
+import { getOrchToAuthExpectedClientId } from "../../../config";
 
 describe("authorize controller", () => {
   let req: RequestOutput;
@@ -45,7 +46,7 @@ describe("authorize controller", () => {
       t: sinon.fake(),
       i18n: { language: "en" },
       query: {
-        client_id: "orchestrationAuth",
+        client_id: getOrchToAuthExpectedClientId(),
         response_type: "code",
       },
     });

--- a/src/components/authorize/tests/authorize-integration.test.ts
+++ b/src/components/authorize/tests/authorize-integration.test.ts
@@ -19,6 +19,7 @@ import {
   getPublicKey,
 } from "./test-data";
 import { JwtService } from "../jwt-service";
+import { getOrchToAuthExpectedClientId } from "../../../config";
 
 describe("Integration:: authorize", () => {
   let app: any;
@@ -96,7 +97,7 @@ describe("Integration:: authorize", () => {
     request(app)
       .get(PATH_NAMES.AUTHORIZE)
       .query({
-        client_id: "orchestrationAuth",
+        client_id: getOrchToAuthExpectedClientId(),
         response_type: "code",
         request: "SomeJWE",
       })
@@ -108,7 +109,7 @@ describe("Integration:: authorize", () => {
     request(app)
       .get(PATH_NAMES.AUTHORIZE)
       .query({
-        client_id: "orchestrationAuth",
+        client_id: getOrchToAuthExpectedClientId(),
         response_type: "code",
         request: "SomeJWE",
         result: "test-result",

--- a/src/components/authorize/tests/test-data.ts
+++ b/src/components/authorize/tests/test-data.ts
@@ -1,4 +1,8 @@
 import * as jose from "jose";
+import {
+  getOrchToAuthExpectedAudience,
+  getOrchToAuthExpectedClientId,
+} from "../../../config";
 
 export function createmockclaims(): any {
   const timestamp = Math.floor(new Date().getTime() / 1000);
@@ -6,9 +10,9 @@ export function createmockclaims(): any {
     confidence: "Cl.Cm",
     iss: "UNKNOWN",
     consent_required: false,
-    client_id: "orchestrationAuth",
+    client_id: getOrchToAuthExpectedClientId(),
     govuk_signin_journey_id: "QOFzoB3o-9gGplMgdT1dJfH4vaI",
-    aud: "UNKNOWN",
+    aud: getOrchToAuthExpectedAudience(),
     service_type: "MANDATORY",
     nbf: timestamp,
     cookie_consent_shared: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,6 +105,14 @@ export function getOrchToAuthSigningPublicKey(): string {
   return process.env.ORCH_TO_AUTH_SIGNING_KEY;
 }
 
+export function getOrchToAuthExpectedClientId(): string {
+  return process.env.ORCH_TO_AUTH_CLIENT_ID || "UNKNOWN";
+}
+
+export function getOrchToAuthExpectedAudience(): string {
+  return process.env.ORCH_TO_AUTH_AUDIENCE || "UNKNOWN";
+}
+
 export function getAccountManagementUrl(): string {
   return process.env.ACCOUNT_MANAGEMENT_URL || "http://localhost:6001";
 }


### PR DESCRIPTION
## What?
- Parameterize aud and client_id in config
- Applies to /authorize route
- Used as part of redirect from /authorize endpoint in OIDC API


## Why?
- These values must match those set in the OIDC API config
- They are part of the validation rules which ensure the JWT received is 'legitimate'

## Related PRs
- Extends work to get the auth orch split journey working in build:
    - https://github.com/alphagov/di-authentication-frontend/pull/1148
    - https://github.com/alphagov/di-authentication-frontend/pull/1149