### PR TITLE
AUT-1736: Extend validateReferer to handle encoded URLs and decode referers before sending to SmartAgent

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -203,7 +203,7 @@ export function validateReferer(
     if (CONTACT_US_REFERER_ALLOWLIST.includes(referer)) {
       valid = true;
     } else {
-      url = new URL(referer);
+      url = new URL(decodeURIComponent(referer));
       valid = url.hostname.endsWith(serviceDomain);
     }
   } catch {

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -78,29 +78,32 @@ const somethingElseSubThemeToPageTitle = {
     "pages.contactUsQuestions.idCheckAppSomethingElse.title",
 };
 
+const serviceDomain = getServiceDomain();
+
 export function contactUsGet(req: Request, res: Response): void {
   if (req.query.supportType === SUPPORT_TYPE.GOV_SERVICE) {
     return res.render("contact-us/index-gov-service-contact-us.njk");
   }
   const REFERER = "referer";
 
-  let referer = validateReferer(req.get(REFERER));
+  let referer = validateReferer(req.get(REFERER), serviceDomain);
   let fromURL;
 
   if (req.query.fromURL) {
-    fromURL = validateReferer(req.query.fromURL as string);
+    fromURL = validateReferer(req.query.fromURL as string, serviceDomain);
     logger.info(`fromURL query param received with value ${fromURL}`);
   }
 
   if (req.query.referer) {
-    referer = validateReferer(req.query.referer as string);
+    referer = validateReferer(req.query.referer as string, serviceDomain);
     logger.info(`referer with referer query param ${referer}`);
   }
 
   if (req.headers?.referer?.includes(REFERER)) {
     try {
       referer = validateReferer(
-        new URL(req.get(REFERER)).searchParams.get(REFERER)
+        new URL(req.get(REFERER)).searchParams.get(REFERER),
+        serviceDomain
       );
       logger.info(`referer with referer header param ${referer}`);
     } catch {
@@ -129,8 +132,8 @@ export function contactUsGetFromTriagePage(req: Request, res: Response): void {
     ...(getAppErrorCode(req.query.appErrorCode as string) && {
       appErrorCode: getAppErrorCode(req.query.appErrorCode as string),
     }),
-    ...(validateReferer(req.query.fromURL as string) && {
-      fromURL: validateReferer(req.query.fromURL as string),
+    ...(validateReferer(req.query.fromURL as string, serviceDomain) && {
+      fromURL: validateReferer(req.query.fromURL as string, serviceDomain),
     }),
   });
 
@@ -190,7 +193,10 @@ export function validateAppId(appSessionId: string): boolean {
   return testResult;
 }
 
-function validateReferer(referer: string): string {
+export function validateReferer(
+  referer: string,
+  serviceDomain: string
+): string {
   let valid = false;
   let url;
   try {
@@ -198,7 +204,7 @@ function validateReferer(referer: string): string {
       valid = true;
     } else {
       url = new URL(referer);
-      valid = url.hostname.endsWith(getServiceDomain());
+      valid = url.hostname.endsWith(serviceDomain);
     }
   } catch {
     logger.warn(`unable to parse referer ${referer}`);
@@ -227,14 +233,17 @@ export function contactUsFormPost(req: Request, res: Response): void {
   let url = PATH_NAMES.CONTACT_US_QUESTIONS;
   const queryParams = new URLSearchParams({
     theme: req.body.theme,
-    referer: validateReferer(req.body.referer),
+    referer: validateReferer(req.body.referer, serviceDomain),
     ...(validateAppId(req.body.appSessionId) && {
       appSessionId: getAppSessionId(req.body.appSessionId),
     }),
   });
 
   if (req.body.fromURL) {
-    queryParams.append("fromURL", validateReferer(req.body.fromURL));
+    queryParams.append(
+      "fromURL",
+      validateReferer(req.body.fromURL, serviceDomain)
+    );
   }
 
   if (
@@ -256,15 +265,15 @@ export function furtherInformationGet(req: Request, res: Response): void {
   }
 
   const backLinkHref =
-    validateReferer(req.get("referer")) || PATH_NAMES.CONTACT_US;
+    validateReferer(req.get("referer"), serviceDomain) || PATH_NAMES.CONTACT_US;
 
   if (isAppJourney(req.query.appSessionId as string)) {
     return res.render("contact-us/further-information/index.njk", {
       theme: req.query.theme,
       hrefBack: backLinkHref,
-      referer: validateReferer(req.query.referer as string),
-      ...(validateReferer(req.query.fromURL as string) && {
-        fromURL: validateReferer(req.query.fromURL as string),
+      referer: validateReferer(req.query.referer as string, serviceDomain),
+      ...(validateReferer(req.query.fromURL as string, serviceDomain) && {
+        fromURL: validateReferer(req.query.fromURL as string, serviceDomain),
       }),
       appSessionId: getAppSessionId(req.query.appSessionId as string),
       ...(getAppErrorCode(req.query.appErrorCode as string) && {
@@ -275,10 +284,10 @@ export function furtherInformationGet(req: Request, res: Response): void {
 
   return res.render("contact-us/further-information/index.njk", {
     theme: req.query.theme,
-    ...(validateReferer(req.query.fromURL as string) && {
-      fromURL: validateReferer(req.query.fromURL as string),
+    ...(validateReferer(req.query.fromURL as string, serviceDomain) && {
+      fromURL: validateReferer(req.query.fromURL as string, serviceDomain),
     }),
-    referer: validateReferer(req.query.referer as string),
+    referer: validateReferer(req.query.referer as string, serviceDomain),
   });
 }
 
@@ -287,9 +296,9 @@ export function furtherInformationPost(req: Request, res: Response): void {
   const queryParams = new URLSearchParams({
     theme: req.body.theme,
     subtheme: req.body.subtheme,
-    referer: validateReferer(req.body.referer),
-    ...(validateReferer(req.body.fromURL) && {
-      fromURL: validateReferer(req.body.fromURL),
+    referer: validateReferer(req.body.referer, serviceDomain),
+    ...(validateReferer(req.body.fromURL, serviceDomain) && {
+      fromURL: validateReferer(req.body.fromURL, serviceDomain),
     }),
   });
 
@@ -338,10 +347,10 @@ export function contactUsQuestionsGet(req: Request, res: Response): void {
     formSubmissionUrl: formSubmissionUrl,
     theme: req.query.theme,
     subtheme: req.query.subtheme,
-    backurl: validateReferer(req.headers.referer),
-    referer: validateReferer(req.query.referer as string),
-    ...(validateReferer(req.query.fromURL as string) && {
-      fromURL: validateReferer(req.query.fromURL as string),
+    backurl: validateReferer(req.headers.referer, serviceDomain),
+    referer: validateReferer(req.query.referer as string, serviceDomain),
+    ...(validateReferer(req.query.fromURL as string, serviceDomain) && {
+      fromURL: validateReferer(req.query.fromURL as string, serviceDomain),
     }),
     pageTitleHeading: pageTitle,
     zendeskFieldMaxLength: ZENDESK_FIELD_MAX_LENGTH,
@@ -398,9 +407,9 @@ export function contactUsQuestionsFormPostToSmartAgent(
       feedbackContact: req.body.contact === "true",
       questions: questions,
       themeQuestions: themeQuestions,
-      referer: validateReferer(req.body.referer),
-      ...(validateReferer(req.body.fromURL) && {
-        fromURL: validateReferer(req.body.fromURL),
+      referer: validateReferer(req.body.referer, serviceDomain),
+      ...(validateReferer(req.body.fromURL, serviceDomain) && {
+        fromURL: validateReferer(req.body.fromURL, serviceDomain),
       }),
       preferredLanguage: getPreferredLanguage(res.locals.language),
       securityCodeSentMethod: req.body.securityCodeSentMethod,
@@ -449,7 +458,7 @@ export function contactUsQuestionsFormPostToZendesk(
       feedbackContact: req.body.contact === "true",
       questions: questions,
       themeQuestions: themeQuestions,
-      referer: validateReferer(req.body.referer),
+      referer: validateReferer(req.body.referer, serviceDomain),
       securityCodeSentMethod: req.body.securityCodeSentMethod,
       identityDocumentUsed: req.body.identityDocumentUsed,
     });

--- a/src/components/contact-us/contact-us-service-smart-agent.ts
+++ b/src/components/contact-us/contact-us-service-smart-agent.ts
@@ -81,7 +81,9 @@ export function getSubthemeTag(themes: Themes): string {
 
 export function getRefererTag(contactForm: ContactForm): string {
   if (contactForm.fromURL) {
-    return `Referer obtained via Triage page fromURL: ${contactForm.fromURL}`;
+    return `Referer obtained via Triage page fromURL: ${decodeURIComponent(
+      contactForm.fromURL
+    )}`;
   } else if (contactForm.referer) {
     return contactForm.referer;
   } else {

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -15,11 +15,13 @@ import {
   getPreferredLanguage,
   contactUsGetFromTriagePage,
   setContactFormSubmissionUrlBasedOnClientName,
+  validateReferer,
 } from "../contact-us-controller";
 import {
   PATH_NAMES,
   SUPPORT_TYPE,
   ZENDESK_THEMES,
+  CONTACT_US_REFERER_ALLOWLIST,
 } from "../../../app.constants";
 import { RequestGet, ResponseRedirect } from "../../../types";
 
@@ -347,6 +349,44 @@ describe("appErrorCode and appSessionId query parameters", () => {
           "di-auth-stub-relying-party-production"
         )
       ).to.equal(PATH_NAMES.CONTACT_US_QUESTIONS);
+    });
+  });
+
+  describe("validateReferer", () => {
+    const serviceDomain = "account.gov.uk";
+    const validReferers = [
+      "https://app.staging.account.gov.uk",
+      "https://integration.account.gov.uk",
+      "https://account.gov.uk",
+    ];
+    const badReferers = ["https://app.staging.account.gov", "https://gov.uk"];
+    const referersWithoutScheme = [
+      "app.staging.account.gov.uk",
+      "account.gov.uk",
+    ];
+
+    it("should return the referer for all values in the allow list", () => {
+      CONTACT_US_REFERER_ALLOWLIST.forEach((item) => {
+        expect(validateReferer(item, serviceDomain)).to.equal(item);
+      });
+    });
+
+    it("should return the referer when the referer ends with the service domain", () => {
+      validReferers.forEach((item) => {
+        expect(validateReferer(item, serviceDomain)).to.equal(item);
+      });
+    });
+
+    it("should return an empty string when the referer does not end with the service domain", () => {
+      badReferers.forEach((item) => {
+        expect(validateReferer(item, serviceDomain)).to.equal("");
+      });
+    });
+
+    it("should throw if passed a referer that is not a URL", () => {
+      referersWithoutScheme.forEach((item) => {
+        expect(validateReferer(item, serviceDomain)).to.equal("");
+      });
     });
   });
 });

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -388,5 +388,14 @@ describe("appErrorCode and appSessionId query parameters", () => {
         expect(validateReferer(item, serviceDomain)).to.equal("");
       });
     });
+
+    it("should return the URL when it is encoded as a URI component", () => {
+      validReferers.forEach((item) => {
+        const encodedItem = encodeURIComponent(item);
+        expect(validateReferer(encodedItem, serviceDomain)).to.equal(
+          encodedItem
+        );
+      });
+    });
   });
 });

--- a/src/components/contact-us/tests/contact-us-service.test.ts
+++ b/src/components/contact-us/tests/contact-us-service.test.ts
@@ -64,5 +64,14 @@ describe("contact-us-service", () => {
 
       expect(getRefererTag(form)).to.equal("Referer not provided");
     });
+
+    it("should return the referer when the fromURL is encoded as a URI component", () => {
+      form.referer = "https://localhost:3000/enter-mfa";
+      form.fromURL = encodeURIComponent("https://localhost:3000/enter-email");
+
+      expect(getRefererTag(form)).to.equal(
+        "Referer obtained via Triage page fromURL: https://localhost:3000/enter-email"
+      );
+    });
   });
 });


### PR DESCRIPTION
## What?

This PR does three things: 

* Refactor `validateReferer` to receive the service domain as an argument and add unit tests (implemented in commit https://github.com/alphagov/di-authentication-frontend/pull/1184/commits/82d137814d340ffc87f91f8791d2ebbc77eb4e8a)
* Extend `validateReferer` to handle URLs that have been encoded as URI components (implemented in commit https://github.com/alphagov/di-authentication-frontend/pull/1184/commits/e211a0147b91a61748d8f7be8b0ac0ac553383ae)
* Decodes the referer before it is passed to SmartAgent (implemented in commit https://github.com/alphagov/di-authentication-frontend/pull/1184/commits/e0fcd72b19a6551d45e4d339962b424c9023d494)

## Why?

Because `validateReferer` is used to validate the `fromURL` query parameters we receive from the Triage Page. These are encoded as a URI components.