### PR TITLE
AUT-1668: Fix single letter casing issue in Terraform variable

### DIFF
--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -141,7 +141,7 @@ locals {
         value = local.service_domain
       },
       {
-        name  = "SUPPORT_WELSH_LANGuAGE_IN_SUPPORT_FORMS"
+        name  = "SUPPORT_WELSH_LANGUAGE_IN_SUPPORT_FORMS"
         value = var.support_welsh_language_in_support_forms
       },
       {


### PR DESCRIPTION
## What?

Fix casing issue in Terraform variable name

## Why?

What was a lowercase `u` should have been uppercase `U`.

## Related PRs

This variable was introduced in https://github.com/alphagov/di-authentication-frontend/pull/1161
