### PR TITLE
AUT-1668: Enable Welsh translations in support forms

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -5,6 +5,7 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
+support_welsh_language_in_support_forms             = "1"
 support_smart_agent                                 = "1"
 support_international_numbers                       = "1"
 support_language_cy                                 = "1"
@@ -14,6 +15,7 @@ password_reset_code_entered_wrong_blocked_minutes   = "0.5"
 account_recovery_code_entered_wrong_blocked_minutes = "0.5"
 code_request_blocked_minutes                        = "0.5"
 code_entered_wrong_blocked_minutes                  = "0.5"
+
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -141,6 +141,10 @@ locals {
         value = local.service_domain
       },
       {
+        name  = "SUPPORT_WELSH_LANGuAGE_IN_SUPPORT_FORMS"
+        value = var.support_welsh_language_in_support_forms
+      },
+      {
         name  = "PASSWORD_RESET_CODE_ENTERED_WRONG_BLOCKED_MINUTES"
         value = var.password_reset_code_entered_wrong_blocked_minutes
       },

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -5,10 +5,11 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
-support_international_numbers = "1"
-support_language_cy           = "1"
-support_account_recovery      = "1"
-support_smart_agent           = "0"
+support_welsh_language_in_support_forms = "1"
+support_international_numbers           = "1"
+support_language_cy                     = "1"
+support_account_recovery                = "1"
+support_smart_agent                     = "0"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -2,16 +2,17 @@ environment         = "staging"
 common_state_bucket = "di-auth-staging-tfstate"
 redis_node_size     = "cache.m4.xlarge"
 
-frontend_auto_scaling_enabled   = true
-frontend_task_definition_cpu    = 512
-frontend_task_definition_memory = 1024
-frontend_auto_scaling_min_count = 4
-frontend_auto_scaling_max_count = 12
-ecs_desired_count               = 4
-support_language_cy             = "1"
-support_international_numbers   = "1"
-support_account_recovery        = "1"
-support_smart_agent             = "0"
+frontend_auto_scaling_enabled           = true
+frontend_task_definition_cpu            = 512
+frontend_task_definition_memory         = 1024
+frontend_auto_scaling_min_count         = 4
+frontend_auto_scaling_max_count         = 12
+ecs_desired_count                       = 4
+support_welsh_language_in_support_forms = "1"
+support_language_cy                     = "1"
+support_international_numbers           = "1"
+support_account_recovery                = "1"
+support_smart_agent                     = "0"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -29,6 +29,11 @@ variable "support_international_numbers" {
   type = string
 }
 
+variable "support_welsh_language_in_support_forms" {
+  type    = string
+  default = "0"
+}
+
 variable "support_language_cy" {
   type = string
 }

--- a/src/components/contact-us/contact-us-questions-validation.ts
+++ b/src/components/contact-us/contact-us-questions-validation.ts
@@ -2,6 +2,13 @@ import { body, check } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware";
 import { ValidationChainFunc } from "../../types";
 import { ZENDESK_FIELD_MAX_LENGTH, ZENDESK_THEMES } from "../../app.constants";
+import { supportWelshInSupportForms } from "../../config";
+
+export function setLanguageToReflectSupportForWelsh(
+  lang: "cy" | "en"
+): "cy" | "en" {
+  return supportWelshInSupportForms() ? lang : "en";
+}
 
 export function validateContactUsQuestionsRequest(): ValidationChainFunc {
   return [
@@ -18,7 +25,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
             suffix,
           {
             value,
-            lng: "en",
+            lng: setLanguageToReflectSupportForWelsh(req.i18n.lng),
           }
         );
       }),
@@ -29,7 +36,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           "pages.contactUsQuestions.takingPhotoOfIdProblem.identityDocument.errorMessage",
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     body("issueDescription")
@@ -38,7 +45,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           getErrorMessageForIssueDescription(req.body.theme, req.body.subtheme),
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     body("issueDescription")
@@ -47,7 +54,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           getErrorMessageForIssueDescription(req.body.theme, req.body.subtheme),
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     body("issueDescription")
@@ -59,7 +66,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
             req.body.theme,
             req.body.subtheme
           ),
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     body("additionalDescription")
@@ -71,7 +78,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
             req.body.theme,
             req.body.subtheme
           ),
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     body("additionalDescription")
@@ -80,7 +87,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           "pages.contactUsQuestions.additionalDescriptionErrorMessage.entryTooLongMessage",
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     body("optionalDescription")
@@ -89,7 +96,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           "pages.contactUsQuestions.optionalDescriptionErrorMessage.entryTooLongMessage",
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     body("moreDetailDescription")
@@ -98,7 +105,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           "pages.contactUsQuestions.optionalDescriptionErrorMessage.message",
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     body("serviceTryingToUse")
@@ -107,7 +114,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           "pages.contactUsQuestions.serviceTryingToUse.errorMessage",
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     body("moreDetailDescription")
@@ -116,7 +123,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           "pages.contactUsQuestions.optionalDescriptionErrorMessage.entryTooLongMessage",
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     body("contact")
@@ -124,7 +131,7 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           "pages.contactUsQuestions.replyByEmail.validationError.noBoxSelected",
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     body("email")
@@ -133,14 +140,14 @@ export function validateContactUsQuestionsRequest(): ValidationChainFunc {
       .withMessage((value, { req }) => {
         return req.t(
           "pages.contactUsQuestions.replyByEmail.validationError.noEmailAddress",
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       })
       .isEmail()
       .withMessage((value, { req }) => {
         return req.t(
           "pages.contactUsQuestions.replyByEmail.validationError.invalidFormat",
-          { value, lng: "en" }
+          { value, lng: setLanguageToReflectSupportForWelsh(req.i18n.lng) }
         );
       }),
     validateBodyMiddleware("contact-us/questions/index.njk"),

--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -24,6 +24,15 @@
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -24,6 +24,15 @@
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
@@ -41,6 +50,15 @@
     name: "optionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['optionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -21,6 +21,15 @@
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
@@ -38,6 +47,15 @@
     name: "additionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])

--- a/src/components/contact-us/questions/_authenticator-app-problem.njk
+++ b/src/components/contact-us/questions/_authenticator-app-problem.njk
@@ -20,6 +20,15 @@
     id: "issueDescription",
     name: "issueDescription",
     value: issueDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
         text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
@@ -37,6 +46,15 @@
     id: "additionalDescription",
     name: "additionalDescription",
     value: additionalDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
         text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())

--- a/src/components/contact-us/questions/_email-subscriptions-questions.njk
+++ b/src/components/contact-us/questions/_email-subscriptions-questions.njk
@@ -20,6 +20,15 @@
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
@@ -37,6 +46,15 @@
     name: "optionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['optionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -24,6 +24,15 @@
     name: "optionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['optionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])

--- a/src/components/contact-us/questions/_id-check-app-something-else.njk
+++ b/src/components/contact-us/questions/_id-check-app-something-else.njk
@@ -21,6 +21,15 @@
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
@@ -38,6 +47,15 @@
         name: "additionalDescription",
         maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['additionalDescription'])

