### PR TITLE
AUT-1650 - Set environment variables across all environments

### DIFF
--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -16,6 +16,7 @@ account_recovery_code_entered_wrong_blocked_minutes                 = "0.5"
 code_request_blocked_minutes                                        = "0.5"
 code_entered_wrong_blocked_minutes                                  = "0.5"
 client_name_that_directs_all_contact_form_submissions_to_smartagent = ""
+url_for_support_links                                               = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
 
 
 logging_endpoint_arns = [

--- a/ci/terraform/ecs.tf
+++ b/ci/terraform/ecs.tf
@@ -137,6 +137,10 @@ locals {
         value = var.smartagent_webform_id
       },
       {
+        name  = "URL_FOR_SUPPORT_LINKS"
+        value = var.url_for_support_links
+      },
+      {
         name  = "CLIENT_NAME_THAT_DIRECTS_ALL_CONTACT_FORM_SUBMISSIONS_TO_SMARTAGENT",
         value = var.client_name_that_directs_all_contact_form_submissions_to_smartagent
       },

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -9,8 +9,9 @@ support_welsh_language_in_support_forms                             = "1"
 support_international_numbers                                       = "1"
 support_language_cy                                                 = "1"
 support_account_recovery                                            = "1"
-support_smart_agent                                                 = "0"
+support_smart_agent                                                 = "1"
 client_name_that_directs_all_contact_form_submissions_to_smartagent = ""
+url_for_support_links                                               = "https://home.integration.account.gov.uk/contact-gov-uk-one-login"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -12,6 +12,8 @@ support_international_numbers                                       = "1"
 support_account_recovery                                            = "1"
 support_smart_agent                                                 = "0"
 client_name_that_directs_all_contact_form_submissions_to_smartagent = "di-auth-stub-relying-party-production"
+support_welsh_language_in_support_forms                             = "0"
+url_for_support_links                                               = "/contact-us"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -18,6 +18,10 @@ frontend_task_definition_cpu    = 256
 frontend_task_definition_memory = 512
 frontend_auto_scaling_enabled   = true
 
+support_smart_agent                     = "1"
+support_welsh_language_in_support_forms = "1"
+url_for_support_links                   = "https://home.build.account.gov.uk/contact-gov-uk-one-login"
+
 orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5P\nx78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ==\n-----END PUBLIC KEY-----"
 
 logging_endpoint_arns = [

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -12,8 +12,9 @@ support_welsh_language_in_support_forms                             = "1"
 support_language_cy                                                 = "1"
 support_international_numbers                                       = "1"
 support_account_recovery                                            = "1"
-support_smart_agent                                                 = "0"
+support_smart_agent                                                 = "1"
 client_name_that_directs_all_contact_form_submissions_to_smartagent = ""
+url_for_support_links                                               = "https://home.staging.account.gov.uk/contact-gov-uk-one-login"
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -146,6 +146,11 @@ variable "smartagent_api_url" {
   type = string
 }
 
+variable "url_for_support_links" {
+  type    = string
+  default = "/contact-us"
+}
+
 variable "client_name_that_directs_all_contact_form_submissions_to_smartagent" {
   type = string
 }


### PR DESCRIPTION
## Re-raised PR 

🆕 This is a reverted PR that had been approved and merged on 19 October. The reason for it being reverted is there were some failing acceptance tests relating to content on the Triage Page. These tests have been temporarily removed until the Triage Page is available in Welsh.

## What?

Sets the following environment variables consistently across all environments. After this change, all `.tfvars` files should reflect the values shown in the table below.

|  | Support SmartAgent  |  Support Welsh in Contact Forms | URL for support links  |
|---|---|---|---|
| Sandpit  | 1  | 1  | `https://home.build.account.gov.uk/contact-gov-uk-one-login`  |
| Build  | 1  | 1  | `https://home.build.account.gov.uk/contact-gov-uk-one-login`  |
| Integration  | 1  | 1  | `https://home.integration.account.gov.uk/contact-gov-uk-one-login`  |
| Staging  | 1  | 1  | `https://home.staging.account.gov.uk/contact-gov-uk-one-login`  |
| Live | 0  | 0  | `/contact-us`  |

## Why?

Prepares the environments for go-live later this month. After this PR, the only change necessary to release to production will be changing these environments to the values in `production.tfvars`

