### PR TITLE
BAU: Add script to deploy to dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,22 @@ You may need to install pre-commit for the script to work.
 brew install pre-commit
 ```
 
+## Deploying the frontend
+
+The frontend is automatically released when you merge a PR.
+
+However, sometimes, you may want to manually trigger a release to an environment, e.g. for testing reasons. The following scripts are available for this:
+
+- `deploy-authdevs.sh` (you'll be asked which authdev to deploy to when you run the script)
+- `deploy-dev.sh`
+- `deploy-sandpit.sh`
+
+To run the scripts, you'll need to have the AWS profile for the specified environment (see script), along with the `digital-identity-tools-dev-admin` profile.
+
+You also need to have Terraform installed (see [here](https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli) for Homebrew installation instructions).
+
+Running the script will build and release your local working copy of the frontend code to the requested environment.
+
 ## Troubleshooting the local run
 
 ### General steps to try first

--- a/ci/terraform/dev.hcl
+++ b/ci/terraform/dev.hcl
@@ -1,0 +1,5 @@
+bucket         = "di-auth-development-tfstate"
+key            = "frontend-dev-terraform.tfstate"
+dynamodb_table = "di-auth-dev-tfstate-locking"
+encrypt        = true
+region         = "eu-west-2"

--- a/ci/terraform/nonprod-common.tfvars
+++ b/ci/terraform/nonprod-common.tfvars
@@ -1,7 +1,3 @@
 service_down_page         = false
 service_down_image_uri    = "706615647326.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository"
 service_down_image_digest = "sha256:2376c76ae4ae05320319752df0bc6d69ef4836e9d66e5c78f941edf42c087f10"
-
-smartagent_api_key    = ""
-smartagent_api_url    = ""
-smartagent_webform_id = ""

--- a/ci/terraform/variables.tf
+++ b/ci/terraform/variables.tf
@@ -117,15 +117,18 @@ variable "logging_endpoint_arns" {
 }
 
 variable "smartagent_webform_id" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "smartagent_api_key" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "smartagent_api_url" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "url_for_support_links" {

--- a/deploy-dev.sh
+++ b/deploy-dev.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+export DEPLOY_ENV="dev"
+export AWS_PROFILE="di-auth-development-admin"
+
+# shellcheck source=scripts/dev_deploy_common.sh
+source "${DIR}/scripts/dev_deploy_common.sh"

--- a/scripts/read_secrets__main.sh
+++ b/scripts/read_secrets__main.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 set -euo pipefail
 
 [[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
@@ -27,3 +26,8 @@ while IFS=$'\t' read -r arn name; do
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
 done <<<"${secrets}"
+
+if [ "${TF_VAR_basic_auth_password:-}" = "none" ]; then
+  export TF_VAR_basic_auth_username=""
+  export TF_VAR_basic_auth_password=""
+fi


### PR DESCRIPTION
## What

Currently, deploying the frontend means running a pipeline that also deploys all of the APIs. That takes a while (~20 mins) and deploys the frontend last, so turnaround is slow if you just want to test in a hosted environment quickly.

We already had scripts for deploying to authdevs and sandpit. This change adds a new script for deploying to the dev environment.

## How to review

1. Code Review

## Checklist

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [x] Documentation has been updated to reflect these changes.