### PR TITLE
AUT-3690: Fix typo in FrontendDnsRecord route53 hosted zone SSM reference

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -1050,7 +1050,7 @@ Resources:
         - "signin-sp.account.gov.uk"
       Type: A
       HostedZoneId: !Sub
-        - "{{resolve:ssm:/deploy/${env}/signin_route53_hostedzone_id}}"
+        - "{{resolve:ssm:/deploy/${env}/signin-sp_route53_hostedzone_id}}"
         - env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
       AliasTarget:
         EvaluateTargetHealth: false


### PR DESCRIPTION
## What

Fix typo in FrontendDnsRecord route53 hosted zone SSM reference
Issue: [AUT-3690]



[AUT-3690]: https://govukverify.atlassian.net/browse/AUT-3690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