### PR TITLE
AUT-1653: Change SmartAgent logging approach to debug Build

### DIFF
--- a/src/utils/smartAgent.ts
+++ b/src/utils/smartAgent.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import smartAgentConfig, { SmartAgentConfig } from "../config/smartAgent";
 import { SmartAgentTicket } from "../components/contact-us/types";
+import { logger } from "./logger";
 
 export class SmartAgentService {
   private readonly webformID: string;
@@ -31,8 +32,14 @@ export class SmartAgentService {
         }
       )
       .catch((error) => {
+        logger.info(`Error posting to SmartAgent API`);
+        logger.info(`webformID is ${this.webformID}`);
+        logger.info(`apiKey is ${this.apiKey}`);
+        logger.info(`apiUrl is ${this.apiUrl}`);
+
+        logger.error(error.toJSON());
         throw new Error(
-          error.response.status + " " + error.response.statusText
+          `${error?.response?.status} ${error?.response?.statusText}`
         );
       });
   }


### PR DESCRIPTION
## What?

Uses optional chaining when constructing string passed to `throw new Error()` and log values used in SmartAgent configuration. 

## Why?

Since the integration PR has been merged we've found that form submissions on Build are resulting in a "Sorry, there is a problem" being presented to users.

Looking into this, it seems there's a call to undefined properties of `error`, so I've changes the syntax to optional chaining.

The hypothesis is that this is a result of the shape of values that are being provided via Secrets Manager so I'm also logging the values of those.

## Related PRs

The PRs that integrated SmartAgent were:

* #1140 
* #1144 
* #1146 