--- a/src/components/contact-us/questions/_id-check-app-technical-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-technical-problem.njk
@@ -21,6 +21,15 @@
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
@@ -38,6 +47,15 @@
         name: "additionalDescription",
         maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['additionalDescription'])

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -26,6 +26,15 @@
     id: "moreDetailDescription",
     name: "moreDetailDescription",
     value: moreDetailDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
         text: errors['moreDetailDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -27,6 +27,15 @@
     name: "optionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: optionalDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['optionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['optionalDescription'])

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -26,6 +26,15 @@
     id: "moreDetailDescription",
     name: "moreDetailDescription",
     value: moreDetailDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     maxlength: zendeskFieldMaxLength,
     errorMessage: {
         text: errors['moreDetailDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())

--- a/src/components/contact-us/questions/_no-uk-mobile-questions.njk
+++ b/src/components/contact-us/questions/_no-uk-mobile-questions.njk
@@ -24,6 +24,15 @@
     name: "moreDetailDescription",
     maxlength: zendeskFieldMaxLength,
     value: moreDetailDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['moreDetailDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['moreDetailDescription'])

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-another-problem.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-another-problem.njk
@@ -21,6 +21,15 @@
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
@@ -38,6 +47,15 @@
         name: "additionalDescription",
         maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['additionalDescription'])

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-at-post-office.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-at-post-office.njk
@@ -24,6 +24,15 @@
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-continuing.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-continuing.njk
@@ -24,6 +24,15 @@
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-entering-details.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-entering-details.njk
@@ -24,6 +24,15 @@
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-finding-result.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-finding-result.njk
@@ -24,6 +24,15 @@
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-letter.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-letter.njk
@@ -24,6 +24,15 @@
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-technical-problem.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-technical-problem.njk
@@ -21,6 +21,15 @@
         name: "issueDescription",
         maxlength: zendeskFieldMaxLength,
         value: issueDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['issueDescription'])
@@ -38,6 +47,15 @@
         name: "additionalDescription",
         maxlength: zendeskFieldMaxLength,
         value: additionalDescription,
+        charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+        charactersUnderLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+        },
+        charactersOverLimitText: {
+            other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+            one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+        },
         errorMessage: {
             text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
         } if (errors['additionalDescription'])

--- a/src/components/contact-us/questions/_proving-identity-problem-questions.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-questions.njk
@@ -20,6 +20,15 @@
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
@@ -37,6 +46,15 @@
     name: "additionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])

--- a/src/components/contact-us/questions/_signing-in-problem-questions.njk
+++ b/src/components/contact-us/questions/_signing-in-problem-questions.njk
@@ -24,6 +24,15 @@
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])

--- a/src/components/contact-us/questions/_suggestion-feedback-questions.njk
+++ b/src/components/contact-us/questions/_suggestion-feedback-questions.njk
@@ -20,6 +20,15 @@
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -21,6 +21,15 @@
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])
@@ -38,6 +47,15 @@
     name: "additionalDescription",
     maxlength: zendeskFieldMaxLength,
     value: additionalDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['additionalDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['additionalDescription'])

--- a/src/components/contact-us/questions/_what-happened.njk
+++ b/src/components/contact-us/questions/_what-happened.njk
@@ -10,6 +10,15 @@
     name: "issueDescription",
     maxlength: zendeskFieldMaxLength,
     value: issueDescription,
+    charactersAtLimitText: 'pages.contactUsQuestions.characterCountComponent.charactersAtLimitText' | translateEnOnly,
+    charactersUnderLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersUnderLimitText.one' | translateEnOnly
+    },
+    charactersOverLimitText: {
+        other: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.other' | translateEnOnly,
+        one: 'pages.contactUsQuestions.characterCountComponent.charactersOverLimitText.one' | translateEnOnly
+    },
     errorMessage: {
         text: errors['issueDescription'].text | translateEnOnly | replace('[maximumCharacters]', zendeskFieldMaxLength.toLocaleString())
     } if (errors['issueDescription'])

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,10 @@ export function supportSmartAgent(): boolean {
   return process.env.SUPPORT_SMART_AGENT === "1";
 }
 
+export function supportWelshInSupportForms(): boolean {
+  return process.env.SUPPORT_WELSH_LANGUAGE_IN_SUPPORT_FORMS === "1";
+}
+
 export function getSupportLinkUrl(): string {
   return process.env.URL_FOR_SUPPORT_LINKS || "/contact-us";
 }

--- a/src/config/nunchucks.ts
+++ b/src/config/nunchucks.ts
@@ -2,6 +2,7 @@ import express from "express";
 import * as nunjucks from "nunjucks";
 import i18next from "i18next";
 import { Environment } from "nunjucks";
