### PR TITLE
BAU: Reenable full URL logging

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -10,7 +10,7 @@ const logger = pino({
       return {
         id: req.id,
         method: req.method,
-        url: req.path,
+        url: req.url,
         from: getRefererFrom(req.headers.referer),
       };
     },


### PR DESCRIPTION
## What?
- Re-enable logging of full URLs (not only paths)

## Why?
- Discussion of relative merits can be found in INCIDEN-96
- This has been requested by security colleagues: https://govukverify.atlassian.net/browse/INCIDEN-96?focusedCommentId=90986

## Related PRs
- Reverses: https://github.com/alphagov/di-authentication-frontend/pull/1120
