### PR TITLE
AUT-1650: Fix back links from Triage Page

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -252,9 +252,13 @@ export function furtherInformationGet(req: Request, res: Response): void {
     return res.redirect(PATH_NAMES.CONTACT_US);
   }
 
+  const backLinkHref =
+    validateReferer(req.get("referer")) || PATH_NAMES.CONTACT_US;
+
   if (isAppJourney(req.query.appSessionId as string)) {
     return res.render("contact-us/further-information/index.njk", {
       theme: req.query.theme,
+      hrefBack: backLinkHref,
       referer: validateReferer(req.query.referer as string),
       ...(validateReferer(req.query.fromURL as string) && {
         fromURL: validateReferer(req.query.fromURL as string),

--- a/src/components/contact-us/further-information/index.njk
+++ b/src/components/contact-us/further-information/index.njk
@@ -6,7 +6,6 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set showBack = true %}
-{% set hrefBack = 'contact-us' %}
 
 {% if theme == 'signing_in' %}
     {% set pageTitleName = 'pages.contactUsFurtherInformation.signingIn.title' | translateEnOnly %}

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -364,5 +364,33 @@ describe("Integration:: contact us - public user", () => {
         )
         .expect(302, done);
     });
+
+    it("should use the referer for the back link where the referer is valid", (done) => {
+      request(app)
+        .get("/contact-us-from-triage-page")
+        .set("referer", "accountCreatedEmail")
+        .query(`theme=${ZENDESK_THEMES.ID_CHECK_APP}`)
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($(".govuk-back-link").first().attr("href")).to.equal(
+            "accountCreatedEmail"
+          );
+        })
+        .expect(200, done);
+    });
+
+    it("should use `/contact-us` in the back link where the referer is not valid", (done) => {
+      request(app)
+        .get("/contact-us-from-triage-page")
+        .set("referer", "http://example.com")
+        .query(`theme=${ZENDESK_THEMES.ID_CHECK_APP}`)
+        .expect(function (res) {
+          const $ = cheerio.load(res.text);
+          expect($(".govuk-back-link").first().attr("href")).to.equal(
+            "/contact-us"
+          );
+        })
+        .expect(200, done);
+    });
   });
 });


### PR DESCRIPTION
## What?

Changes the "Back" link `href` on `/contact-us-further-information` from being a hard-coded value to either: 

1. the `referer` where the referer passes the checks in `validateReferer`, or
2. `/contact-us` where it does not

## Why?

When testing inbound links from the triage page that was deployed to Integration today, we found the links that include the `theme=id_check_app` parameter are redirected to `/contact-us-further-information` as expected but always use `/contact-us` as the back link `href`  (see the description in #1160 of how the presence of `theme=id_check_app` results in the user being passed directly to `/contact-us-further-information). This is problematic for two reasons: 

1. The user had not come from `/contact-us`
2. It resulted in the user getting stuck in a loop between `/contact-us` and `/contact-us-further-information` when clicking the back link

This was happening because the Back link `href` was hard-coded into the template. This had not been a problem previously because the only route to this page was via `/contact-us` but, with the introduction of the triage page, users have an alternative route to reach the page

## Related PRs

* #1160 Updated the contact forms to receive parameters from the triage page and introduced the routing.
