### PR TITLE
AUT-3884: Change 'appliedAt' to handle number, not string

### DIFF
--- a/src/components/account-intervention/types.ts
+++ b/src/components/account-intervention/types.ts
@@ -16,6 +16,6 @@ export interface AccountInterventionStatus extends DefaultApiResponse {
   passwordResetRequired: boolean;
   blocked: boolean;
   temporarilySuspended: boolean;
-  appliedAt: string;
+  appliedAt: number;
   reproveIdentity: boolean;
 }

--- a/src/utils/interventions.ts
+++ b/src/utils/interventions.ts
@@ -17,6 +17,6 @@ export function passwordHasBeenResetMoreRecentlyThanInterventionApplied(
 ): boolean {
   return (
     req.session.user.passwordResetTime !== undefined &&
-    req.session.user.passwordResetTime > parseInt(status.appliedAt)
+    req.session.user.passwordResetTime > status.appliedAt
   );
 }

--- a/test/helpers/account-interventions-helpers.ts
+++ b/test/helpers/account-interventions-helpers.ts
@@ -13,7 +13,7 @@ export type AccountInterventionsFlags = {
 export const setupAccountInterventionsResponse = (
   baseApi: string,
   flags: AccountInterventionsFlags,
-  maybeDateTimeStamp?: string
+  maybeDateTimeStamp?: number
 ): void => {
   const dateTimeStamp =
     maybeDateTimeStamp === undefined ? nowDateTime() : maybeDateTimeStamp;
@@ -31,7 +31,7 @@ export const setupAccountInterventionsResponse = (
 
 const nowDateTime = () => {
   const d = new Date();
-  return d.valueOf().toString();
+  return d.valueOf();
 };
 
 export const noInterventions: AccountInterventionsFlags = {
@@ -43,7 +43,7 @@ export const noInterventions: AccountInterventionsFlags = {
 
 export function accountInterventionsFakeHelper(
   flags: AccountInterventionsFlags,
-  maybeDateTimeStamp?: string
+  maybeDateTimeStamp?: number
 ): AccountInterventionsInterface {
   const dateTimeStamp =
     maybeDateTimeStamp === undefined ? nowDateTime() : maybeDateTimeStamp;

--- a/test/unit/middleware/account-interventions-middleware.test.ts
+++ b/test/unit/middleware/account-interventions-middleware.test.ts
@@ -161,7 +161,7 @@ describe("accountInterventionsMiddleware", () => {
               temporarilySuspended: true,
               reproveIdentity: false,
             },
-            nowUnixTime.toString()
+            nowUnixTime
           );
 
         await callMiddleware(
@@ -188,7 +188,7 @@ describe("accountInterventionsMiddleware", () => {
               temporarilySuspended: true,
               reproveIdentity: false,
             },
-            beforeNow.toString()
+            beforeNow
           );
 
         await callMiddleware(


### PR DESCRIPTION
## What

Updating the front-end model of `appliedAt` to match the updated backend.

It's safe to release the backend without this change as we'd just pass a `number` into `parseInt`, which still works correctly.

More context on this PR here:
https://github.com/govuk-one-login/authentication-api/pull/5865

## How to review

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
    * [ ] Ensure that the case where a password was recently changed is still blocked

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/5865