+import { supportWelshInSupportForms } from "../config";
 
 export function configureNunjucks(
   app: express.Application,
@@ -21,7 +22,12 @@ export function configureNunjucks(
   nunjucksEnv.addFilter(
     "translateEnOnly",
     function (key: string, options?: any) {
-      const translate = i18next.getFixedT("en");
+      let translate;
+      if (supportWelshInSupportForms()) {
+        translate = i18next.getFixedT(this.ctx.i18n.language);
+      } else {
+        translate = i18next.getFixedT("en");
+      }
       return translate(key, options);
     }
   );

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1578,100 +1578,111 @@
       }
     },
     "contactUsPublic": {
-      "title": "Contact us",
-      "header": "GOV.UK One Login: rhoi gwybod am broblem neu roi adborth",
+      "title": "Cysylltu â ni",
+      "header": "Cyfrif GOV.UK: rhoi gwybod am broblem neu roi adborth",
       "section1": {
-        "paragraph1": "Use this form to:",
-        "bulletPoint1": "dywedwch wrthym am broblem rydych chi’n ei chael gyda’ch GOV.UK One Login",
-        "bulletPoint2": "awgrymu gwelliannau neu roi adborth am eich profiad o ddefnyddio eich GOV.UK One Login",
-        "paragraph2": "Our office hours are 9:30am to 5:30pm, Monday to Friday. We’ll respond to you by email in 2 working days."
+        "paragraph1": "Defnyddiwch y ffurflen hon i:",
+        "bulletPoint1": "ddweud wrthym am broblem rydych yn ei chael gyda’ch cyfrif GOV.UK",
+        "bulletPoint2": "awgrymu gwelliannau neu roi adborth am eich profiad o ddefnyddio eich  GOV.UK One Login",
+        "paragraph2": "Ein horiau swyddfa yw 9:30am tan 5:30pm, o ddydd Llun i ddydd Gwener. Byddwn yn ymateb i chi drwy e-bost mewn 2 ddiwrnod gwaith."
       },
       "section3": {
-        "header": "What are you contacting us about?",
+        "header": "Am beth rydych yn cysylltu â ni?",
         "accountCreation": "Problem creu GOV.UK One Login",
         "signingIn": "Problem mewngofnodi i’ch GOV.UK One Login",
-        "provingIdentity": "A problem proving your identity",
+        "provingIdentity": "Problem profi eich hunaniaeth",
         "somethingElse": "Problem arall wrth ddefnyddio eich GOV.UK One Login",
-        "emailSubscriptions": "GOV.UK email subscriptions",
-        "suggestionsFeedback": "Awgrym neu adborth am ddefnyddio eich GOV.UK One Login",
-        "idCheckApp": "A problem proving your identity using the GOV.UK ID Check app",
-        "provingIdentityFaceToFace": "A problem proving your identity with the Post Office",
-        "errorMessage": "Select a reason for contacting us"
+        "emailSubscriptions": "Tanysgrifiadau e-bost GOV.UK",
+        "suggestionsFeedback": "Awgrym neu adborth am ddefnyddio’ch GOV.UK One Login",
+        "idCheckApp":"Problem profi eich hunaniaeth wrth ddefnyddio ap GOV.UK ID Check",
+        "provingIdentityFaceToFace": "Problem profi eich hunaniaeth gyda’r Swyddfa Bost",
+        "errorMessage": "Dewiswch reswm dros gysylltu â ni"
       },
-      "continueLabel": "Continue"
+      "continueLabel": "Parhau"
     },
     "contactUsFurtherInformation": {
       "signingIn": {
         "title": "Problem mewngofnodi i’ch GOV.UK One Login",
         "header": "Problem mewngofnodi i’ch GOV.UK One Login",
         "section1": {
-          "header": "Tell us what happened",
-          "radio1": "You did not get a security code",
-          "radio2": "The security code did not work",
-          "radio3": "You’ve changed your phone number or lost your phone",
-          "radio4": "You’ve forgotten your password",
-          "radio5": "Rydych wedi cael gwybod nad oes modd ‘dod o hyd’ i’ch GOV.UK One Login",
-          "radio6": "There was a technical problem (for example, the service was unavailable)",
-          "radio7": "Something else",
-          "errorMessage": "Dewiswch y broblem a gawsoch wrth fewngofnodi i’ch GOV.UK One Login"
+          "header": "Dywedwch wrthym beth ddigwyddodd",
+          "radio1": "Ni chawsoch god diogelwch",
+          "radio2": "Nid oedd y cod diogelwch yn gweithio",
+          "radio3": "Rydych wedi newid eich rhif ffôn neu wedi colli eich ffôn",
+          "radio4": "Rydych wedi anghofio eich cyfrinair",
+          "radio5": "Dywedwyd wrthych ’na ellir dod o hyd’ i’ch GOV.UK One Login",
+          "radio6": "Roedd problem dechnegol (er enghraifft, nid oedd y gwasanaeth ar gael)",
+          "radio7": "Rhywbeth arall",
+          "errorMessage": "Dewiswch y broblem oedd gennych wrth fewngofnodi i ’ch GOV.UK One Login"
         }
       },
       "accountCreation": {
         "title": "Problem creu GOV.UK One Login",
         "header": "Problem creu GOV.UK One Login",
         "section1": {
-          "header": "Tell us what happened",
-          "radio1": "You did not get a security code",
-          "radio2": "The security code did not work",
-          "radio3": "You do not have a UK mobile phone number",
-          "radio4": "There was a technical problem (for example, the service was unavailable)",
-          "radio5": "Something else",
-          "radio6": "You had a problem with an authenticator app",
-          "errorMessage": "Dewis y broblem a gawsoch chi wrth greu eich GOV.UK One Login"
+          "header": "Dywedwch wrthym beth ddigwyddodd",
+          "radio1": "Ni chawsoch god diogelwch",
+          "radio2": "Nid oedd y cod diogelwch yn gweithio",
+          "radio3": "Nid oes gennych rif ffôn symudol y DU",
+          "radio4": "Roedd problem dechnegol (er enghraifft, nid oedd y gwasanaeth ar gael)",
+          "radio5": "Rhywbeth arall",
+          "radio6": "Roeddech wedi cael problem gydag ap dilysydd",
+          "errorMessage": "Dewiswch y broblem oedd gennych wrth greu eich GOV.UK One Login"
         }
       },
       "idCheckApp": {
-        "title": "A problem proving your identity using the GOV.UK ID Check app",
-        "header": "A problem proving your identity using the GOV.UK ID Check app",
+        "title": "Problem profi eich hunaniaeth drwy ddefnyddio’r ap GOV.UK ID Check",
+        "header": "Problem profi eich hunaniaeth drwy ddefnyddio’r ap GOV.UK ID Check",
         "section1": {
-          "header": "Tell us what happened",
-          "linkingProblem": "You had a problem linking the app to your web browser",
-          "photoProblem": "You had a problem taking a photo of your identity document (for example, passport or driving licence)",
-          "faceScanningProblem": "You had a problem scanning your face",
-          "technicalError": "There was a technical problem (for example you saw an error message)",
-          "somethingElse": "Something else",
-          "errorMessage": "Select the problem you had when proving your identity using the GOV.UK ID Check app"
+          "header": "Dywedwch wrthym beth ddigwyddodd",
+          "linkingProblem": "Roeddech wedi cael problem cysylltu’r ap gyda’ch porwr gwe",
+          "photoProblem": "Roeddech wedi cael problem tynnu llun eich dogfen hunaniaeth (er enghraifft, pasbort neu drwydded gyrru)",
+          "faceScanningProblem": "Roeddech wedi cael problem sganio eich wyneb",
+          "technicalError": "Roedd problem dechnegol (er enghraifft, fe welsoch neges gwall)",
+          "somethingElse": "Rhywbeth arall",
+          "errorMessage": "Dewiswch y broblem a gawsoch pan yn profi eich hunaniaeth drwy ddefnyddio’r ap GOV.UK ID Check"
         }
       },
       "provingIdentityFaceToFace": {
-        "title": "A problem proving your identity with the Post Office",
-        "header": "A problem proving your identity with the Post Office",
+        "title": "Problem profi eich hunaniaeth gyda’r Swyddfa Bost",
+        "header": "Problem profi eich hunaniaeth gyda’r Swyddfa Bost",
         "section1": {
-          "header": "Tell us what happened",
-          "problemEnteringDetails": "You had a problem entering your details",
-          "problemPostOfficeLetter": "You had a problem with your Post Office customer letter",
-          "problemAtPostOffice": "You had a problem at the Post Office",
-          "problemFindingResult": "You had a problem finding out the result of your identity check",
-          "problemContinuing": "You had a problem continuing to the service you want to use",
-          "technicalProblem": "There was a technical problem (for example, you saw an error message)",
-          "anotherProblem": "Something else",
-          "errorMessage": "Select the problem you had when proving your identity with the Post Office"
+          "header": "Dywedwch wrthym beth ddigwyddodd",
+          "problemEnteringDetails": "Roeddech wedi cael problem rhoi eich manylion",
+          "problemPostOfficeLetter": "Roeddech wedi cael problem gyda’ch llythyr Swyddfa Bost",
+          "problemAtPostOffice": "Roeddech wedi cael problem yn y Swyddfa Bost",
+          "problemFindingResult": "Roeddech wedi cael problem dod o hyd i ganlyniad eich gwiriad hunaniaeth",
+          "problemContinuing": "Roeddech wedi cael problem parhau i’r gwasanaeth roeddech am ei ddefnyddio",
+          "technicalProblem": "Roedd problem dechnegol (er enghraifft, fe welsoch neges gwall)",
+          "anotherProblem": "Rhywbeth arall",
+          "errorMessage": "Dewiswch y broblem a gawsoch pan yn profi eich hunaniaeth gyda’r Swyddfa Bost"
         }
       }
     },
     "contactUsQuestions": {
+      "characterCountComponent": {
+        "charactersAtLimitText": "Mae gennych 0 nod ar ôl",
+        "charactersUnderLimitText": {
+          "other": "Mae gennych %{count} nod ar ôl",
+          "one": "Un nod i fynd"
+        },
+        "charactersOverLimitText": {
+          "other": "Mae gennych %{count} nod yn ormod",
+          "one": "Un nod yn ormod"
+        }
+      },
       "personalInformation": {
-        "paragraph1": "Do not include personal or financial information, for example your passport or credit card details."
+        "paragraph1": "Peidiwch â chynnwys gwybodaeth bersonol nac ariannol, er enghraifft manylion eich pasbort neu gerdyn credyd."
       },
       "whatHappened": {
-        "header": "What happened?",
-        "paragraph1": "For example, did you see any warning or error messages?",
-        "errorMessage": "Enter what happened"
+        "header": "Beth ddigwyddodd?",
+        "paragraph1": "Er enghraifft, a wnaethoch chi weld unrhyw rybudd neu negeseuon gwall?",
+        "errorMessage": "Rhowch beth ddigwyddodd"
       },
       "serviceTryingToUse": {
-        "header": "What service were you trying to use?",
-        "hint": "If you cannot remember the name of the service, tell us what you were trying to do, for example get a DBS check. Or you can tell us the name of the government department you’ve been dealing with.",
-        "errorMessage": "Enter the name of the service"
+        "header": "Pa wasanaeth oeddech chi’n ceisio ei ddefnyddio?",
+        "hint": "Os na allwch gofio enw’r gwasanaeth, dywedwch wrthym beth roeddech yn ceisio ei wneud, er enghraifft cael gwiriad DBS. Neu gallwch ddweud wrthym enw’r adran o’r llywodraeth rydych wedi bod yn delio gyda.",
+        "errorMessage": "Rhowch enw’r gwasanaeth"
       },
       "replyByEmail": {
         "validationError": {
@@ -1681,141 +1692,141 @@
         }
       },
       "emailReply": {
-        "header": "Can we reply to you by email?",
-        "emailLabel": "Email address",
-        "emailHint": "We will only use this to reply to your message",
-        "nameLabel": "Name (Optional)",
-        "privacyNote": "Read our <a href=\"/privacy-notice\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">privacy notice</a> for more information on how we use your personal information."
+        "header": "Allwn ni ymateb i chi drwy e-bost?",
+        "emailLabel": "Cyfeiriad e-bost",
+        "emailHint": "Byddwn ond yn defnyddio hyn i ymateb i’ch neges",
+        "nameLabel": "Enw (Dewisol)",
+        "privacyNote": "Darllenwch ein <a href=\"/privacy-notice\" class=\"govuk-link\" rel=\"noreferrer noopener\" target=\"_blank\">hysbysiad preifatrwydd</a> am fwy o wybodaeth am sut rydym yn defnyddio eich gwybodaeth bersonol."
       },
       "anotherProblem": {
         "title": "Problem wrth ddefnyddio eich GOV.UK One Login",
         "header": "Problem wrth ddefnyddio eich GOV.UK One Login",
         "section1": {
-          "header": "What were you trying to do?",
-          "errorMessage": "Enter what you were trying to do"
+          "header": "Beth oeddech chi’n ceisio ei wneud?",
+          "errorMessage": "Rhowch beth oeddech chi’n ceisio ei wneud"
         },
         "section2": {
-          "header": "What happened?",
-          "paragraph1": "For example, was there a technical problem?",
-          "errorMessage": "Enter what happened"
+          "header": "Beth ddigwyddodd?",
+          "paragraph1": "Er enghraifft, a oedd problem dechnegol?",
+          "errorMessage": "Rhowch beth ddigwyddodd"
         }
       },
       "authenticatorApp": {
-        "title": "You had a problem with an authenticator app",
-        "header": "You had a problem with an authenticator app",
+        "title": "Roeddech wedi cael problem gydag ap dilysydd",
+        "header": "Roeddech wedi cael problem gydag ap dilysydd",
         "section1": {
-          "header": "What were you trying to do?",
-          "errorMessage": "Enter what you were trying to do"
+          "header": "Beth oeddech chi’n ceisio ei wneud?",
+          "errorMessage": "Rhowch beth oeddech chi’n ceisio ei wneud"
         },
         "section2": {
-          "header": "What happened?",
-          "paragraph1": "For example, you had a problem with the QR code or finding an authenticator app",
-          "errorMessage": "Enter what happened"
+          "header": "Beth ddigwyddodd?",
+          "paragraph1": "Er enghraifft, roedd gennych broblem gyda’r cod QR neu ddod o hyd i ap dilysydd",
+          "errorMessage": "Rhowch beth ddigwyddodd"
         }
       },
       "emailSubscriptions": {
-        "title": "Your GOV.UK email subscriptions",
-        "header": "Your GOV.UK email subscriptions",
+        "title": "Eich tanysgrifiadau e-bost GOV.UK",
+        "header": "Eich tanysgrifiadau e-bost GOV.UK",
         "section1": {
-          "header": "What were you trying to do and what happened?",
-          "errorMessage": "Enter what you were trying to do and what happened"
+          "header": "Beth oeddech chi’n ceisio ei wneud a beth ddigwyddodd?",
+          "errorMessage": "Rhowch beth oeddech chi’n ceisio ei wneud a beth ddigwyddodd"
         },
         "section2": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give feedback"
+          "header": "Ydych chi eisiau dweud unrhyw beth arall wrthym",
+          "paragraph1": "Er enghraifft, os ydych eisiau ychwanegu mwy o fanylion neu roi adborth"
         }
       },
       "suggestionOrFeedback": {
-        "title": "Awgrym neu adborth am ddefnyddio eich GOV.UK One Login",
-        "header": "Awgrym neu adborth am ddefnyddio eich GOV.UK One Login",
+        "title": "Awgrym neu adborth am ddefnyddio’ch GOV.UK One Login",
+        "header": "Awgrym neu adborth am ddefnyddio’ch GOV.UK One Login",
         "section1": {
-          "header": "Your suggestion or feedback",
-          "errorMessage": "Enter your suggestion or feedback"
+          "header": "Eich awgrym neu adborth",
+          "errorMessage": "Rhowch eich awgrym neu adborth"
         }
       },
       "technicalError": {
-        "title": "There was a technical problem",
-        "header": "There was a technical problem",
+        "title": "Roedd problem dechnegol",
+        "header": "Roedd problem dechnegol",
         "section1": {
-          "header": "What were you trying to do?",
-          "errorMessage": "Enter what you were trying to do"
+          "header": "Beth oeddech chi’n ceisio ei wneud?",
+          "errorMessage": "Rhowch beth oeddech chi’n ceisio ei wneud"
         },
         "section2": {
-          "header": "What happened?",
-          "paragraph1": "Include details of the error",
-          "errorMessage": "Enter what happened"
+          "header": "Beth ddigwyddodd?",
+          "paragraph1": "Dylech gynnwys manylion y gwall",
+          "errorMessage": "Rhowch beth ddigwyddodd"
         },
         "section3": {
-          "header": "If possible, tell us the URL of the page the error happened on?"
+          "header": "Os yn bosib, dywedwch wrthym URL y dudalen y digwyddodd y gwall arno?"
         }
       },
       "provingIdentity": {
-        "title": "A problem proving your identity",
-        "header": "A problem proving your identity",
+        "title": "Problem profi eich hunaniaeth",
+        "header": "Problem profi eich hunaniaeth",
         "section1": {
-          "header": "What were you trying to do?",
-          "errorMessage": "Enter what you were trying to do"
+          "header": "Beth oeddech chi’n ceisio ei wneud?",
+          "errorMessage": "Rhowch beth oeddech chi’n ceisio ei wneud"
         },
         "section2": {
-          "header": "What happened?",
-          "paragraph1": "For example, did you see any warning or error messages?",
-          "errorMessage": "Enter what happened"
+          "header": "Beth ddigwyddodd?",
+          "paragraph1": "Er enghraifft, a wnaethoch chi weld unrhyw rybudd neu negeseuon gwall?",
+          "errorMessage": "Rhowch beth ddigwyddodd"
         }
       },
       "securityCodeSentMethod": {
-        "email": "",
-        "textMessage": "",
-        "textMessageUkNumber": "",
-        "textMessageInternationalNumber": "",
-        "authApp": "",
-        "errorMessage": ""
+        "email": "E-bost",
+        "textMessage": "Neges destun",
+        "textMessageUkNumber": "Neges destun i rif ffôn y DU",
+        "textMessageInternationalNumber": "Neges destun i rif ffôn o wlad arall",
+        "authApp": "Ap dilysydd",
+        "errorMessage": "Dewiswch a anfonwyd y cod drwy e-bost neu neges destun"
       },
       "noSecurityCode": {
-        "title": "You did not get a security code",
-        "header": "You did not get a security code",
+        "title": "Ni chawsoch god diogelwch",
+        "header": "Ni chawsoch god diogelwch",
         "section1": {
-          "header": "How did you expect to get the security code?",
-          "errorMessage": "Select whether you expected to get the code by email, text message or authenticator app",
-          "errorMessageSignIn": "Select whether you expected to get the code by text message or authenticator app"
+          "header": "Sut oeddech chi’n disgwyl cael y cod diogelwch?",
+          "errorMessage": "Dewiswch os oeddech yn disgwyl cael y cod trwy e-bost, neges destun neu ap dilysydd",
+          "errorMessageSignIn": "Dewiswch os oeddech yn disgwyl cael y cod trwy neges destun neu ap dilysydd"
         },
         "section2": {
-          "header": "Anything else you want to tell us",
-          "hintText": "You can add more detail, such as what you were trying to do, or give us feedback"
+          "header": "Ydych chi eisiau dweud unrhyw beth arall wrthym",
+          "hintText": "Gallwch ychwanegu mwy o fanylion, fel beth oeddech yn ceisio ei wneud, neu roi adborth i ni"
         }
       },
       "invalidSecurityCode": {
-        "title": "The security code does not work",
-        "header": "The security code does not work",
+        "title": "Nid yw’r cod diogelwch yn gweithio",
+        "header": "Nid yw’r cod diogelwch yn gweithio",
         "section1": {
-          "header": "How did you get the security code?",
-          "errorMessage": "Select whether you got the code by email, text message or authenticator app",
-          "errorMessageSignIn": "Select whether you got the code by text message or authenticator app"
+          "header": "Sut gawsoch chi’r cod diogelwch?",
+          "errorMessage": "Dewiswch os gawsoch chi’r cod trwy e-bost, neges destun neu ap dilysydd",
+          "errorMessageSignIn": "Dewiswch os gawsoch chi’r cod trwy neges destun neu ap dilysydd"
         },
         "section2": {
-          "header": "Anything else you want to tell us",
-          "hintText": "You can add more detail, such as what you were trying to do, or give us feedback"
+          "header": "Ydych chi eisiau dweud unrhyw beth arall wrthym",
+          "hintText": "Gallwch ychwanegu mwy o fanylion, fel beth oeddech yn ceisio ei wneud, neu roi adborth i ni"
         }
       },
       "noUKMobile": {
-        "title": "You do not have a UK mobile phone number",
-        "header": "You do not have a UK mobile phone number",
+        "title": "Nid oes gennych rif ffôn symudol y DU",
+        "header": "Nid oes gennych rif ffôn symudol y DU",
         "section1": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "You can add more detail, such as what you were trying to do, or give us feedback"
+          "header": "Ydych chi eisiau dweud unrhyw beth arall wrthym",
+          "paragraph1": "Gallwch ychwanegu mwy o fanylion, fel beth oeddech yn ceisio ei wneud, neu roi adborth i ni"
         }
       },
       "issueDescriptionErrorMessage": {
-        "entryTooLongMessage": "What were you trying to do must be [maximumCharacters] characters or less",
-        "anythingElseTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less",
-        "whatHappenedTooLongMessage": "What happened must be [maximumCharacters] characters or less",
-        "suggestionFeedbackTooLongMessage": "Your suggestion or feedback must be [maximumCharacters] characters or less"
+        "entryTooLongMessage": "Mae’n rhaid i Beth oeddech chi’n ceisio ei wneud fod yn [maximumCharacters] nod neu lai",
+        "anythingElseTooLongMessage": "Mae’n rhaid i Ydych chi eisiau dweud unrhyw beth arall wrthym fod yn [maximumCharacters] nod neu lai",
+        "whatHappenedTooLongMessage": "Mae’n rhaid i Beth ddigwyddodd fod yn [maximumCharacters] nod neu lai",
+        "suggestionFeedbackTooLongMessage": "Mae’n rhaid i Eich awgrym neu adborth fod yn [maximumCharacters] nod neu lai"
       },
       "additionalDescriptionErrorMessage": {
-        "entryTooLongMessage": "What happened must be [maximumCharacters] characters or less"
+        "entryTooLongMessage": "Mae’n rhaid i Beth ddigwyddodd fod yn [maximumCharacters] nod neu lai"
       },
       "optionalDescriptionErrorMessage": {
-        "message": "Enter more detail",
-        "entryTooLongMessage": "Anything else you want to tell us must be [maximumCharacters] characters or less"
+        "message": "Rhowch fwy o fanylion",
+        "entryTooLongMessage": "Mae’n rhaid i Ydych chi eisiau dweud unrhyw beth arall wrthym fod yn [maximumCharacters] nod neu lai"
       },
       "forgottenPassword": {
         "title": "Rydych wedi anghofio eich cyfrinair",
@@ -1838,17 +1849,17 @@
         }
       },
       "accountCreationProblem": {
-        "title": "Problem arall wrth greu eich GOV.UK One Login",
-        "header": "Problem arall wrth greu eich GOV.UK One Login",
+        "title": "Problem arall gyda chreu eich GOV.UK One Login",
+        "header": "Problem arall gyda chreu eich GOV.UK One Login",
         "section1": {
-          "header": "Anything else you want to tell us",
-          "paragraph1": "For example, if you want to add more detail or give us feedback",
-          "errorMessage": "Enter what happened"
+          "header": "Ydych chi eisiau dweud unrhyw beth arall wrthym",
+          "paragraph1": "Er enghraifft, os ydych eisiau ychwanegu mwy o fanylion neu roi adborth i ni",
+          "errorMessage": "Rhowch beth ddigwyddodd"
         }
       },
       "signignInProblem": {
-        "title": "Problem arall wrth fewngofnodi i’ch GOV.UK One Login",
-        "header": "Problem arall wrth fewngofnodi i’ch GOV.UK One Login",
+        "title": "Problem arall gyda mewngofnodi i’ch GOV.UK One Login",
+        "header": "Problem arall gyda mewngofnodi i’ch GOV.UK One Login",
         "section1": {
           "header": "Ydych chi eisiau dweud unrhyw beth arall wrthym",
           "paragraph1": "Er enghraifft, os ydych eisiau ychwanegu mwy o fanylion neu roi adborth i ni",
@@ -1862,7 +1873,7 @@
           "header": "Pa wasanaeth oeddech chi’n ceisio ei ddefnyddio?",
           "paragraph1": "Er enghraifft, eich tanysgrifiadau e-bost GOV.UK, eich cyfrif treth personol neu Gredyd Cynhwysol",
           "errorMessage": "Rhowch ba wasanaeth roeddech yn ceisio ei ddefnyddio",
-          "entryTooLongErrorMessage": "What service were you trying to use must be [maximumCharacters] characters or less"
+          "entryTooLongErrorMessage": "Mae’n rhaid i Pa wasanaeth oeddech chi’n ceisio ei ddefnyddio fod yn [maximumCharacters] nod neu lai"
         },
         "section2": {
           "header": "Ydych chi eisiau dweud unrhyw beth arall wrthym",
@@ -1870,121 +1881,121 @@
         }
       },
       "linkingProblem": {
-        "title": "You had a problem linking the app to your web browser",
-        "header": "You had a problem linking the app to your web browser"
+        "title": "Roeddech wedi cael problem cysylltu’r ap gyda’ch porwr gwe",
+        "header": "Roeddech wedi cael problem cysylltu’r ap gyda’ch porwr gwe"
       },
       "takingPhotoOfIdProblem": {
-        "title": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
-        "header": "You had a problem taking a photo of your identity document using the GOV.UK ID Check app",
+        "title": "Roeddech wedi cael problem tynnu llun eich dogfen hunaniaeth wrth ddefnyddio’r ap GOV.UK ID Check",
+        "header": "Roeddech wedi cael problem tynnu llun eich dogfen hunaniaeth wrth ddefnyddio’r ap GOV.UK ID Check",
         "identityDocument": {
-          "header": "Which identity document were you using?",
-          "errorMessage": "Select which identity document you were using",
+          "header": "Pa ddogfen hunaniaeth oeddech chi’n ei defnyddio?",
+          "errorMessage": "Dewiswch pa ddogfen hunaniaeth oeddech chi’n ei defnyddio",
           "types": {
-            "passport": "Passport",
-            "biometricResidencePermit": "Biometric residence permit",
-            "drivingLicence": "Driving licence"
+            "passport": "Pasbort",
+            "biometricResidencePermit": "Trwydded preswylio biometrig",
+            "drivingLicence": "Trwydded yrru"
           }
         }
       },
       "faceScanningProblem": {
-        "title": "You had a problem scanning your face using the GOV.UK ID Check app",
-        "header": "You had a problem scanning your face using the GOV.UK ID Check app"
+        "title": "Roeddech wedi cael problem sganio eich wyneb wrth ddefnyddio’r ap GOV.UK ID Check",
+        "header": "Roeddech wedi cael problem sganio eich wyneb wrth ddefnyddio’r ap GOV.UK ID Check"
       },
       "idCheckAppTechnicalProblem": {
-        "title": "You had a technical problem",
+        "title": "Roeddech wedi cael problem dechnegol",
         "section1": {
-          "title": "You had a technical problem",
-          "header": "What were you trying to do?",
-          "errorMessage": "Tell us what you were trying to do"
+          "title": "Roeddech wedi cael problem dechnegol",
+          "header": "Beth oeddech chi’n ceisio ei wneud?",
+          "errorMessage": "Dywedwch wrthym beth oeddech yn ceisio ei wneud"
         },
         "section2": {
-          "header": "What happened?",
-          "paragraph1": "Include details of the error",
-          "errorMessage": "Tell us what happened"
+          "header": "Beth ddigwyddodd?",
+          "paragraph1": "Dylech gynnwys manylion y gwall",
+          "errorMessage": "Dywedwch wrthym beth ddigwyddodd"
         }
       },
       "idCheckAppSomethingElse": {
-        "title": "Another problem with the GOV.UK ID Check app",
+        "title": "Problem arall gyda’r ap GOV.UK ID Check",
         "section1": {
-          "title": "Another problem with the GOV.UK ID Check app",
-          "header": "What were you trying to do?",
-          "errorMessage": "Tell us what you were trying to do"
+          "title": "Problem arall gyda’r ap GOV.UK ID Check",
+          "header": "Beth oeddech chi’n ceisio ei wneud?",
+          "errorMessage": "Dywedwch wrthym beth oeddech yn ceisio ei wneud"
         },
         "section2": {
-          "header": "What happened?",
-          "paragraph1": "For example, was there a technical problem?",
-          "errorMessage": "Tell us what happened"
+          "header": "Beth ddigwyddodd?",
+          "paragraph1": "Er enghraifft, a oedd problem dechnegol?",
+          "errorMessage": "Dywedwch wrthym beth ddigwyddodd"
         }
       },
       "provingIdentityFaceToFaceDetails": {
-        "title": "A problem entering your details",
-        "header": "A problem entering your details",
+        "title": "Problem rhoi eich manylion",
+        "header": "Problem rhoi eich manylion",
         "whatHappened": {
-          "label": "Tell us what happened",
-          "hint": "For example, you had a problem entering your personal details or details from your photo ID, such as your passport or driving licence.",
-          "errorMessage": "Enter what happened"
+          "label": "Dywedwch wrthym beth ddigwyddodd",
+          "hint": "Er enghraifft, roeddech wedi cael problem rhoi eich manylion personol neu fanylion o’ch ID gyda llun, fel eich pasbort neu trwydded yrru.",
+          "errorMessage": "Rhowch beth ddigwyddodd"
         }
       },
       "provingIdentityFaceToFaceLetter": {
-        "title": "A problem with your Post Office customer letter",
-        "header": "A problem with your Post Office customer letter",
+        "title": "Problem gyda’ch llythyr cwsmer Swyddfa Bost",
+        "header": "Problem gyda’ch llythyr cwsmer Swyddfa Bost",
         "whatHappened": {
-          "label": "Tell us what happened",
-          "hint": "For example, you had a problem receiving, downloading or viewing your Post Office customer letter.",
-          "errorMessage": "Enter what happened"
+          "label": "Dywedwch wrthym beth ddigwyddodd",
+          "hint": "Er enghraifft, roeddech wedi cael problem derbyn, lawrlwytho neu weld eich llythyr cwsmer Swyddfa Bost.",
+          "errorMessage": "Rhowch beth ddigwyddodd"
         }
       },
       "provingIdentityFaceToFacePostOffice": {
-        "title": "A problem at the Post Office",
-        "header": "A problem at the Post Office",
+        "title": "Problem yn y Swyddfa Bost",
+        "header": "Problem yn y Swyddfa Bost",
         "whatHappened": {
-          "label": "Tell us what happened",
-          "hint": "For example, the Post Office staff were unable to scan your photo ID, such as your passport or driving licence.",
-          "errorMessage": "Enter what happened"
+          "label": "Dywedwch wrthym beth ddigwyddodd",
+          "hint": "Er enghraifft, roedd staff y Swyddfa Bost yn methu sganio eich ID gyda llun, fel eich pasbort neu trwydded yrru.",
+          "errorMessage": "Rhowch beth ddigwyddodd"
         }
       },
       "provingIdentityFaceToFaceIdResults": {
-        "title": "A problem finding out the result of your identity check",
-        "header": "A problem finding out the result of your identity check",
+        "title": "Problem darganfod canlyniad eich gwiriad hunaniaeth",
+        "header": "Problem darganfod canlyniad eich gwiriad hunaniaeth",
         "whatHappened": {
-          "label": "Tell us what happened",
-          "hint": "For example, you couldn’t see your identity check result after you signed in.",
-          "errorMessage": "Enter what happened"
+          "label": "Dywedwch wrthym beth ddigwyddodd",
+          "hint": "Er enghraifft, nid oeddech yn gallu gweld canlyniad eich gwiriad hunaniaeth wedi i chi fewngofnodi.",
+          "errorMessage": "Rhowch beth ddigwyddodd"
         }
       },
       "provingIdentityFaceToFaceService": {
-        "title": "A problem continuing to the service you want to use",
-        "header": "A problem continuing to the service you want to use",
+        "title": "Problem gyda pharhau i’r gwasanaeth roeddech eisiau ei ddefnyddio",
+        "header": "Problem gyda pharhau i’r gwasanaeth roeddech eisiau ei ddefnyddio",
         "whatHappened": {
-          "label": "Tell us what happened",
-          "hint": "For example, you could not find your way back to the service you want to use.",
-          "errorMessage": "Enter what happened"
+          "label": "Dywedwch wrthym beth ddigwyddodd",
+          "hint": "Er enghraifft, nid oeddech yn gallu dod o hyd i’ch ffordd yn ôl i’r gwasanaeth rydych eisiau ei ddefnyddio .",
+          "errorMessage": "Rhowch beth ddigwyddodd"
         }
       },
       "provingIdentityFaceToFaceTechnicalProblem": {
-        "title": "There was a technical problem",
+        "title": "Roedd problem dechnegol",
         "section1": {
-          "title": "What were you trying to do?",
-          "header": "What were you trying to do?",
-          "errorMessage": "Tell us what you were trying to do"
+          "title": "Beth oeddech chi’n ceisio ei wneud?",
+          "header": "Beth oeddech chi’n ceisio ei wneud?",
+          "errorMessage": "Dywedwch wrthym beth oeddech yn ceisio ei wneud"
         },
         "section2": {
-          "header": "What happened?",
-          "paragraph1": "For example, did you see an error message?",
-          "errorMessage": "Tell us what happened"
+          "header": "Beth ddigwyddodd?",
+          "paragraph1": "Er enghraifft, wnaethoch chi weld neges gwall?",
+          "errorMessage": "Dywedwch wrthym beth ddigwyddodd"
         }
       },
       "provingIdentityFaceToFaceSomethingElse": {
-        "title": "Another problem with proving your identity with the Post Office",
+        "title": "Problem arall gyda phrofi eich hunaniaeth gyda’r Swyddfa Bost",
         "section1": {
-          "title": "Another problem with proving your identity with the Post Office",
-          "header": "What were you trying to do?",
-          "errorMessage": "Tell us what you were trying to do"
+          "title": "Problem arall gyda phrofi eich hunaniaeth gyda’r Swyddfa Bost",
+          "header": "Beth oeddech chi’n ceisio ei wneud?",
+          "errorMessage": "Dywedwch wrthym beth oeddech yn ceisio ei wneud"
         },
         "section2": {
-          "header": "What happened?",
-          "paragraph1": "For example, did you see an error message?",
-          "errorMessage": "Tell us what happened"
+          "header": "Beth ddigwyddodd?",
+          "paragraph1": "Er enghraifft, wnaethoch chi weld neges gwall?",
+          "errorMessage": "Dywedwch wrthym beth ddigwyddodd"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1660,6 +1660,17 @@
       }
     },
     "contactUsQuestions": {
+      "characterCountComponent": {
+        "charactersAtLimitText": "You have %{count} characters remaining",
+        "charactersUnderLimitText": {
+          "other": "You have %{count} characters remaining",
+          "one": "One character to go"
+        },
+        "charactersOverLimitText": {
+          "other": "You have %{count} characters too many",
+          "one": "One character too many"
+        }
+      },
       "personalInformation": {
         "paragraph1": "Do not include personal or financial information, for example your passport or credit card details."
       },

--- a/src/middleware/html-lang-middleware.ts
+++ b/src/middleware/html-lang-middleware.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Request, Response } from "express";
 import { PATH_NAMES } from "../app.constants";
