### PR TITLE
AUT-3772 - Reuse old env auth encryption kms key in new frontend instance

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -517,11 +517,6 @@ Resources:
               Value: GTM-TK92W68
             - Name: SUPPORT_AUTHORIZE_CONTROLLER
               Value: 1
-            - Name: ENCRYPTION_KEY_ID
-              Value: !If
-                - UseSubEnvironment
-                - !Sub "alias/${SubEnvironment}-authentication-encryption-key-alias"
-                - !Sub "alias/${Environment}-authentication-encryption-key-alias"
             - Name: ORCH_TO_AUTH_SIGNING_KEY
               Value: !If
                 - UseSubEnvironment
@@ -600,6 +595,11 @@ Resources:
                 - UseSubEnvironment
                 - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${SubEnvironment}/frontend-api-key"
                 - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/${Environment}/frontend-api-key"
+            - Name: ENCRYPTION_KEY_ID
+              ValueFrom: !If
+                - UseSubEnvironment
+                - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/deploy/${SubEnvironment}/authentication-encryption-key-id"
+                - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/deploy/${Environment}/authentication-encryption-key-id"
             - Name: REDIS_HOST
               ValueFrom: !If
                 - UseSubEnvironment
@@ -825,8 +825,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - kms:Decrypt*
-                Resource:
-                  - !GetAtt AuthEncryptionKmsKey.Arn
+                Resource: !Sub
+                  - '{{resolve:secretsmanager:/deploy/${env}/authentication-encryption-key-id}}'
+                  - env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       PermissionsBoundary: !If
         - UsePermissionsBoundary
         - !Ref PermissionsBoundary
@@ -1566,40 +1567,6 @@ Resources:
   #
   # Encryption
   #
-
-  AuthEncryptionKmsKey:
-    Type: AWS::KMS::Key
-    Properties:
-      Description: "KMS encryption key for decrypting requests from Orchestration"
-      KeyUsage: "ENCRYPT_DECRYPT"
-      KeySpec: "RSA_2048"
-      KeyPolicy:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - kms:*
-            Resource: "*"
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-AuthEncryptionKmsKey"
-        - Key: Environment
-          Value: !Ref Environment
-        - Key: Application
-          Value: "auth-frontend"
-        - Key: Source
-          Value: govuk-one-login/authentication-frontend/cloudformation/deploy/template.yaml
-
-  AuthEncryptionKmsAlias:
-    Type: AWS::KMS::Alias
-    Properties:
-      AliasName: !If
-        - UseSubEnvironment
-        - !Sub "alias/${SubEnvironment}-authentication-encryption-key-alias"
-        - !Sub "alias/${Environment}-authentication-encryption-key-alias"
-      TargetKeyId: !Ref AuthEncryptionKmsKey
 
   KmsKey:
     Type: AWS::KMS::Key


### PR DESCRIPTION
## What

Reuse old env auth encryption kms key in new frontend instance
Issue: [AUT-3772]

<!-- Describe what you have changed and why -->

## How to review

Successful redirect from orchstub to auth frontend, dependent on https://github.com/govuk-one-login/authentication-stubs/pull/36 changes to be applied to the stub

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->


[AUT-3772]: https://govukverify.atlassian.net/browse/AUT-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