### PR TITLE
AUT-1816: Enable SmartAgent submissions where client name is Production Stub

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -5,16 +5,17 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
-support_welsh_language_in_support_forms             = "1"
-support_smart_agent                                 = "1"
-support_international_numbers                       = "1"
-support_language_cy                                 = "1"
-support_account_recovery                            = "1"
-support_auth_orch_split                             = "0"
-password_reset_code_entered_wrong_blocked_minutes   = "0.5"
-account_recovery_code_entered_wrong_blocked_minutes = "0.5"
-code_request_blocked_minutes                        = "0.5"
-code_entered_wrong_blocked_minutes                  = "0.5"
+support_welsh_language_in_support_forms                             = "1"
+support_smart_agent                                                 = "1"
+support_international_numbers                                       = "1"
+support_language_cy                                                 = "1"
+support_account_recovery                                            = "1"
+support_auth_orch_split                                             = "0"
+password_reset_code_entered_wrong_blocked_minutes                   = "0.5"
+account_recovery_code_entered_wrong_blocked_minutes                 = "0.5"
+code_request_blocked_minutes                                        = "0.5"
+code_entered_wrong_blocked_minutes                                  = "0.5"
+client_name_that_directs_all_contact_form_submissions_to_smartagent = ""
 
 
 logging_endpoint_arns = [

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -137,6 +137,10 @@ locals {
         value = var.smartagent_webform_id
       },
       {
+        name  = "CLIENT_NAME_THAT_DIRECTS_ALL_CONTACT_FORM_SUBMISSIONS_TO_SMARTAGENT",
+        value = var.client_name_that_directs_all_contact_form_submissions_to_smartagent
+      },
+      {
         name  = "SERVICE_DOMAIN"
         value = local.service_domain
       },

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -5,11 +5,12 @@ frontend_auto_scaling_enabled   = true
 frontend_task_definition_cpu    = 512
 frontend_task_definition_memory = 1024
 
-support_welsh_language_in_support_forms = "1"
-support_international_numbers           = "1"
-support_language_cy                     = "1"
-support_account_recovery                = "1"
-support_smart_agent                     = "0"
+support_welsh_language_in_support_forms                             = "1"
+support_international_numbers                                       = "1"
+support_language_cy                                                 = "1"
+support_account_recovery                                            = "1"
+support_smart_agent                                                 = "0"
+client_name_that_directs_all_contact_form_submissions_to_smartagent = ""
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -2,15 +2,16 @@ environment         = "production"
 common_state_bucket = "digital-identity-prod-tfstate"
 redis_node_size     = "cache.m4.xlarge"
 
-frontend_auto_scaling_enabled   = true
-frontend_task_definition_cpu    = 512
-frontend_task_definition_memory = 1024
-frontend_auto_scaling_min_count = 4
-frontend_auto_scaling_max_count = 12
-ecs_desired_count               = 4
-support_international_numbers   = "1"
-support_account_recovery        = "1"
-support_smart_agent             = "0"
+frontend_auto_scaling_enabled                                       = true
+frontend_task_definition_cpu                                        = 512
+frontend_task_definition_memory                                     = 1024
+frontend_auto_scaling_min_count                                     = 4
+frontend_auto_scaling_max_count                                     = 12
+ecs_desired_count                                                   = 4
+support_international_numbers                                       = "1"
+support_account_recovery                                            = "1"
+support_smart_agent                                                 = "0"
+client_name_that_directs_all_contact_form_submissions_to_smartagent = "di-auth-stub-relying-party-production"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -2,17 +2,18 @@ environment         = "staging"
 common_state_bucket = "di-auth-staging-tfstate"
 redis_node_size     = "cache.m4.xlarge"
 
-frontend_auto_scaling_enabled           = true
-frontend_task_definition_cpu            = 512
-frontend_task_definition_memory         = 1024
-frontend_auto_scaling_min_count         = 4
-frontend_auto_scaling_max_count         = 12
-ecs_desired_count                       = 4
-support_welsh_language_in_support_forms = "1"
-support_language_cy                     = "1"
-support_international_numbers           = "1"
-support_account_recovery                = "1"
-support_smart_agent                     = "0"
+frontend_auto_scaling_enabled                                       = true
+frontend_task_definition_cpu                                        = 512
+frontend_task_definition_memory                                     = 1024
+frontend_auto_scaling_min_count                                     = 4
+frontend_auto_scaling_max_count                                     = 12
+ecs_desired_count                                                   = 4
+support_welsh_language_in_support_forms                             = "1"
+support_language_cy                                                 = "1"
+support_international_numbers                                       = "1"
+support_account_recovery                                            = "1"
+support_smart_agent                                                 = "0"
+client_name_that_directs_all_contact_form_submissions_to_smartagent = ""
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -146,6 +146,10 @@ variable "smartagent_api_url" {
   type = string
 }
 
+variable "client_name_that_directs_all_contact_form_submissions_to_smartagent" {
+  type = string
+}
+
 variable "zendesk_username" {
   type    = string
   default = ""

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -48,6 +48,8 @@ export const PATH_NAMES = {
   CONTACT_US_SUBMIT_SUCCESS: "/contact-us-submit-success",
   CONTACT_US_FURTHER_INFORMATION: "/contact-us-further-information",
   CONTACT_US_QUESTIONS: "/contact-us-questions",
+  CONTACT_US_TESTING_SMARTAGENT_IN_LIVE:
+    "/contact-us-questions-testing-smartagent-in-production",
   PROVE_IDENTITY: "/prove-identity",
   DOC_CHECKING_APP: "/doc-checking-app",
   DOC_CHECKING_APP_CALLBACK: "/doc-app-callback",

--- a/src/components/contact-us/contact-us-routes.ts
+++ b/src/components/contact-us/contact-us-routes.ts
@@ -53,6 +53,12 @@ if (supportSmartAgent()) {
   );
 }
 
+router.post(
+  PATH_NAMES.CONTACT_US_TESTING_SMARTAGENT_IN_LIVE,
+  validateContactUsQuestionsRequest(),
+  asyncHandler(contactUsQuestionsFormPostToSmartAgent())
+);
+
 router.get(PATH_NAMES.CONTACT_US_SUBMIT_SUCCESS, contactUsSubmitSuccessGet);
 
 export { router as contactUsRouter };

--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.accountCreationProblem.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.accountNotFound.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.anotherProblem.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_authenticator-app-problem.njk
+++ b/src/components/contact-us/questions/_authenticator-app-problem.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.authenticatorApp.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_email-subscriptions-questions.njk
+++ b/src/components/contact-us/questions/_email-subscriptions-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.emailSubscriptions.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.forgottenPassword.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.faceScanningProblem.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_id-check-app-linking-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-linking-problem.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.linkingProblem.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_id-check-app-something-else.njk
+++ b/src/components/contact-us/questions/_id-check-app-something-else.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.idCheckAppSomethingElse.section1.title' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.takingPhotoOfIdProblem.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_id-check-app-technical-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-technical-problem.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.idCheckAppTechnicalProblem.section1.title' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_invalid-security-code-questions.njk
+++ b/src/components/contact-us/questions/_invalid-security-code-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.invalidSecurityCode.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions?radio_buttons=true" method="post" novalidate>
+<form action="{{formSubmissionUrl}}?radio_buttons=true" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_no-phone-number-access-questions.njk
+++ b/src/components/contact-us/questions/_no-phone-number-access-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.noPhoneNumberAccess.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions?radio_buttons=true" method="post" novalidate>
+<form action="{{formSubmissionUrl}}?radio_buttons=true" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_no-security-code-questions.njk
+++ b/src/components/contact-us/questions/_no-security-code-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.noSecurityCode.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions?radio_buttons=true" method="post" novalidate>
+<form action="{{formSubmissionUrl}}?radio_buttons=true" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_no-uk-mobile-questions.njk
+++ b/src/components/contact-us/questions/_no-uk-mobile-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.noUKMobile.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-another-problem.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-another-problem.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceSomethingElse.section1.title' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-at-post-office.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-at-post-office.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.provingIdentityFaceToFacePostOffice.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-continuing.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-continuing.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceService.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-entering-details.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-entering-details.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceDetails.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-finding-result.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-finding-result.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceIdResults.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-problem-letter.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-problem-letter.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceLetter.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_proving-identity-face-to-face-technical-problem.njk
+++ b/src/components/contact-us/questions/_proving-identity-face-to-face-technical-problem.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.provingIdentityFaceToFaceTechnicalProblem.section1.title' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_proving-identity-problem-questions.njk
+++ b/src/components/contact-us/questions/_proving-identity-problem-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.provingIdentity.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_signing-in-problem-questions.njk
+++ b/src/components/contact-us/questions/_signing-in-problem-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.signignInProblem.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_suggestion-feedback-questions.njk
+++ b/src/components/contact-us/questions/_suggestion-feedback-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.suggestionOrFeedback.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.technicalError.header' | translateEnOnly }}
 </h1>
 
-<form action="/contact-us-questions" method="post" novalidate>
+’<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -14,8 +14,13 @@ import {
   isAppJourney,
   getPreferredLanguage,
   contactUsGetFromTriagePage,
+  setContactFormSubmissionUrlBasedOnClientName,
 } from "../contact-us-controller";
-import { SUPPORT_TYPE, ZENDESK_THEMES } from "../../../app.constants";
+import {
+  PATH_NAMES,
+  SUPPORT_TYPE,
+  ZENDESK_THEMES,
+} from "../../../app.constants";
 import { RequestGet, ResponseRedirect } from "../../../types";
 
 describe("contact us controller", () => {
@@ -323,6 +328,25 @@ describe("appErrorCode and appSessionId query parameters", () => {
       it(`should return false when passed a invalid appSessionId like ${i}`, () => {
         expect(isAppJourney(i)).to.be.false;
       });
+    });
+  });
+
+  describe("setContactFormSubmissionUrlBasedOnClientName", () => {
+    it("should return the value of PATH_NAMES.CONTACT_US_TESTING_SMARTAGENT_IN_LIVE where there's a match", () => {
+      expect(
+        setContactFormSubmissionUrlBasedOnClientName(
+          "di-auth-stub-relying-party-production",
+          "di-auth-stub-relying-party-production"
+        )
+      ).to.equal(PATH_NAMES.CONTACT_US_TESTING_SMARTAGENT_IN_LIVE);
+    });
+    it("should return the value of PATH_NAMES.CONTACT_US_QUESTIONS where there is no match", () => {
+      expect(
+        setContactFormSubmissionUrlBasedOnClientName(
+          "di-auth-stub-relying-party-build",
+          "di-auth-stub-relying-party-production"
+        )
+      ).to.equal(PATH_NAMES.CONTACT_US_QUESTIONS);
     });
   });
 });

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -10,6 +10,7 @@ import {
 import {
   ZENDESK_THEMES,
   ZENDESK_FIELD_MAX_LENGTH,
+  PATH_NAMES,
 } from "../../../app.constants";
 import { ContactUsServiceInterface } from "../types";
 import { RequestGet, ResponseRedirect } from "../../../types";
@@ -51,6 +52,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "something_else",
         subtheme: undefined,
         backurl: BACKURL,
@@ -69,6 +71,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "email_subscriptions",
         subtheme: undefined,
         backurl: BACKURL,
@@ -87,6 +90,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "suggestions_feedback",
         subtheme: undefined,
         backurl: BACKURL,
@@ -106,6 +110,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "proving_identity",
         subtheme: undefined,
         backurl: BACKURL,
@@ -134,6 +139,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "no_security_code",
         backurl: REFERER_HEADER,
@@ -153,6 +159,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "invalid_security_code",
         backurl: REFERER_HEADER,
@@ -172,6 +179,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "no_phone_number_access",
         backurl: REFERER_HEADER,
@@ -191,6 +199,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "forgotten_password",
         backurl: REFERER_HEADER,
@@ -210,6 +219,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "account_not_found",
         backurl: REFERER_HEADER,
@@ -229,6 +239,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "technical_error",
         backurl: REFERER_HEADER,
@@ -248,6 +259,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "signing_in",
         subtheme: "something_else",
         backurl: REFERER_HEADER,
@@ -270,6 +282,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "no_security_code",
         backurl: REFERER_HEADER,
@@ -289,6 +302,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "invalid_security_code",
         backurl: REFERER_HEADER,
@@ -308,6 +322,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "no_uk_mobile_number",
         backurl: REFERER_HEADER,
@@ -327,6 +342,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "technical_error",
         backurl: REFERER_HEADER,
@@ -346,6 +362,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "something_else",
         backurl: REFERER_HEADER,
@@ -365,6 +382,7 @@ describe("contact us questions controller", () => {
       contactUsQuestionsGet(req as Request, res as Response);
 
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
+        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
         subtheme: "authenticator_app_problem",
         backurl: REFERER_HEADER,

--- a/src/config.ts
+++ b/src/config.ts
@@ -160,6 +160,13 @@ export function getSmartAgentWebformId(): string {
   return process.env.SMARTAGENT_WEBFORM_ID || "";
 }
 
+export function getClientNameThatDirectsAllContactFormSubmissionsToSmartAgent(): string {
+  return (
+    process.env
+      .CLIENT_NAME_THAT_DIRECTS_ALL_CONTACT_FORM_SUBMISSIONS_TO_SMARTAGENT || ""
+  );
+}
+
 export function getServiceSignInLink(): string {
   return process.env.SERVICE_SIGN_IN_LINK || "https://www.gov.uk/sign-in";
 }


### PR DESCRIPTION
## What?

This PR does two things to allow testing of form submissions to SmartAgent in the production environment:

1. Sets all contact form `action` attributes to point to a new `CONTACT_US_TESTING_SMARTAGENT_IN_LIVE` path where the `req?.session?.client?.name` matches the production stub client name. If there's no match, the form `action` will use the existing `CONTACT_US_QUESTIONS` path. 
2. Adds a new POST route for the `CONTACT_US_TESTING_SMARTAGENT_IN_LIVE` path that directs form submission to SmartAgent, rather than Zendesk 

## Why?

At a meeting on 6 October we were asked if it would be possible for form submissions to SmartAgent to be tested in the Live environment before go-live. This requirement had not been known before the meeting and introduces some complexity because the current SmartAgent implementation relies upon a switch at the environment level: the presence of the `SUPPORT_SMART_AGENT=1` environment variable will route submissions to SmartAgent. Without this, submissions are routed to Zendesk.

## Approach

### What didn't seem to work
Having discussed this with @JHjava, it initially seemed best to introduce a controller method that would route to SmartAgent where the client name matched that of the production stub. An important aspect of this is the requirement to access `req.session`. However, trying to implement this was problematic and I couldn't get it to work (I tried a few different approaches but repeatedly got `500`s and it was difficult to understand why).

### The alternative approach presented here
I then considered other options and wondered if a better way to achieve this might be to set the form action attribute to a new route where the condition was met, and to use the existing `contactUsQuestionsFormPostToSmartAgent` method as the handler for that route. This shifts the test for `req?.session?.client?.name` upstream to the form render, rather than the form processing.

## Bugs identified by SonarCloud
The two bugs identified by SonarCloud relate the the known issue relating to `asyncHandler`. There is a ticket in the backlog to fix this (See Jira ticket AUT-1713)

## Related PRs

Previous PRs relating to the SmartAgent integration are: 

* #1140 
* #1144 
* #1166 
* #1168 
* #1160 
