### PR TITLE
AUT-1650: Support triage page

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -82,6 +82,7 @@ import { errorPageRouter } from "./components/common/errors/error-routes";
 import { setInternationalPhoneNumberSupportMiddleware } from "./middleware/set-international-phone-number-support-middleware";
 import { checkYourEmailSecurityCodesRouter } from "./components/account-recovery/check-your-email-security-codes/check-your-email-security-codes-routes";
 import { changeSecurityCodesConfirmationRouter } from "./components/account-recovery/change-security-codes-confirmation/change-security-codes-confirmation-routes";
+import { outboundContactUsLinksMiddleware } from "./middleware/outbound-contact-us-links-middleware";
 
 const APP_VIEWS = [
   path.join(__dirname, "components"),
@@ -195,6 +196,7 @@ async function createApp(): Promise<express.Application> {
   app.use(initialiseSessionMiddleware);
   app.use(crossDomainTrackingMiddleware);
   app.use(setInternationalPhoneNumberSupportMiddleware);
+  app.use(outboundContactUsLinksMiddleware);
 
   registerRoutes(app);
 

--- a/src/components/common/footer/footer-pages-controller.ts
+++ b/src/components/common/footer/footer-pages-controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { PATH_NAMES } from "../../../app.constants";
+import { PATH_NAMES, SUPPORT_TYPE } from "../../../app.constants";
 
 export function privacyStatementGet(req: Request, res: Response): void {
   res.render("common/footer/privacy-statement.njk");
@@ -18,9 +18,17 @@ export function supportGet(req: Request, res: Response): void {
 }
 
 export function supportPost(req: Request, res: Response): void {
-  res.redirect(
-    appendQueryParam("supportType", req.body.supportType, PATH_NAMES.CONTACT_US)
-  );
+  if (req.body.supportType === SUPPORT_TYPE.GOV_SERVICE) {
+    res.redirect(
+      appendQueryParam(
+        "supportType",
+        req.body.supportType,
+        PATH_NAMES.CONTACT_US
+      )
+    );
+  } else {
+    res.redirect(res.locals.contactUsLinkUrl);
+  }
 }
 
 function appendQueryParam(param: string, value: string, url: string) {

--- a/src/components/common/footer/privacy-statement.njk
+++ b/src/components/common/footer/privacy-statement.njk
@@ -734,7 +734,7 @@
             <a class="govuk-link" href="{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.link_href' | translate }}">{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_one.link_text' | translate }}</a>
         </li>
         <li>
-            <a class="govuk-link" href="{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_two.link_href' | translate }}">{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_two.link_text' | translate }}</a>
+            <a class="govuk-link" href="{{ contactUsLinkUrl }}">{{ 'pages.privacy.sections.how_we_protect_your_information.list_one.item_two.link_text' | translate }}</a>
         </li>
     </ul>
 

--- a/src/components/common/footer/terms-conditions.njk
+++ b/src/components/common/footer/terms-conditions.njk
@@ -161,7 +161,7 @@
     {{'pages.termsAndConditions.section11.header' | translate}}
   </h2>
   <p class="govuk-body">
-    <a href="/contact-us" class="govuk-link">{{'pages.termsAndConditions.section11.paragraph1.linkText' | translate}}</a>{{'pages.termsAndConditions.section11.paragraph1.text1' | translate}}
+    <a href="/support" class="govuk-link">{{'pages.termsAndConditions.section11.paragraph1.linkText' | translate}}</a>{{'pages.termsAndConditions.section11.paragraph1.text1' | translate}}
   </p>
   <ul class="govuk-list govuk-list--bullet">
     <li>{{'pages.termsAndConditions.section11.bulletPoint1' | translate}}</li>

--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -46,13 +46,17 @@
 }) }}
 {% endblock %}
 
+{% set phaseBannerText %}
+    {{ 'general.phaseBanner.message.start' | translate }} <a href="{{ contactUsLinkUrl }}" class="govuk-link" rel="noopener" target="_blank">{{ 'general.phaseBanner.message.linkText' | translate }}</a> {{ 'general.phaseBanner.message.end' | translate }}
+{% endset %}
+
 {% block main %}
       <div class="govuk-width-container {{ containerClasses }}">
         {{ govukPhaseBanner({
           tag: {
             text: 'general.phaseBanner.tag' | translate
           },
-          html: 'general.phaseBanner.content' | translate
+          html: phaseBannerText
         }) }}
 	      {% block beforeContent %}{% endblock %}
 	      {% if showBack %}
@@ -92,7 +96,7 @@
               text: 'general.footer.privacy.linkText' | translate
           },
           {
-                href: "/contact-us?supportType=PUBLIC",
+              href: contactUsLinkUrl,
               attributes: {target: "_blank"},
               text: 'general.footer.support.linkText' | translate
           }

--- a/src/components/contact-us/common-english-only/layout/base.njk
+++ b/src/components/contact-us/common-english-only/layout/base.njk
@@ -46,13 +46,17 @@
 }) }}
 {% endblock %}
 
