### PR TITLE
AUT-2552: Add applied at timestamp to interventions response

### DIFF
--- a/src/components/account-intervention/types.ts
+++ b/src/components/account-intervention/types.ts
@@ -15,4 +15,5 @@ export interface AccountInterventionStatus extends DefaultApiResponse {
   passwordResetRequired: boolean;
   blocked: boolean;
   temporarilySuspended: boolean;
+  appliedAt: string;
 }

--- a/test/helpers/account-interventions-helpers.ts
+++ b/test/helpers/account-interventions-helpers.ts
@@ -11,8 +11,11 @@ export type AccountInterventionsFlags = {
 
 export const setupAccountInterventionsResponse = (
   baseApi: string,
-  flags: AccountInterventionsFlags
+  flags: AccountInterventionsFlags,
+  maybeDateTimeStamp?: string
 ) => {
+  const dateTimeStamp =
+    maybeDateTimeStamp === undefined ? nowDateTime() : maybeDateTimeStamp;
   nock(baseApi)
     .post(API_ENDPOINTS.ACCOUNT_INTERVENTIONS)
     .once()
@@ -21,7 +24,13 @@ export const setupAccountInterventionsResponse = (
       passwordResetRequired: flags.passwordResetRequired,
       blocked: flags.blocked,
       temporarilySuspended: flags.temporarilySuspended,
+      appliedAt: dateTimeStamp,
     });
+};
+
+const nowDateTime = () => {
+  const d = new Date();
+  return d.valueOf().toString();
 };
 
 export const noInterventions: AccountInterventionsFlags = {
@@ -36,7 +45,7 @@ export function accountInterventionsFakeHelper(
   blocked: boolean,
   temporarilySuspended: boolean
 ) {
-  const fakeAccountInterventionsService: AccountInterventionsInterface = {
+  return {
     accountInterventionStatus: sinon.fake.returns({
       data: {
         email: email,
@@ -46,5 +55,4 @@ export function accountInterventionsFakeHelper(
       },
     }),
   } as unknown as AccountInterventionsInterface;
-  return fakeAccountInterventionsService;
 }


### PR DESCRIPTION
This updates the response we're expecting from the account interventions service in the frontend api to add the timestamp that the intervention was applied at.

This field is currently unused, but will be used as part of the logic to ensure that a user who has just reset their password is not made to go through the reset password journey twice.

Note that the relevant change has not yet been made to the API, but adding an additional field here which is not returned is harmless as we do not do any validation on this and there are no runtime type checks. We can merge this first, and then update the response from the frontend api.

## How to review

1. Code Review
2. (If you like, I have already tested this) Run this locally, pointing at build for the backend. Set yourself up with an account intervention (e.g. blocked) in the database. Go through a sign in journey, and get to a blocked screen without encountering an error (should have no effect on the journey). I can help you set yourself up - just ping me