### PR TITLE
AUT-1715: Align Sign in or create page content for both MANDATORY and OPTIONAL clients

### DIFF
--- a/src/components/sign-in-or-create/index.njk
+++ b/src/components/sign-in-or-create/index.njk
@@ -4,12 +4,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
-{% if serviceType === 'OPTIONAL' %}
-  {% set pageTitleVariableName = 'pages.signInOrCreate.optional.title' %}
-{% endif %}
-{% if serviceType === 'MANDATORY' %}
-  {% set pageTitleVariableName = 'pages.signInOrCreate.mandatory.title' %}
-{% endif %}
+{% set pageTitleVariableName = 'pages.signInOrCreate.mandatory.title' %}
 
 {% set pageTitleName = pageTitleVariableName | translate %}
 
@@ -22,11 +17,7 @@
 {% block content %}
   {% include "common/errors/errorSummary.njk" %}
 
-  {% if serviceType === 'OPTIONAL' %}
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.signInOrCreate.optional.header' | translate}}</h1>
-  {% else %}
-    <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.signInOrCreate.mandatory.header' | translate}}</h1>
-  {% endif %}
+  <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.signInOrCreate.mandatory.header' | translate}}</h1>
 
   <p class="govuk-body">{{ 'pages.signInOrCreate.paragraph' | translate }}</p>
   <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
## What?

Align Sign in or create page content for both MANDATORY and OPTIONAL clients.

## Why?

OPTIONAL clients (where the user is not required to create an account before starting the service journey) had slightly different content on the sign in or create screen, to cover the scenario where the user was to create an account to save their progress.  As this content was not thought to be help it has been removed, so that OPTIONAL clients now see exactly the same content as MANDATORY clients.

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.

- [ ] Changes to the user interface have been demonstrated