### PR TITLE
AUT-3725: Redirect to error page if enter password response returns m…

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -15,7 +15,7 @@ import {
 } from "../common/constants";
 import { BadRequestError, ReauthJourneyError } from "../../utils/error";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine";
-import { JOURNEY_TYPE, MFA_METHOD_TYPE } from "../../app.constants";
+import { JOURNEY_TYPE, MFA_METHOD_TYPE, PATH_NAMES } from "../../app.constants";
 import xss from "xss";
 import { EnterEmailServiceInterface } from "../enter-email/types";
 import { enterEmailService } from "../enter-email/enter-email-service";
@@ -130,6 +130,13 @@ export function enterPasswordPost(
         errorCode === ERROR_CODES.RE_AUTH_SIGN_IN_DETAILS_ENTERED_EXCEEDED
       ) {
         return handleMaxCredentialsReached(errorCode, journeyType, res, req);
+      }
+
+      if (errorCode === ERROR_CODES.SESSION_ID_MISSING_OR_INVALID) {
+        req.log.warn(
+          `Backend session is missing or invalid - user cannot enter password. Session id ${sessionId}`
+        );
+        return res.redirect(PATH_NAMES.ERROR_PAGE);
       }
 
       let validationKey;

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -135,6 +135,31 @@ describe("enter password controller", () => {
           JOURNEY_TYPE.REAUTHENTICATION
         );
       });
+
+      it("should redirect to error page when backend responds indicating session missing or invalid", async () => {
+        const fakePasswordService: EnterPasswordServiceInterface = {
+          loginUser: sinon.fake.returns({
+            success: false,
+            data: {
+              code: ERROR_CODES.SESSION_ID_MISSING_OR_INVALID,
+            },
+          }),
+        } as unknown as EnterPasswordServiceInterface;
+
+        const fakeMfaService: MfaServiceInterface = {
+          sendMfaCode: sinon.fake.returns({
+            success: true,
+          }),
+        } as unknown as MfaServiceInterface;
+
+        await enterPasswordPost(
+          false,
+          fakePasswordService,
+          fakeMfaService
+        )(req as Request, res as Response);
+
+        expect(res.redirect).to.have.calledWith(PATH_NAMES.ERROR_PAGE);
+      });
     });
 
     it("can send the journeyType when sending the password", async () => {


### PR DESCRIPTION
…issing or invalid session

This error response means that we cannot continue. However, at the moment we fall through to the default error behaviour, which is to reload the page with a validation error, making it seem like the user entered the incorrect password.

This handles an edge case in reauthentication whereby the user is logged in in two tabs, starts a reauth journey in another up until the point of entering a password, and then logs out in the first tab. At this point, they will enter an infinite loop of seeming password validation errors regardless of password, whereas in fact the backend is totally unable to proceed.

It's also possible to replicate this in the signin journey, although you have to be very specific with timings.

Currently, redirecting to the error page will return a 500 status. This particular case (a user has logged off) does not actually indicate a server error. We can choose to update this later if this causes an issue.

## How to review

Deploy to a test environment and:

* Log in on two tabs in the same browser
* Start a reauth journey in one and enter email
* Logout in the second tab
* See that whatever password you enter in your reauth journey, you hit an error page

You can compare to the behaviour in staging.