### PR TITLE
AUT-3775: Remove suspect-unauthorised-access feature flag

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -958,8 +958,6 @@ Resources:
               Value: !If [UseMfaResetWithIpv, "1", "0"]
             - Name: ROUTE_USERS_TO_NEW_IPV_JOURNEY
               Value: !If [UseRouteUsersToNewIpvJourney, "1", "0"]
-            - Name: CONTACT_US_SUSPECT_UNAUTHORISED_ACCESS
-              Value: !If [IsNotProduction, "1", "0"]
           Secrets:
             - Name: API_KEY
               ValueFrom: !If

--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -12,7 +12,6 @@ import { ExpressRouteFunc } from "../../types";
 import crypto from "crypto";
 import { logger } from "../../utils/logger";
 import {
-  contactUsSuspectUnauthorisedAccess,
   getServiceDomain,
   getSupportLinkUrl,
   supportMfaResetWithIpv,
@@ -143,7 +142,6 @@ export function contactUsGet(req: Request, res: Response): void {
     ...(getAppSessionId(req.query.appSessionId as string) && {
       appSessionId: getAppSessionId(req.query.appSessionId as string),
     }),
-    contactUsSuspectUnauthorisedAccess: contactUsSuspectUnauthorisedAccess(),
   };
 
   return res.render("contact-us/index-public-contact-us.njk", options);

--- a/src/components/contact-us/index-public-contact-us.njk
+++ b/src/components/contact-us/index-public-contact-us.njk
@@ -80,10 +80,6 @@
         }
     ] %}
 
