### PR TITLE
AUT-1736: Update Contact Form to consume Triage Page variables

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -44,6 +44,7 @@ export const PATH_NAMES = {
   SIGN_IN_RETRY_BLOCKED: "/sign-in-retry-blocked",
   UPLIFT_JOURNEY: "/uplift",
   CONTACT_US: "/contact-us",
+  CONTACT_US_FROM_TRIAGE_PAGE: "/contact-us-from-triage-page",
   CONTACT_US_SUBMIT_SUCCESS: "/contact-us-submit-success",
   CONTACT_US_FURTHER_INFORMATION: "/contact-us-further-information",
   CONTACT_US_QUESTIONS: "/contact-us-questions",

--- a/src/components/contact-us/contact-us-routes.ts
+++ b/src/components/contact-us/contact-us-routes.ts
@@ -10,6 +10,7 @@ import {
   furtherInformationPost,
   contactUsQuestionsFormPostToZendesk,
   contactUsQuestionsFormPostToSmartAgent,
+  contactUsGetFromTriagePage,
 } from "./contact-us-controller";
 import { validateContactUsRequest } from "./contact-us-validation";
 import { validateContactUsQuestionsRequest } from "./contact-us-questions-validation";
@@ -19,6 +20,7 @@ import { supportSmartAgent } from "../../config";
 const router = express.Router();
 
 router.get(PATH_NAMES.CONTACT_US, contactUsGet);
+router.get(PATH_NAMES.CONTACT_US_FROM_TRIAGE_PAGE, contactUsGetFromTriagePage);
 router.post(
   PATH_NAMES.CONTACT_US,
   validateContactUsRequest("contact-us/index-public-contact-us.njk", "theme"),

--- a/src/components/contact-us/contact-us-service-smart-agent.ts
+++ b/src/components/contact-us/contact-us-service-smart-agent.ts
@@ -79,6 +79,16 @@ export function getSubthemeTag(themes: Themes): string {
   return "";
 }
 
+export function getRefererTag(contactForm: ContactForm): string {
+  if (contactForm.fromURL) {
+    return `Referer obtained via Triage page fromURL: ${contactForm.fromURL}`;
+  } else if (contactForm.referer) {
+    return contactForm.referer;
+  } else {
+    return "Referer not provided";
+  }
+}
+
 export function contactUsServiceSmartAgent(
   smartAgentClient: SmartAgentService = defaultSmartAgentClient
 ): {
@@ -137,9 +147,7 @@ export function contactUsServiceSmartAgent(
       contactForm.identityDocumentUsed
     );
 
-    customAttributes["sa-webformrefer"] = contactForm.referer
-      ? contactForm.referer
-      : "Unable to capture referer";
+    customAttributes["sa-webformrefer"] = getRefererTag(contactForm);
 
     customAttributes["sa-tag-preferred-language"] =
       contactForm.preferredLanguage;

--- a/src/components/contact-us/further-information/_account-creation-further-information.njk
+++ b/src/components/contact-us/further-information/_account-creation-further-information.njk
@@ -7,6 +7,7 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 
         {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 

--- a/src/components/contact-us/further-information/_id-check-app-further-information.njk
+++ b/src/components/contact-us/further-information/_id-check-app-further-information.njk
@@ -7,6 +7,7 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
         {% set items = [

--- a/src/components/contact-us/further-information/_proving-identity-post-office-further-information.njk
+++ b/src/components/contact-us/further-information/_proving-identity-post-office-further-information.njk
@@ -7,6 +7,7 @@
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
 
     {% include "contact-us/questions/_id-check-app-hidden-fields.njk" %}
 

--- a/src/components/contact-us/further-information/_signing-in-further-information.njk
+++ b/src/components/contact-us/further-information/_signing-in-further-information.njk
@@ -7,6 +7,7 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -34,6 +34,7 @@
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
     {% if appSessionId %}
         <input type="hidden" name="appSessionId" value="{{appSessionId}}"/>
     {% endif %}

--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="accountCreationProblem"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="accountNotFound"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="anotherProblem"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_authenticator-app-problem.njk
+++ b/src/components/contact-us/questions/_authenticator-app-problem.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="authenticatorApp"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_email-subscriptions-questions.njk
+++ b/src/components/contact-us/questions/_email-subscriptions-questions.njk
@@ -7,6 +7,7 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="emailSubscription"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="forgottenPassword"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
     <input type="hidden" name="formType" value="idCheckApp"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_id-check-app-linking-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-linking-problem.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="idCheckApp"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_id-check-app-something-else.njk
+++ b/src/components/contact-us/questions/_id-check-app-something-else.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
     <input type="hidden" name="formType" value="idCheckAppSomethingElse"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
     <input type="hidden" name="formType" value="idCheckAppPhotoProblem"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_id-check-app-technical-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-technical-problem.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
     <input type="hidden" name="formType" value="idCheckAppTechnicalProblem"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="invalidSecurityCode"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="noPhoneNumberAccess"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="noSecurityCode"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_no-uk-mobile-questions.njk
+++ b/src/components/contact-us/questions/_no-uk-mobile-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="noUKMobile"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-another-problem.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-another-problem.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
     <input type="hidden" name="formType" value="provingIdentityFaceToFaceSomethingElse"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-at-post-office.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-at-post-office.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
     <input type="hidden" name="formType" value="provingIdentityFaceToFace"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-continuing.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-continuing.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
     <input type="hidden" name="formType" value="provingIdentityFaceToFace"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-entering-details.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-entering-details.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
     <input type="hidden" name="formType" value="provingIdentityFaceToFace"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-finding-result.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-finding-result.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
     <input type="hidden" name="formType" value="provingIdentityFaceToFace"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-letter.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-letter.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
     <input type="hidden" name="formType" value="provingIdentityFaceToFace"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-technical-problem.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-technical-problem.njk
@@ -8,6 +8,7 @@
     <input type="hidden" name="theme" value="{{theme}}"/>
     <input type="hidden" name="subtheme" value="{{subtheme}}"/>
     <input type="hidden" name="backurl" value="{{backurl}}"/>
+    <input type="hidden" name="fromURL" value="{{fromURL}}"/>
     <input type="hidden" name="formType" value="provingIdentityFaceToFaceTechnicalProblem"/>
     <input type="hidden" name="referer" value="{{referer}}"/>
     {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_proving-identity-problem-questions.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-questions.njk
@@ -7,6 +7,7 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="provingIdentity"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_signing-in-problem-questions.njk
+++ b/src/components/contact-us/questions/_signing-in-problem-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="signingInProblem"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_suggestion-feedback-questions.njk
+++ b/src/components/contact-us/questions/_suggestion-feedback-questions.njk
@@ -7,6 +7,7 @@
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="suggestionFeedback"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -8,6 +8,7 @@
 <input type="hidden" name="theme" value="{{theme}}"/>
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
+<input type="hidden" name="fromURL" value="{{fromURL}}"/>
 <input type="hidden" name="formType" value="technicalError"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -4,7 +4,7 @@ import { expect, sinon } from "../../../../test/utils/test-utils";
 import nock = require("nock");
 import * as cheerio from "cheerio";
 import decache from "decache";
-import { PATH_NAMES } from "../../../app.constants";
+import { PATH_NAMES, ZENDESK_THEMES } from "../../../app.constants";
 
 describe("Integration:: contact us - public user", () => {
   let token: string | string[];
@@ -343,5 +343,26 @@ describe("Integration:: contact us - public user", () => {
       })
       .expect("Location", PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS)
       .expect(302, done);
+  });
+
+  describe("Links to /contact-us-from-triage-page", () => {
+    it("should redirect to /contact-us", (done) => {
+      request(app)
+        .get("/contact-us-from-triage-page")
+        .query("fromURL=http//localhost/sign-in-or-create")
+        .expect("Location", `${PATH_NAMES.CONTACT_US}?`)
+        .expect(302, done);
+    });
+
+    it("should redirect to /contact-us-further-information", (done) => {
+      request(app)
+        .get("/contact-us-from-triage-page")
+        .query(`theme=${ZENDESK_THEMES.ID_CHECK_APP}`)
+        .expect(
+          "Location",
+          `${PATH_NAMES.CONTACT_US_FURTHER_INFORMATION}?theme=${ZENDESK_THEMES.ID_CHECK_APP}`
+        )
+        .expect(302, done);
+    });
   });
 });

--- a/src/components/contact-us/tests/contact-us-service.test.ts
+++ b/src/components/contact-us/tests/contact-us-service.test.ts
@@ -2,6 +2,8 @@ import { expect } from "chai";
 import { describe } from "mocha";
 import { ZENDESK_THEMES } from "../../../app.constants";
 import { getZendeskIdentifierTag } from "../contact-us-service";
+import { getRefererTag } from "../contact-us-service-smart-agent";
+import { ContactForm } from "../types";
 
 describe("contact-us-service", () => {
   describe("getZendeskIdentifierTag", () => {
@@ -17,5 +19,50 @@ describe("contact-us-service", () => {
         }
       });
     }
+  });
+
+  describe("getRefererTag", () => {
+    const form: ContactForm = {
+      descriptions: undefined,
+      feedbackContact: false,
+      optionalData: undefined,
+      questions: undefined,
+      referer: "",
+      subject: "",
+      themeQuestions: undefined,
+      themes: undefined,
+      fromURL: undefined,
+    };
+
+    it("should return the fromURL when one is truthy", () => {
+      form.fromURL = "https://localhost:3000/enter-email";
+
+      expect(getRefererTag(form)).to.equal(
+        "Referer obtained via Triage page fromURL: https://localhost:3000/enter-email"
+      );
+    });
+
+    it("should return the fromURL when a referer is also truthy", () => {
+      form.referer = "https://localhost:3000/enter-mfa";
+      form.fromURL = "https://localhost:3000/enter-email";
+
+      expect(getRefererTag(form)).to.equal(
+        "Referer obtained via Triage page fromURL: https://localhost:3000/enter-email"
+      );
+    });
+
+    it("should return the referer when no fromURL is provided", () => {
+      form.referer = "https://localhost:3000/enter-mfa";
+      form.fromURL = "";
+
+      expect(getRefererTag(form)).to.equal("https://localhost:3000/enter-mfa");
+    });
+
+    it("should return the 'Referer not provided' when a neither fromURL or referer is truthy", () => {
+      form.referer = "";
+      form.fromURL = "";
+
+      expect(getRefererTag(form)).to.equal("Referer not provided");
+    });
   });
 });

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -12,6 +12,7 @@ export interface ContactForm {
   preferredLanguage?: string;
   securityCodeSentMethod?: string;
   identityDocumentUsed?: string;
+  fromURL?: string;
 }
 
 export interface OptionalData {


### PR DESCRIPTION
## What?

Allows Contact Form application to:

1. handle GET parameters that will be included in links from the Triage Page
2. persist these through the journey
3. include the values in submissions to SmartAgent. 

The properties are: 

* `fromURL` which will be included in all links from the Triage Page. This holds the page URL that the user had been on before they went to the Triage Page. 
* Three additional parameters that will be included for ID Check App links coming from the Triage Page. These properties are `theme=id_check_app`, `appSessionId` and `appErrorCode`.

### Approach 

There are two parts to this: 

1. I've chosen to introduce a new route (`/contact-us-from-triage-page`) and controller method to handle requests coming from the Triage Page because links that include the `theme=id_check_app` query parameter will need to be redirected. This seemed better than adding branching logic to the `contactUsGet` handler for `/contact-us`)
6. Where these GET parameters are included, they persist through the Contact Forms through a combination of parameters passed to `res.redirect` and as hidden form fields. This follows the same approach that's used for the existing query parameters

## Why?

A Triage Page is being developed by the Home team that will send through a new `fromURL` query parameter in addition to existing parameters required by the ID Check App.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change