### PR TITLE
AUT-1831: Fix back links from Triage Page

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -252,9 +252,13 @@ export function furtherInformationGet(req: Request, res: Response): void {
     return res.redirect(PATH_NAMES.CONTACT_US);
   }
 
+  const backLinkHref =
+    validateReferer(req.get("referer")) || PATH_NAMES.CONTACT_US;
+
   if (isAppJourney(req.query.appSessionId as string)) {
     return res.render("contact-us/further-information/index.njk", {
       theme: req.query.theme,
+      hrefBack: backLinkHref,
       referer: validateReferer(req.query.referer as string),
       ...(validateReferer(req.query.fromURL as string) && {
         fromURL: validateReferer(req.query.fromURL as string),

--- a/src/components/contact-us/further-information/index.njk
+++ b/src/components/contact-us/further-information/index.njk
@@ -6,7 +6,6 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% set showBack = true %}
-{% set hrefBack = 'contact-us' %}
 
 {% if theme == 'signing_in' %}
     {% set pageTitleName = 'pages.contactUsFurtherInformation.signingIn.title' | translateEnOnly %}


### PR DESCRIPTION
## What?

Changes the "Back" link `href` on `/contact-us-further-information` from being a hard-coded value to either: 

1. the `referer` where the referer passes the checks in `validateReferer`, or
2. `/contact-us` where it does not

## Why?

When testing inbound links from the triage page that was deployed to Integration today, we found the links that include the `theme=id_check_app` parameter are redirected to `/contact-us-further-information` as expected but always use `/contact-us` as the back link `href`  (see the description in #1160 of how the presence of `theme=id_check_app` results in the user being passed directly to `/contact-us-further-information). This is problematic for two reasons: 

1. The user had not come from `/contact-us`
2. It resulted in the user getting stuck in a loop between `/contact-us` and `/contact-us-further-information` when clicking the back link

This was happening because the Back link `href` was hard-coded into the template. This had not been a problem previously because the only route to this page was via `/contact-us` but, with the introduction of the triage page, users have an alternative route to reach the page

## Testing it from localhost

To test the behaviour from localhost you'll need to simulate an inbound link from the triage page. Pasting the code snippets below into the browser console will inject a hyperlink into the DOM. Clicking that link will simulate the behaviour of a link coming from the triage page. 

### A link that includes the theme
This link should result in the user being directed to `/contact-us-further-information` with a working "Back" link.

```javascript
// This one includes the theme
(() => {
      const a = document.createElement('a');
      const linkText = document.createTextNode("A link from the Triage Page with theme=id_check_app");
      a.appendChild(linkText);
      const domain = window.location.origin;
      const protocol = window.location.protocol; 
      const appSessionId = "appSessionId=1234abcd-12ab-11aa-90aa-04938abc12ab";
      const appErrorCode = "appErrorCode=aed1";
      const theme = "theme=id_check_app";
      const fromURL = `fromURL=${domain}/security`;
      a.href = `${domain}/contact-us-from-triage-page?${appSessionId}&${appErrorCode}&${theme}&${fromURL}`;
      document.getElementById('main-content').appendChild(a);
})()
```

### A link that does not include the theme 

This link should result in the user being directed to `/contact-us` with a working "Back" link.

```javascript
  (() => {
    const a = document.createElement('a');
    const linkText = document.createTextNode("A link from the Triage Page");
    a.appendChild(linkText);
    const domain = window.location.origin;
    const protocol = window.location.protocol;
    const appSessionId = "appSessionId=1234abcd-12ab-11aa-90aa-04938abc12ab";
    const appErrorCode = "appErrorCode=aed1";
    const fromURL = `fromURL=${domain}/security`
    a.href = `${domain}/contact-us-from-triage-page?${appSessionId}&${appErrorCode}&${fromURL}`;
    document.getElementById('main-content').appendChild(a);
  })()
```

## Related PRs

* #1160 Updated the contact forms to receive parameters from the triage page and introduced the routing.
