### PR TITLE
SPT-473: Update pre-commit reference to programme hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
         exclude: ^(ci|.github)/.*|docker-compose.*|.pre-commit-config.yaml$
         files: ^.*\.(yml|yaml)$
 
-  - repo: https://github.com/alphagov/di-pre-commit-hooks.git
+  - repo: https://github.com/govuk-one-login/pre-commit-hooks.git
     rev: 0.0.1
     hooks:
       - id: terraform-format


### PR DESCRIPTION
## What?

- The `di-pre-commit-hooks` repo has now been migrated to the `govuk-one-login` org, update `.pre-commit-config.yaml` to reflect the change.

## Why?

The `di-pre-commit-hooks` repo has now been migrated to the `govuk-one-login` org.

## Change have been demonstrated

N/A
