### PR TITLE
AUT-1720: don't try to export invalid tfvars

### DIFF
--- a/ci/terraform/read_secrets.sh
+++ b/ci/terraform/read_secrets.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
 ENVIRONMENT="${1}"
 
 if [ "$ENVIRONMENT" = "dev" ]; then
@@ -13,12 +18,16 @@ secrets="$(
     jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
 )"
 
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
+
 while IFS=$'\t' read -r arn name; do
+  if [[ ! ${name} =~ ^[a-zA-Z0-9_]+$ ]]; then
+    printf '!! Invalid secret name: %s. Secret name must match /^[a-zA-Z0-9_]+/. Exiting' "${name}" >&2
+    exit 1
+  fi
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
 done <<<"${secrets}"
-
-if [ "$TF_VAR_basic_auth_password" = "none" ]; then
-  export TF_VAR_basic_auth_username=""
-  export TF_VAR_basic_auth_password=""
-fi


### PR DESCRIPTION
## What?

Error and exit if an attempt would be made to export an envar with an invalid name.

## Why?

We shouldn't try to export a variable with an invalid character in the name (eg. `-`), as we know before trying that it will fail.

The secrets namespace we are parsing is exclusively for the consumption of this script, so invalid secrets are cause to fail to deploy.
