### PR TITLE
AUT-4112: Add /ipv-callback as optional path from /auth-code

### DIFF
--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -711,6 +711,9 @@ const authStateMachine = createMachine(
             PATH_NAMES.UNAVAILABLE_TEMPORARY,
           ],
         },
+        meta: {
+          optionalPaths: [PATH_NAMES.PROVE_IDENTITY_CALLBACK],
+        },
       },
       [PATH_NAMES.SECURITY_CODE_CHECK_TIME_LIMIT]: {
         on: {

--- a/src/components/prove-identity-callback/tests/prove-identity-callback-integration.test.ts
+++ b/src/components/prove-identity-callback/tests/prove-identity-callback-integration.test.ts
@@ -1,0 +1,92 @@
+import { PATH_NAMES } from "../../../app.constants";
+import { describe } from "mocha";
+import { request, sinon } from "../../../../test/utils/test-utils";
+import express, { NextFunction, Request, Response } from "express";
+import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper";
+import decache from "decache";
+import { IdentityProcessingStatus } from "../types";
+
+describe("Integration: prove identity callback", () => {
+  let app: express.Application;
+
+  describe("permission to visit /ipv-callback", () => {
+    it(`should allow visit to /ipv-callback when was on /auth-code`, async () => {
+      // arrange
+      const redirectPath = "https://test.example.com";
+      app = await stubMiddlewareAndCreateApp(
+        PATH_NAMES.AUTH_CODE,
+        redirectPath
+      );
+
+      // act
+      await request(app, (test) =>
+        test
+          .get(PATH_NAMES.PROVE_IDENTITY_CALLBACK)
+          // assert
+          .expect(302)
+          .expect("Location", redirectPath)
+      );
+    });
+
+    it("should redirect when not on permitted journey to /ipv-callback", async () => {
+      // arrange
+      const startingPage = PATH_NAMES.ROOT;
+      app = await stubMiddlewareAndCreateApp(startingPage);
+
+      // act
+      await request(app, (test) =>
+        test
+          .get(PATH_NAMES.PROVE_IDENTITY_CALLBACK)
+          // assert
+          .expect(302)
+          .expect("Location", startingPage)
+      );
+    });
+  });
+});
+
+const stubMiddlewareAndCreateApp = async (
+  previousPath: string,
+  redirectPath?: string
+) => {
+  decache("../../../app");
+
+  decache("../../../middleware/session-middleware");
+  const sessionMiddleware = require("../../../middleware/session-middleware");
+  sinon
+    .stub(sessionMiddleware, "validateSessionMiddleware")
+    .callsFake(function (
+      req: Request,
+      res: Response,
+      next: NextFunction
+    ): void {
+      res.locals.sessionId = "testSessionId";
+      res.locals.clientSessionId = "testClientSessionId";
+      res.locals.persistentSessionId = "testPersistentSessionId";
+
+      req.session.client = {
+        name: "testClientName",
+      };
+      req.session.user = {
+        email: "test@test.com",
+        journey: getPermittedJourneyForPath(previousPath),
+      };
+
+      next();
+    });
+
+  if (redirectPath) {
+    decache("../prove-identity-callback-service");
+    const proveIdentityCallbackServiceFile = require("../prove-identity-callback-service");
+    sinon
+      .stub(proveIdentityCallbackServiceFile, "proveIdentityCallbackService")
+      .returns({
+        processIdentity: sinon.fake.resolves({
+          data: { status: IdentityProcessingStatus.COMPLETED },
+        }),
+        generateSuccessfulRpReturnUrl: sinon.fake.resolves(redirectPath),
+      });
+  }
+
+  return await require("../../../app").createApp();
+};


### PR DESCRIPTION
## What

Setting us up for some future work in AUT-4113.

Currently, (1) users visit `/prove-identity`, (2) redirect to IPV, (3) then visit `/ipv-callback`.

In the new flow, (1) they'll visit `/auth-code`, (2) redirect to IPV, (3) then visit `/ipc-callback`. So we need to allow (1) to (3) as an optional route.

This ticket adds it as an optional path and adds some tests to make sure it's accessible from the right places.

## How to review

1. Code Review

It won't be possible to test until AUT-4113 is complete (sending you to `/auth-code` rather than `/prove-identity`)