### PR TITLE
BAU: Fix accidental character in support form questions

### DIFF
--- a/src/components/contact-us/questions/_account-creation-problem-questions.njk
+++ b/src/components/contact-us/questions/_account-creation-problem-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.accountCreationProblem.header' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_account-not-found-questions.njk
+++ b/src/components/contact-us/questions/_account-not-found-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.accountNotFound.header' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_another-problem-questions.njk
+++ b/src/components/contact-us/questions/_another-problem-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.anotherProblem.header' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_authenticator-app-problem.njk
+++ b/src/components/contact-us/questions/_authenticator-app-problem.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.authenticatorApp.header' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_forgotten-password-questions.njk
+++ b/src/components/contact-us/questions/_forgotten-password-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.forgottenPassword.header' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-face-scanning-problem.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.faceScanningProblem.header' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_id-check-app-linking-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-linking-problem.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.linkingProblem.header' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_id-check-app-something-else.njk
+++ b/src/components/contact-us/questions/_id-check-app-something-else.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.idCheckAppSomethingElse.section1.title' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
+++ b/src/components/contact-us/questions/_id-check-app-taking-photo-of-id-problem.njk
@@ -2,7 +2,7 @@
     {{ 'pages.contactUsQuestions.takingPhotoOfIdProblem.header' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
     <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
     <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_no-uk-mobile-questions.njk
+++ b/src/components/contact-us/questions/_no-uk-mobile-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.noUKMobile.header' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_suggestion-feedback-questions.njk
+++ b/src/components/contact-us/questions/_suggestion-feedback-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.suggestionOrFeedback.header' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>

--- a/src/components/contact-us/questions/_technical-error-questions.njk
+++ b/src/components/contact-us/questions/_technical-error-questions.njk
@@ -2,7 +2,7 @@
   {{ 'pages.contactUsQuestions.technicalError.header' | translateEnOnly }}
 </h1>
 
-’<form action="{{formSubmissionUrl}}" method="post" novalidate>
+<form action="{{formSubmissionUrl}}" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="theme" value="{{theme}}"/>


### PR DESCRIPTION
This apostrophe actually renders on the page and is accidental

## What?

Removes an accidental character from the support form question pages.

## Why?

This renders on the page - you can see this live e.g. [here](https://signin.account.gov.uk/contact-us-questions?theme=account_creation&subtheme=no_uk_mobile_number&referer=)

| Before this fix (see live e.g at  | After this fix |
|----|----|
|<img width="629" alt="Screenshot 2023-10-18 at 14 53 29" src="https://github.com/alphagov/di-authentication-frontend/assets/25515510/be95db14-48fa-4f46-9eb9-a31b15000ccf">|<img width="588" alt="Screenshot 2023-10-18 at 14 54 17" src="https://github.com/alphagov/di-authentication-frontend/assets/25515510/f8722e69-1972-456e-bd7e-0178d65359e5">|