+import { supportWelshInSupportForms } from "../config";
 
 export function setHtmlLangMiddleware(
   req: Request,
@@ -7,8 +8,23 @@ export function setHtmlLangMiddleware(
   next: NextFunction
 ): void {
   if (req.i18n) {
-    const re = new RegExp(`^${PATH_NAMES.CONTACT_US}`);
-    res.locals.htmlLang = re.test(req.url) ? "en" : req.i18n.language;
+    if (forceEnglishLanguageInSupportForms(req, supportWelshInSupportForms())) {
+      res.locals.htmlLang = "en";
+    } else {
+      res.locals.htmlLang = req.i18n.language;
+    }
   }
   next();
+}
+
+export function isSupportForm(req: Request): boolean {
+  const re = new RegExp(`^${PATH_NAMES.CONTACT_US}`);
+  return re.test(req.url);
+}
+
+export function forceEnglishLanguageInSupportForms(
+  req: Request,
+  supportWelsh: boolean
+): boolean {
+  return isSupportForm(req) && !supportWelsh;
 }


### PR DESCRIPTION
## What?

This PR enables Welsh translation of support forms in lower environments while English remains the only language available in the live environment. This has been approached by:

1. Introducing the Welsh translation values in place of English placeholder values
2. Updating all instances of `govukCharacterCount` to use locale files for text relating to characters remaining
3. Introducing a `SUPPORT_WELSH_LANGAGE_IN_SUPPORT_FORMS` feature flag to control Welsh support in different environments
4. Update code that forces English language to permit Welsh translation where the feature flag is set (see `setLanguageToReflectSupportForWelsh()` and the `translateEnOnly` Nunjucks filter
5. Creates the feature flag in Terraform

## Why?

Until now, the Contact Forms have been available in English only but the new Contact Centre will support Welsh language. For this reason we need to enable Welsh language in lower environment for testing while continuing to provide English only forms in Live. When the new Contact Centre is live, we'll need to remove the code that manages localisation differently within the Contact Forms.

## Local testing

During development I've tested the following properties and forms. For each form I've tested the **initial render** and **error states**

- [x] HTML `lang` set correctly
- [x] Index page for Government services contacting us
- [x] GOV.UK account: report a problem or give feedback
- [x] A problem creating a GOV.UK account
- [x] (Account creation) You do not have a UK mobile phone number
- [x] (Account creation) You did not get a security code
- [x] (Account creation) The security code did not work
- [x] (Account creation) You had a problem with an authenticator app
- [x] (Account creation) There was a technical problem (for example, the service was unavailable)
- [x] (Account creation) Something else
- [x] A problem signing in to your GOV.UK account
- [x] (Signing in) You did not get a security code
- [x] (Signing in) The security code did not work
- [x] (Signing in) You’ve forgotten your password
- [x] (Signing in) You’ve changed your phone number or lost your phone
- [x] (Signing in) You’ve been told your account ‘cannot be found’
- [x] (Signing in) There was a technical problem (for example, the service was unavailable)
- [x] (Signing in) Something else
- [x] Another problem using your GOV.UK account
- [x] A problem proving your identity using the GOV.UK ID Check app
- [x] (ID Check App) You had a problem linking the app to your web browser
- [x] (ID Check App) You had a problem taking a photo of your identity document (for example, passport or driving licence)
- [x] (ID Check App) You had a problem scanning your face
- [x] (ID Check App) There was a technical problem (for example you saw an error message)
- [x] (ID Check App) Something else
- [x] A problem proving your identity with the Post Office
- [x] (Post Office) You had a problem entering your details
- [x] (Post Office) You had a problem with your Post Office customer letter
- [x] (Post Office) You had a problem at the Post Office
- [x] (Post Office) You had a problem finding out the result of your identity check
- [x] (Post Office) You had a problem continuing to the service you want to use
- [x] (Post Office) There was a technical problem (for example, you saw an error message)
- [x] (Post Office) Something else
- [x] A problem proving your identity
- [x] GOV.UK email subscriptions
- [x] A suggestion or feedback about using your GOV.UK account
- [x] Successful submission page

## Change have been demonstrated

No changes necessary to Figma.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change