+{% set phaseBannerText %}
+    {{ 'general.phaseBanner.message.start' | translateEnOnly }} <a href="{{ contactUsLinkUrl }}" class="govuk-link" rel="noopener" target="_blank">{{ 'general.phaseBanner.message.linkText' | translateEnOnly }}</a> {{ 'general.phaseBanner.message.end' | translateEnOnly }}
+{% endset %}
+
 {% block main %}
       <div class="govuk-width-container {{ containerClasses }}">
         {{ govukPhaseBanner({
           tag: {
             text: 'general.phaseBanner.tag' | translateEnOnly
           },
-          html: 'general.phaseBanner.content' | translateEnOnly
+          html: phaseBannerText | translateEnOnly
         }) }}
 	      {% block beforeContent %}{% endblock %}
 	      {% if showBack %}
@@ -92,7 +96,7 @@
               text: 'general.footer.privacy.linkText' | translateEnOnly
           },
           {
-                href: "/contact-us?supportType=PUBLIC",
+              href: contactUsLinkUrl,
               attributes: {target: "_blank"},
               text: 'general.footer.support.linkText' | translateEnOnly
           }

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,10 @@ export function supportSmartAgent(): boolean {
   return process.env.SUPPORT_SMART_AGENT === "1";
 }
 
+export function getSupportLinkUrl(): string {
+  return process.env.URL_FOR_SUPPORT_LINKS || "/contact-us";
+}
+
 export async function getRedisConfig(appEnv: string): Promise<RedisConfig> {
   const hostKey = `${appEnv}-${process.env.REDIS_KEY}-redis-master-host`;
   const portKey = `${appEnv}-${process.env.REDIS_KEY}-redis-port`;

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -10,7 +10,11 @@
     "sendMessage": "Anfon neges",
     "phaseBanner": {
       "tag": "beta",
-      "content": "Mae hwn yn wasanaeth newydd – bydd eich <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i’w wella."
+      "message": {
+        "start": "Mae hwn yn wasanaeth newydd – bydd eich ",
+        "linkText": "adborth (agor mewn tab newydd)",
+        "end": " yn ein helpu i’w wella."
+      }
     },
     "authenticatorAppIssuer": "GOV.UK One Login",
     "yes": "Gallwch",
@@ -44,7 +48,7 @@
       "label": "Parhau"
     },
     "contactAccounts": {
-      "contactLinkHref": "https://signin.account.gov.uk/contact-us",
+      "contactLinkHref": "https://signin.account.gov.uk/support",
       "contactLinkText": "Cysylltu â thîm GOV.UK One Login (agor mewn tab newydd)"
     },
     "header": {
@@ -1358,8 +1362,7 @@
               "link_href": "https://www.ncsc.gov.uk/cyberaware/home"
             },
             "item_two": {
-              "link_text": "cysylltwch â ni ar unwaith os ydych yn amau bod eich cyfrif wedi cael ei gyfaddawdu",
-              "link_href": "https://signin.account.gov.uk/support"
+              "link_text": "cysylltwch â ni ar unwaith os ydych yn amau bod eich cyfrif wedi cael ei gyfaddawdu"
             }
           }
         },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -10,7 +10,11 @@
     "sendMessage": "Send message",
     "phaseBanner": {
       "tag": "beta",
-      "content": "This is a new service – your <a  href=\"/contact-us?supportType=PUBLIC\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">feedback (opens in new tab)</a> will help us to improve it."
+      "message": {
+        "start": "This is a new service – your ",
+        "linkText": "feedback (opens in new tab)",
+        "end": " will help us to improve it."
+      }
     },
     "authenticatorAppIssuer": "GOV.UK One Login",
     "yes": "Yes",
