### PR TITLE
AUT-2029: Turn on the frame ancestor feature switch in production.

### DIFF
--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -20,4 +20,5 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
-dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables"
+dynatrace_secret_arn                     = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables"
+frame_ancestors_form_actions_csp_headers = "1"


### PR DESCRIPTION
## What?

Turn on the frame ancestor feature switch in production.

## Why?

We need to add the frame ancestors to our Content Security Policy headers for security reasons. 

## Change have been demonstrated

We have turned on the feature switch in all of the other environments without any problems.