### PR TITLE
AUT-1338: update phone number issue contact form pages

### DIFF
--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -144,7 +144,7 @@ export const ZENDESK_THEMES = {
   TECHNICAL_ERROR: "technical_error",
   NO_SECURITY_CODE: "no_security_code",
   INVALID_SECURITY_CODE: "invalid_security_code",
-  NO_UK_MOBILE_NUMBER: "no_uk_mobile_number",
+  SIGN_IN_PHONE_NUMBER_ISSUE: "sign_in_phone_number_issue",
   FORGOTTEN_PASSWORD: "forgotten_password",
   NO_PHONE_NUMBER_ACCESS: "no_phone_number_access",
   PROVING_IDENTITY: "proving_identity",

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -26,8 +26,8 @@ const themeToPageTitle = {
     "pages.contactUsQuestions.noSecurityCode.title",
   [ZENDESK_THEMES.INVALID_SECURITY_CODE]:
     "pages.contactUsQuestions.invalidSecurityCode.title",
-  [ZENDESK_THEMES.NO_UK_MOBILE_NUMBER]:
-    "pages.contactUsQuestions.noUKMobile.title",
+  [ZENDESK_THEMES.SIGN_IN_PHONE_NUMBER_ISSUE]:
+    "pages.contactUsQuestions.signInPhoneNumberIssue.title",
   [ZENDESK_THEMES.FORGOTTEN_PASSWORD]:
     "pages.contactUsQuestions.forgottenPassword.title",
   [ZENDESK_THEMES.NO_PHONE_NUMBER_ACCESS]:
@@ -552,9 +552,9 @@ export function getQuestionsFromFormTypeForMessageBody(
         { lng: "en" }
       ),
     },
-    noUKMobile: {
+    signInPhoneNumberIssue: {
       moreDetailDescription: req.t(
-        "pages.contactUsQuestions.noUKMobile.section1.header",
+        "pages.contactUsQuestions.signInPhoneNumberIssue.section1.header",
         { lng: "en" }
       ),
     },
@@ -782,7 +782,7 @@ export function getQuestionFromThemes(
       "pages.contactUsFurtherInformation.accountCreation.section1.radio2",
       { lng: "en" }
     ),
-    no_uk_mobile_number: req.t(
+    sign_in_phone_number_issue: req.t(
       "pages.contactUsFurtherInformation.accountCreation.section1.radio3",
       { lng: "en" }
     ),

--- a/src/components/contact-us/further-information/_account-creation-further-information.njk
+++ b/src/components/contact-us/further-information/_account-creation-further-information.njk
@@ -21,7 +21,7 @@
                     text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio2' | translateEnOnly
                 },
                 {
-                    value: "no_uk_mobile_number",
+                    value: "sign_in_phone_number_issue",
                     text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio3' | translateEnOnly
                 },
                 {

--- a/src/components/contact-us/further-information/_account-creation-further-information.njk
+++ b/src/components/contact-us/further-information/_account-creation-further-information.njk
@@ -13,16 +13,16 @@
 
         {% set items = [
                 {
-                    value: "no_uk_mobile_number",
-                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio3' | translateEnOnly
-                },
-                {
                     value: "no_security_code",
                     text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio1' | translateEnOnly
                 },
                 {
                     value: "invalid_security_code",
                     text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio2' | translateEnOnly
+                },
+                {
+                    value: "no_uk_mobile_number",
+                    text: 'pages.contactUsFurtherInformation.accountCreation.section1.radio3' | translateEnOnly
                 },
                 {
                     value: "authenticator_app_problem",

--- a/src/components/contact-us/questions/_sign_in_phone_number_issue.njk
+++ b/src/components/contact-us/questions/_sign_in_phone_number_issue.njk
@@ -1,5 +1,5 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-0 govuk-!-margin-bottom-3">
-  {{ 'pages.contactUsQuestions.noUKMobile.header' | translateEnOnly }}
+  {{ 'pages.contactUsQuestions.signInPhoneNumberIssue.header' | translateEnOnly }}
 </h1>
 
 <form action="{{formSubmissionUrl}}" method="post" novalidate>
@@ -9,17 +9,17 @@
 <input type="hidden" name="subtheme" value="{{subtheme}}"/>
 <input type="hidden" name="backurl" value="{{backurl}}"/>
 <input type="hidden" name="fromURL" value="{{fromURL}}"/>
-<input type="hidden" name="formType" value="noUKMobile"/>
+<input type="hidden" name="formType" value="signInPhoneNumberIssue"/>
 <input type="hidden" name="referer" value="{{referer}}"/>
 {% include 'contact-us/questions/_id-check-app-hidden-fields.njk' %}
 
 {{ govukCharacterCount({
     label: {
-      text: 'pages.contactUsQuestions.noUKMobile.section1.header' | translateEnOnly,
+      text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section1.header' | translateEnOnly,
       classes: "govuk-label--s"
     },
     hint: {
-        text: 'pages.contactUsQuestions.noUKMobile.section1.paragraph1' | translateEnOnly
+        text: 'pages.contactUsQuestions.signInPhoneNumberIssue.section1.paragraph1' | translateEnOnly
       },
     id: "moreDetailDescription",
     name: "moreDetailDescription",

--- a/src/components/contact-us/questions/index.njk
+++ b/src/components/contact-us/questions/index.njk
@@ -31,8 +31,8 @@
         {% include 'contact-us/questions/_invalid-security-code-questions.njk' %}
     {% endif %}
 
-    {% if subtheme == 'no_uk_mobile_number' %}
-        {% include 'contact-us/questions/_no-uk-mobile-questions.njk' %}
+    {% if subtheme == 'sign_in_phone_number_issue' %}
+        {% include 'contact-us/questions/_sign_in_phone_number_issue.njk' %}
     {% endif %}
 
     {% if subtheme == 'forgotten_password' %}

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -105,7 +105,7 @@ describe("Integration:: contact us - public user", () => {
       request(app)
         .get(PATH_NAMES.CONTACT_US_FURTHER_INFORMATION)
         .query("theme=account_creation")
-        .query("subtheme=no_uk_mobile_number")
+        .query("subtheme=sign_in_phone_number_issue")
         .query("referer=" + referer)
         .expect(function (res) {
           const $ = cheerio.load(res.text);

--- a/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-further-information-controller.test.ts
@@ -163,12 +163,12 @@ describe("contact us further information controller", () => {
     });
     it("should redirect /contact-us-questions page when 'You do not have a UK mobile phone number' radio option is chosen", async () => {
       req.body.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
-      req.body.subtheme = ZENDESK_THEMES.NO_UK_MOBILE_NUMBER;
+      req.body.subtheme = ZENDESK_THEMES.SIGN_IN_PHONE_NUMBER_ISSUE;
       req.body.referer = REFERER;
       furtherInformationPost(req as Request, res as Response);
 
       expect(res.redirect).to.have.calledWith(
-        "/contact-us-questions?theme=account_creation&subtheme=no_uk_mobile_number&referer=http%3A%2F%2Flocalhost%3A3000%2Fenter-email"
+        "/contact-us-questions?theme=account_creation&subtheme=sign_in_phone_number_issue&referer=http%3A%2F%2Flocalhost%3A3000%2Fenter-email"
       );
     });
     it("should redirect /contact-us-questions page when 'There was a technical problem' radio option is chosen", async () => {

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -314,9 +314,9 @@ describe("contact us questions controller", () => {
         appSessionId: "",
       });
     });
-    it("should render contact-us-questions if a 'You do not have a UK number' radio option was chosen", () => {
+    it("should render contact-us-questions if a 'You have another problem with a phone number' radio option was chosen", () => {
       req.query.theme = ZENDESK_THEMES.ACCOUNT_CREATION;
-      req.query.subtheme = ZENDESK_THEMES.NO_UK_MOBILE_NUMBER;
+      req.query.subtheme = ZENDESK_THEMES.SIGN_IN_PHONE_NUMBER_ISSUE;
       req.headers.referer = REFERER_HEADER;
       req.query.referer = REFERER;
       contactUsQuestionsGet(req as Request, res as Response);
@@ -324,10 +324,11 @@ describe("contact us questions controller", () => {
       expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
         formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
         theme: "account_creation",
-        subtheme: "no_uk_mobile_number",
+        subtheme: "sign_in_phone_number_issue",
         backurl: REFERER_HEADER,
         referer: REFERER,
-        pageTitleHeading: "pages.contactUsQuestions.noUKMobile.title",
+        pageTitleHeading:
+          "pages.contactUsQuestions.signInPhoneNumberIssue.title",
         zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
         ipnSupport: undefined,
         appErrorCode: "",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1808,8 +1808,8 @@
         }
       },
       "noUKMobile": {
-        "title": "Nid oes gennych rif ffôn symudol y DU",
-        "header": "Nid oes gennych rif ffôn symudol y DU",
+        "title": "Problem arall gyda rhif ffôn",
+        "header": "Problem arall gyda rhif ffôn",
         "section1": {
           "header": "Ydych chi eisiau dweud unrhyw beth arall wrthym",
           "paragraph1": "Gallwch ychwanegu mwy o fanylion, fel beth oeddech yn ceisio ei wneud, neu roi adborth i ni"

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1623,7 +1623,7 @@
           "header": "Dywedwch wrthym beth ddigwyddodd",
           "radio1": "Ni chawsoch god diogelwch",
           "radio2": "Nid oedd y cod diogelwch yn gweithio",
-          "radio3": "Nid oes gennych rif ffôn symudol y DU",
+          "radio3": "Roedd gennych broblem arall gyda rhif ffôn",
           "radio4": "Roedd problem dechnegol (er enghraifft, nid oedd y gwasanaeth ar gael)",
           "radio5": "Rhywbeth arall",
           "radio6": "Roeddech wedi cael problem gydag ap dilysydd",

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1807,7 +1807,7 @@
           "hintText": "Gallwch ychwanegu mwy o fanylion, fel beth oeddech yn ceisio ei wneud, neu roi adborth i ni"
         }
       },
-      "noUKMobile": {
+      "signInPhoneNumberIssue": {
         "title": "Problem arall gyda rhif ffôn",
         "header": "Problem arall gyda rhif ffôn",
         "section1": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1807,7 +1807,7 @@
           "hintText": "You can add more detail, such as what you were trying to do, or give us feedback"
         }
       },
-      "noUKMobile": {
+      "signInPhoneNumberIssue": {
         "title": "Another problem with a phone number",
         "header": "Another problem with a phone number",
         "section1": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1808,8 +1808,8 @@
         }
       },
       "noUKMobile": {
-        "title": "You do not have a UK mobile phone number",
-        "header": "You do not have a UK mobile phone number",
+        "title": "Another problem with a phone number",
+        "header": "Another problem with a phone number",
         "section1": {
           "header": "Anything else you want to tell us",
           "paragraph1": "You can add more detail, such as what you were trying to do, or give us feedback"

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1623,7 +1623,7 @@
           "header": "Tell us what happened",
           "radio1": "You did not get a security code",
           "radio2": "The security code did not work",
-          "radio3": "You do not have a UK mobile phone number",
+          "radio3": "You had another problem with a phone number",
           "radio4": "There was a technical problem (for example, the service was unavailable)",
           "radio5": "Something else",
           "radio6": "You had a problem with an authenticator app",


### PR DESCRIPTION
For reviewer - wanted to check whether updating the form value field had any implications.

## What?

* Updates the text on the radio button on the "A problem creating a GOV.UK One Login" page from ‘You do not have a UK mobile number’ radio button to ‘You had another problem with a phone number’
* Reorders these radio buttons so that this makes sense in the context
* Updates the title of the subsequent page when a user selects this radio button so that this page makes sense
* Updates the tag assigned to this when sent through to zendesk

## Why?

Users can now create a GOV.UK One Login with a non-UK mobile number, so the lack of a UK number should not, in itself, be a problem. However, users are still selecting this option, so users could still be experiencing problems that are not covered by the other radio buttons (the verbatim data from the user support form does not give enough detail to know what the problems are). Keeping the radio button but changing the wording may help us understand some of these other problems are.

## Screenshots

| Page | Before | After |
|-----|----|---|
| A problem creating a GOV.UK One Login - EN |<img width="607" alt="Screenshot 2023-10-23 at 12 56 29" src="https://github.com/alphagov/di-authentication-frontend/assets/25515510/2f6e32e3-d6e7-4fb3-8ae0-3a9aaccf1e8b">|<img width="511" alt="Screenshot 2023-10-23 at 12 59 09" src="https://github.com/alphagov/di-authentication-frontend/assets/25515510/5d615162-5812-45ec-bf28-20b59b7301e1">|
| A problem creating a GOV.UK One Login - CY |<img width="614" alt="Screenshot 2023-10-23 at 13 23 00" src="https://github.com/alphagov/di-authentication-frontend/assets/25515510/69835233-d975-4372-8fb5-422f04b07d13">|<img width="641" alt="Screenshot 2023-10-23 at 13 21 04" src="https://github.com/alphagov/di-authentication-frontend/assets/25515510/45870a21-2a07-444d-99e1-dd83297d95a8">|
| Subsequent page - EN |<img width="749" alt="Screenshot 2023-10-23 at 13 01 53" src="https://github.com/alphagov/di-authentication-frontend/assets/25515510/82f8d47a-301d-4f9a-999a-7f83675a5339">|<img width="667" alt="Screenshot 2023-10-23 at 13 00 50" src="https://github.com/alphagov/di-authentication-frontend/assets/25515510/9f3c6b05-7446-44cf-b415-52d71d00cbd5">|
| Subsequent page - CY |<img width="707" alt="Screenshot 2023-10-23 at 13 23 47" src="https://github.com/alphagov/di-authentication-frontend/assets/25515510/6ff3253a-ae3f-4b8e-8dc3-ff3057058366">|<img width="688" alt="Screenshot 2023-10-23 at 13 27 19" src="https://github.com/alphagov/di-authentication-frontend/assets/25515510/006441a1-a70d-471c-b270-33e1787837da">|

## Change have been demonstrated

Changes to the user interface or content should be demonstrated to Content Design and Interaction Design before being merged. This is to ensure they can make any necessary changes to Figma.
- [x] Changes to the user interface have been demonstrated

Delete this section if the PR does not change the UI.

## Performance Analysis have been informed of the change

- [x] Performance Analysis have been informed of the change