@@ -44,7 +48,7 @@
       "label": "Continue"
     },
     "contactAccounts": {
-      "contactLinkHref": "https://signin.account.gov.uk/contact-us",
+      "contactLinkHref": "https://signin.account.gov.uk/support",
       "contactLinkText": "Contact the GOV.UK One Login team (opens in a new tab)"
     },
     "header": {
@@ -1358,8 +1362,7 @@
               "link_href": "https://www.ncsc.gov.uk/cyberaware/home"
             },
             "item_two": {
-              "link_text": "contact us immediately if you suspect that your account has been compromised",
-              "link_href": "https://signin.account.gov.uk/support"
+              "link_text": "contact us immediately if you suspect that your account has been compromised"
             }
           }
         },

--- a/src/middleware/outbound-contact-us-links-middleware.ts
+++ b/src/middleware/outbound-contact-us-links-middleware.ts
@@ -1,0 +1,35 @@
+import { NextFunction, Request, Response } from "express";
+import { getSupportLinkUrl } from "../config";
+
+export function buildUrlFromRequest(req: Request): string {
+  return `${req.protocol}://${req.get("host")}${req.originalUrl}`;
+}
+
+export function appendFromUrlWhenTriagePageUrl(
+  contactUsLinkUrl: string,
+  fromUrl: string
+): string {
+  const triagePageUrlRegEx = /contact-gov-uk-one-login/;
+
+  if (triagePageUrlRegEx.test(contactUsLinkUrl)) {
+    const encodedFromUrl = encodeURIComponent(fromUrl);
+
+    contactUsLinkUrl = `${contactUsLinkUrl}?fromURL=${encodedFromUrl}`;
+  }
+
+  return contactUsLinkUrl;
+}
+
+export function outboundContactUsLinksMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  let contactUsLinkUrl = getSupportLinkUrl();
+  const fromUrl = buildUrlFromRequest(req);
+
+  contactUsLinkUrl = appendFromUrlWhenTriagePageUrl(contactUsLinkUrl, fromUrl);
+
+  res.locals.contactUsLinkUrl = contactUsLinkUrl;
+  next();
+}