-    {% if not contactUsSuspectUnauthorisedAccess %}
-        {% set items = items.slice(0, 6).concat(items.slice(7)) %}
-    {% endif %}
-
     {{ govukRadios({
         name: "theme",
         fieldset: {

--- a/src/components/contact-us/tests/__snapshots__/contact-us-controller-integration.test.ts.snap
+++ b/src/components/contact-us/tests/__snapshots__/contact-us-controller-integration.test.ts.snap
@@ -1,38 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Integration:: contact us - public user rendering correct theme options should return all options except SUSPECT_UNAUTHORISED_ACCESS when CONTACT_US_SUSPECT_UNAUTHORISED_ACCESS is '0' 1`] = `
-Object {
-  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
-  "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": "feedback",
-  "taxonomyLevel3": "",
-  "taxonomyLevel4": "",
-  "taxonomyLevel5": "",
-}
-`;
-
-exports[`Integration:: contact us - public user rendering correct theme options should return all options except SUSPECT_UNAUTHORISED_ACCESS when CONTACT_US_SUSPECT_UNAUTHORISED_ACCESS is 'undefined' 1`] = `
-Object {
-  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
-  "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": "feedback",
-  "taxonomyLevel3": "",
-  "taxonomyLevel4": "",
-  "taxonomyLevel5": "",
-}
-`;
-
-exports[`Integration:: contact us - public user rendering correct theme options should return all options when CONTACT_US_SUSPECT_UNAUTHORISED_ACCESS is '1' 1`] = `
-Object {
-  "contentId": "e08d04e6-b24f-4bad-9955-1eb860771747",
-  "taxonomyLevel1": "authentication",
-  "taxonomyLevel2": "feedback",
-  "taxonomyLevel3": "",
-  "taxonomyLevel4": "",
-  "taxonomyLevel5": "",
-}
-`;
-
 exports[`Integration:: contact us - public user should return contact us further information account creation page 1`] = `
 Object {
   "contentId": "a06d6387-d411-47db-8f7d-88871286330b",

--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -74,57 +74,6 @@ describe("Integration:: contact us - public user", () => {
     );
   };
 
-  describe("rendering correct theme options", () => {
-    it("should return all options when CONTACT_US_SUSPECT_UNAUTHORISED_ACCESS is '1'", async () => {
-      process.env.CONTACT_US_SUSPECT_UNAUTHORISED_ACCESS = "1";
-
-      await request(app, (test) =>
-        test
-          .get(PATH_NAMES.CONTACT_US)
-          .expect(200)
-          .expect((res) => {
-            const $ = cheerio.load(res.text);
-            expect($("input[name=theme]").length).to.equal(9);
-            expect($("input[value=account_creation]").length).to.equal(1);
-            expect($("input[value=signing_in]").length).to.equal(1);
-            expect($("input[value=id_check_app]").length).to.equal(1);
-            expect($("input[value=id_face_to_face]").length).to.equal(1);
-            expect($("input[value=proving_identity]").length).to.equal(1);
-            expect($("input[value=email_subscriptions]").length).to.equal(1);
-            expect(
-              $("input[value=suspect_unauthorised_access]").length
-            ).to.equal(1);
-            expect($("input[value=something_else]").length).to.equal(1);
-            expect($("input[value=suggestions_feedback]").length).to.equal(1);
-          })
-      );
-    });
-
-    ["0", undefined].forEach((envVar) => {
-      it(`should return all options except SUSPECT_UNAUTHORISED_ACCESS when CONTACT_US_SUSPECT_UNAUTHORISED_ACCESS is '${envVar}'`, async () => {
-        process.env.CONTACT_US_SUSPECT_UNAUTHORISED_ACCESS = envVar;
-
-        await request(app, (test) => test.get(PATH_NAMES.CONTACT_US))
-          .expect(200)
-          .expect((res) => {
-            const $ = cheerio.load(res.text);
-            expect($("input[name=theme]").length).to.equal(8);
-            expect($("input[value=account_creation]").length).to.equal(1);
-            expect($("input[value=signing_in]").length).to.equal(1);
-            expect($("input[value=id_check_app]").length).to.equal(1);
-            expect($("input[value=id_face_to_face]").length).to.equal(1);
-            expect($("input[value=proving_identity]").length).to.equal(1);
-            expect($("input[value=email_subscriptions]").length).to.equal(1);
-            expect(
-              $("input[value=suspect_unauthorised_access]").length
-            ).to.equal(0);
-            expect($("input[value=something_else]").length).to.equal(1);
-            expect($("input[value=suggestions_feedback]").length).to.equal(1);
-          });
-      });
-    });
-  });
-
   it("should return contact us page", async () => {
     await request(app, (test) =>
       test.get(PATH_NAMES.CONTACT_US).query("supportType=PUBLIC").expect(200)

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -59,10 +59,6 @@ describe("contact us controller", () => {
   });
 
   describe("contactUsGet", () => {
-    before(() => {
-      process.env.CONTACT_US_SUSPECT_UNAUTHORISED_ACCESS = "1";
-    });
-
     it("should render contact us gov page if gov radio option was chosen", () => {
       req.query.supportType = SUPPORT_TYPE.GOV_SERVICE;
       contactUsGet(req as Request, res as Response);
@@ -93,7 +89,6 @@ describe("contact us controller", () => {
           referer: "",
           fromURL: undefined,
           hrefBack: PATH_NAMES.CONTACT_US,
-          contactUsSuspectUnauthorisedAccess: true,
         }
       );
     });
@@ -112,7 +107,6 @@ describe("contact us controller", () => {
           referer: encodeURIComponent(REFERER),
           fromURL: fromUrlEncoded,
           hrefBack: `${PATH_NAMES.CONTACT_US}?fromURL=${fromUrlEncoded}`,
-          contactUsSuspectUnauthorisedAccess: true,
         }
       );
     });
@@ -137,7 +131,6 @@ describe("contact us controller", () => {
             referer: "",
             fromURL: undefined,
             hrefBack: PATH_NAMES.CONTACT_US,
-            contactUsSuspectUnauthorisedAccess: true,
           }
         );
       });

--- a/src/config.ts
+++ b/src/config.ts
@@ -195,7 +195,3 @@ export function routeUsersToNewIpvJourney(): boolean {
 export function showTestBanner(): boolean {
   return getAppEnv() !== "production" || process.env.SHOW_TEST_BANNER === "1";
 }
-
-export function contactUsSuspectUnauthorisedAccess(): boolean {
-  return process.env.CONTACT_US_SUSPECT_UNAUTHORISED_ACCESS === "1";
-}


### PR DESCRIPTION
## What

This PR can be merged in once testing of AUT-3775 is complete. It enables the "suspect-unauthorised-access" form on production by removing the feature flag wrapped around it.

This reverts commit 7c80fda9608a7e1c8341c2220a6ac6ae77eebaf9.

## How to review

1. Code Review

## Checklist

- [x] A UCD review has been performed
- [x] A QA review has been performed
- [ ] A UAT review has been performed by the Home team
- [ ] Remaining blockers resolved [here](https://govukverify.atlassian.net/browse/AUT-3775?focusedCommentId=208316)