### PR TITLE
AUT-3946: Disable UA_ENABLED (Universal Analytics) flag everywhere

### DIFF
--- a/ci/terraform/authdev1.tfvars
+++ b/ci/terraform/authdev1.tfvars
@@ -55,5 +55,5 @@ orch_stub_to_auth_audience           = "https://signin.authdev1.sandpit.account.
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
 
-ua_enabled              = "true"
+ua_enabled              = "false"
 analytics_cookie_domain = ".sandpit.account.gov.uk"

--- a/ci/terraform/authdev2.tfvars
+++ b/ci/terraform/authdev2.tfvars
@@ -50,7 +50,7 @@ orch_stub_to_auth_audience           = "https://signin.authdev2.sandpit.account.
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
 
-ua_enabled              = "true"
+ua_enabled              = "false"
 analytics_cookie_domain = ".sandpit.account.gov.uk"
 
 ip_endpoint_rate_limiting_configuration = [

--- a/ci/terraform/build.tfvars
+++ b/ci/terraform/build.tfvars
@@ -44,5 +44,5 @@ cloudfront_auth_frontend_enabled = true
 cloudfront_auth_dns_enabled      = true
 cloudfront_WafAcl_Logdestination = "csls_cw_logs_destination_prodpython"
 
-ua_enabled              = "true"
+ua_enabled              = "false"
 analytics_cookie_domain = ".build.account.gov.uk"

--- a/ci/terraform/integration.tfvars
+++ b/ci/terraform/integration.tfvars
@@ -40,5 +40,5 @@ orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CA
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.integration.account.gov.uk/"
 
-ua_enabled              = "true"
+ua_enabled              = "false"
 analytics_cookie_domain = ".integration.account.gov.uk"

--- a/ci/terraform/production.tfvars
+++ b/ci/terraform/production.tfvars
@@ -42,7 +42,7 @@ orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CA
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.account.gov.uk/"
 
-ua_enabled                           = "true"
+ua_enabled                           = "false"
 universal_analytics_gtm_container_id = "GTM-TT5HDKV"
 ga4_enabled                          = "true"
 google_analytics_4_gtm_container_id  = "GTM-K4PBJH3"

--- a/ci/terraform/sandpit.tfvars
+++ b/ci/terraform/sandpit.tfvars
@@ -50,5 +50,5 @@ logging_endpoint_arns = [
 
 dynatrace_secret_arn = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
 
-ua_enabled              = "true"
+ua_enabled              = "false"
 analytics_cookie_domain = ".sandpit.account.gov.uk"

--- a/ci/terraform/staging.tfvars
+++ b/ci/terraform/staging.tfvars
@@ -43,7 +43,7 @@ orch_to_auth_signing_public_key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CA
 orch_to_auth_client_id          = "orchestrationAuth"
 orch_to_auth_audience           = "https://signin.staging.account.gov.uk/"
 
-ua_enabled                           = "true"
+ua_enabled                           = "false"
 universal_analytics_gtm_container_id = "GTM-TK92W68"
 ga4_enabled                          = "true"
 google_analytics_4_gtm_container_id  = "GTM-KD86CMZ"

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -896,7 +896,7 @@ Resources:
             - Name: GA4_ENABLED
               Value: false
             - Name: UA_ENABLED
-              Value: true
+              Value: false
             - Name: UNIVERSAL_ANALYTICS_GTM_CONTAINER_ID
               Value: GTM-TK92W68
             - Name: GOOGLE_ANALYTICS_4_GTM_CONTAINER_ID

--- a/scripts/_create_env_file.py
+++ b/scripts/_create_env_file.py
@@ -130,7 +130,7 @@ DEFAULT_USER_VARIABLES: list[EnvFileSection] = [
                 "comment": "GA4 Enablement",
             },
             "UA_ENABLED": {
-                "value": "true",
+                "value": "false",
                 "comment": "Univeral Analytics",
             },
             "UNIVERSAL_ANALYTICS_GTM_CONTAINER_ID": {


### PR DESCRIPTION
## What

Update config files everywhere to disable the `UA_ENABLED` flag. UA events no longer get fired.

There's a question over whether we actually _want_ to do this here:
https://govukverify.atlassian.net/browse/AUT-3964?focusedCommentId=195614
(it looks like it removes quite a few events that we potentially rely on)

## How to review

1. Code Review

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.