--- a/src/middleware/tests/outbound-contact-us-links-middleware.test.ts
+++ b/src/middleware/tests/outbound-contact-us-links-middleware.test.ts
@@ -1,0 +1,107 @@
+import chai, { expect } from "chai";
+import { Request, Response } from "express";
+import sinon from "sinon";
+import sinonChai from "sinon-chai";
+import {
+  appendFromUrlWhenTriagePageUrl,
+  buildUrlFromRequest,
+  outboundContactUsLinksMiddleware,
+} from "../outbound-contact-us-links-middleware";
+
+chai.use(sinonChai);
+
+describe("Middleware", () => {
+  describe("outboundContactUsLinksMiddleware", () => {
+    let req: Request;
+    let res: Response;
+    let next: sinon.SinonSpy;
+
+    beforeEach(() => {
+      req = {
+        cookies: {},
+        headers: {},
+        session: {
+          id: "session-id",
+          destroy: sinon.stub().callsArg(0),
+        },
+        log: {
+          error: sinon.stub(),
+          info: sinon.stub(),
+        },
+        get: function (headerName: string) {
+          if (headerName === "Referrer") {
+            return this.headers["referer"] || this.headers["referrer"];
+          }
+        },
+      } as any;
+      res = {
+        locals: {},
+        status: sinon.stub().returns({
+          json: sinon.stub(),
+        }),
+      } as any;
+      next = sinon.spy();
+    });
+
+    it("should call next", () => {
+      outboundContactUsLinksMiddleware(req, res, next);
+      expect(req.session.destroy).to.not.have.been.called;
+      expect(res.status).to.not.have.been.called;
+      expect(next).to.have.been.calledOnce;
+    });
+
+    it("should set `res.locals.contactUsLinkUrl`", () => {
+      expect(res.locals).to.not.have.property("contactUsLinkUrl");
+      outboundContactUsLinksMiddleware(req, res, next);
+      expect(res.locals).to.have.property("contactUsLinkUrl");
+    });
+  });
+
+  describe("buildFromUrl", () => {
+    let req: Request;
+
+    beforeEach(() => {
+      req = {
+        protocol: "https",
+        headers: {
+          host: "home.account.gov.uk",
+        },
+        originalUrl: "/contact-gov-uk-one-login",
+        get: function (headerName: string) {
+          return this.headers[headerName];
+        },
+      } as any;
+    });
+
+    it("should build the fromUrl as expected", () => {
+      const builtUrl = buildUrlFromRequest(req),
+        expectedUrl = "https://home.account.gov.uk/contact-gov-uk-one-login";
+
+      expect(builtUrl).to.equal(expectedUrl);
+      buildUrlFromRequest(req);
+    });
+  });
+
+  describe("appendFromUrlWhenTriagePageUrl", () => {
+    it("should append when there's a match", () => {
+      const matchingUrl =
+          "https://home.account.gov.uk/contact-gov-uk-one-login",
+        fromUrl = "https://signin.account.gov.uk/enter-password";
+
+      const result = appendFromUrlWhenTriagePageUrl(matchingUrl, fromUrl);
+
+      expect(result).to.equal(
+        `${matchingUrl}?fromURL=${encodeURIComponent(fromUrl)}`
+      );
+    });
+
+    it("should not append when there isn't a match", () => {
+      const nonMatchingUrl = "https://signin.account.gov.uk/contact-us",
+        fromUrl = "https://signin.account.gov.uk/enter-password";
+
+      const result = appendFromUrlWhenTriagePageUrl(nonMatchingUrl, fromUrl);
+
+      expect(result).to.not.contain(encodeURIComponent(fromUrl));
+    });
+  });
+});


### PR DESCRIPTION
## What?

### Some background

All pages currently provide direct links to the Contact Forms (at `/contact-us`) via a "feedback" link in the phase banner and a "support" link in the footer of all page. There are also _indirect_ routes to the Contact Forms through Privacy notice, Terms & Conditions and Accessibility statement links (to `/support`) which present a form asking users if they are members of the public or working for a government service (when a user selects the public option on this page they are routed to the contact forms).

### What this PR does

1. Allows the URL for contact forms to be set through a new `URL_FOR_SUPPORT_LINKS` environment variable so links can be go to the new Triage Page (and this can be tested in lower environments)
2. Retains `/contact-us` as a default where the environment variable is not provided
3. Adds the current page URL as an encoded `fromURL` query parameter where `URL_FOR_SUPPORT_LINKS` is set to the URL for the Contact Centre triage page (`fromURL` is required by the Triage Page - more detail is available in the Jira ticket)
4. Changes the `supportPost` method in `footer-page-controller.ts` to route public users to the `URL_FOR_SUPPORT_LINKS` URL

## Why?

As part of the Contact Centre project, a new triage page is being built and all support links from Auth are to go there.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change


