### PR TITLE
AUT-1766: Add app error code to SmartAgent payload

### DIFF
--- a/src/components/contact-us/contact-us-service-smart-agent.ts
+++ b/src/components/contact-us/contact-us-service-smart-agent.ts
@@ -149,6 +149,9 @@ export function contactUsServiceSmartAgent(
 
     customAttributes["sa-webformrefer"] = getRefererTag(contactForm);
 
+    customAttributes["sa-app-error-code"] =
+      contactForm.optionalData.appErrorCode;
+
     customAttributes["sa-tag-preferred-language"] =
       contactForm.preferredLanguage;
 

--- a/src/components/contact-us/types.ts
+++ b/src/components/contact-us/types.ts
@@ -76,6 +76,7 @@ export interface SmartAgentCustomAttributes {
   "sa-tag-identifier"?: string;
   "sa-tag-theme"?: string;
   "sa-tag-subtheme"?: string;
+  "sa-app-error-code"?: string;
 }
 
 export interface SmartAgentTicket {


### PR DESCRIPTION
## What?

Sends the `appErrorCode` through to a new `sa-app-error-code` property in the SmartAgent payload.

## Why?

The `sa-app-error-code` property was added to the SmartAgent API mappings after the previous integration was put in place.

## Related PRs

* https://github.com/alphagov/di-authentication-frontend/pull/1140 
