### PR TITLE
AUT-4118: Fix "Back" link from some contact form pages

### DIFF
--- a/src/components/contact-us/contact-us-controller.ts
+++ b/src/components/contact-us/contact-us-controller.ts
@@ -180,7 +180,10 @@ export function prepareBackLink(
     } else {
       hrefBack = PATH_NAMES.CONTACT_US;
     }
-  } else if (req.path.endsWith(PATH_NAMES.CONTACT_US_QUESTIONS)) {
+  } else if (
+    req.path.endsWith(PATH_NAMES.CONTACT_US_QUESTIONS) &&
+    !!req.query.subtheme
+  ) {
     hrefBack = PATH_NAMES.CONTACT_US_FURTHER_INFORMATION;
   } else {
     hrefBack = PATH_NAMES.CONTACT_US;

--- a/src/components/contact-us/tests/contact-us-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller.test.ts
@@ -507,11 +507,19 @@ describe("prepareBackLink", () => {
     ).to.equal(supportLinkURL);
   });
 
-  it("should return the CONTACT_US_FURTHER_INFORMATION path when the req.path ends with the CONTACT_US_QUESTIONS path", () => {
+  it("should return the CONTACT_US_FURTHER_INFORMATION path when the req.path ends with the CONTACT_US_QUESTIONS path and has req.query.subtheme", () => {
     req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
+    req.query.subtheme = "testSubtheme";
     expect(
       prepareBackLink(req as Request, supportLinkURL, serviceDomain)
     ).to.equal(PATH_NAMES.CONTACT_US_FURTHER_INFORMATION);
+  });
+
+  it("should return the CONTACT_US path when the req.path ends with the CONTACT_US_QUESTIONS path and doesn't have req.query.subtheme", () => {
+    req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
+    expect(
+      prepareBackLink(req as Request, supportLinkURL, serviceDomain)
+    ).to.equal(PATH_NAMES.CONTACT_US);
   });
 
   it("should return the supportLinkURL with a fromURL parameter when one is included in the req.url", () => {

--- a/src/components/contact-us/tests/contact-us-questions-controller.test.ts
+++ b/src/components/contact-us/tests/contact-us-questions-controller.test.ts
@@ -80,7 +80,7 @@ describe("contact us questions controller", () => {
               formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
               theme: theme,
               subtheme: undefined,
-              backurl: `${PATH_NAMES.CONTACT_US_FURTHER_INFORMATION}?theme=${theme}`,
+              backurl: `${PATH_NAMES.CONTACT_US}?theme=${theme}`,
               supportMfaResetWithIpv: false,
               referer: encodeURIComponent(REFERER),
               pageTitleHeading: `pages.contactUsQuestions.${translationKey}.title`,
@@ -132,7 +132,7 @@ describe("contact us questions controller", () => {
         {
           radioButtonText: "Something else",
           subTheme: CONTACT_US_THEMES.SOMETHING_ELSE,
-          translationKey: "accountCreation", // TODO - AUT-4118 - I think this should be accountCreationProblem instead
+          translationKey: "accountCreation",
         },
       ].forEach(({ radioButtonText, subTheme, translationKey }) => {
         it(`should render ${PATH_NAMES.CONTACT_US_QUESTIONS} if '${radioButtonText}' radio option as chosen`, () => {
@@ -199,7 +199,7 @@ describe("contact us questions controller", () => {
         {
           radioButtonText: "Something else",
           subTheme: CONTACT_US_THEMES.SOMETHING_ELSE,
-          translationKey: "anotherProblem", // TODO - AUT-4118 - I think this should be signignInProblem instead (yes, with the typo)
+          translationKey: "anotherProblem",
         },
       ].forEach(({ radioButtonText, subTheme, translationKey }) => {
         it(`should render ${PATH_NAMES.CONTACT_US_QUESTIONS} if '${radioButtonText}' radio option as chosen`, () => {
@@ -231,27 +231,40 @@ describe("contact us questions controller", () => {
       });
     });
 
-    // TODO - AUT-4118 - Make this, and other, tests check if content has been rendered to the page
-    it("should render contact-us-questions if a 'A problem proving your identity' radio option was chosen", () => {
-      req.query.theme = CONTACT_US_THEMES.PROVING_IDENTITY;
-      req.headers.referer = REFERER;
-      req.query.referer = REFERER;
-      req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
-      contactUsQuestionsGet(req as Request, res as Response);
+    describe("from /contact-us-further-information proving_identity", () => {
+      [
+        {
+          radioButtonText: "Something else",
+          subTheme: CONTACT_US_THEMES.PROVING_IDENTITY_SOMETHING_ELSE,
+          translationKey: "provingIdentitySomethingElse",
+        },
+      ].forEach(({ radioButtonText, subTheme, translationKey }) => {
+        it(`should render ${PATH_NAMES.CONTACT_US_QUESTIONS} if '${radioButtonText}' radio option as chosen`, () => {
+          req.query.theme = CONTACT_US_THEMES.PROVING_IDENTITY;
+          req.query.subtheme = subTheme;
+          req.headers.referer = REFERER;
+          req.query.referer = REFERER;
+          req.path = PATH_NAMES.CONTACT_US_QUESTIONS;
+          contactUsQuestionsGet(req as Request, res as Response);
 
-      expect(res.render).to.have.calledWith("contact-us/questions/index.njk", {
-        formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
-        theme: "proving_identity",
-        subtheme: undefined,
-        backurl: `/contact-us-further-information?theme=${CONTACT_US_THEMES.PROVING_IDENTITY}`,
-        supportMfaResetWithIpv: false,
-        referer: encodeURIComponent(REFERER),
-        pageTitleHeading: "pages.contactUsQuestions.provingIdentity.title",
-        contactUsFieldMaxLength: CONTACT_US_FIELD_MAX_LENGTH,
-        contactCountryMaxLength: CONTACT_US_COUNTRY_MAX_LENGTH,
-        appErrorCode: "",
-        appSessionId: "",
-        contentId: "",
+          expect(res.render).to.have.calledWith(
+            "contact-us/questions/index.njk",
+            {
+              formSubmissionUrl: PATH_NAMES.CONTACT_US_QUESTIONS,
+              theme: CONTACT_US_THEMES.PROVING_IDENTITY,
+              subtheme: subTheme,
+              backurl: `${PATH_NAMES.CONTACT_US_FURTHER_INFORMATION}?theme=${CONTACT_US_THEMES.PROVING_IDENTITY}`,
+              supportMfaResetWithIpv: false,
+              referer: encodeURIComponent(REFERER),
+              pageTitleHeading: `pages.contactUsQuestions.${translationKey}.title`,
+              contactUsFieldMaxLength: CONTACT_US_FIELD_MAX_LENGTH,
+              contactCountryMaxLength: CONTACT_US_COUNTRY_MAX_LENGTH,
+              appErrorCode: "",
+              appSessionId: "",
+              contentId: "",
+            }
+          );
+        });
       });
     });
   });


### PR DESCRIPTION
## What

The `/contact-us-questions` page always assumed that the "Back" button should go to `/contact-us-further-information`. That's not the case though - sometimes it should go back to the main `/contact-us` page.

The correct logic is
```
if we're on the '/contact-us-questions' page
    if we only have a 'theme'
        redirect back to '/contact-us'
    if we have a 'theme' and a 'subtheme'
        redirect back to '/contact-us-further-information'
```

The logic to generate the back link is quite complicated, so I've tried to be light-touch in the fix. There's a bit of "it's working so don't touch it", where the tests are checking for things I don't think are necessarily true, but that can wait for a point when we refactor the forms.

I also moved a bunch of the tests around to make them a bit easier to read, as well as parameterising them where possible.

## How to review

1. Code Review
2. Deploy to an env and try clicking into/out of forms to make sure they redirect correctly

## Screen recordings

**Navigating between pages of the contact form**

https://github.com/user-attachments/assets/b137da31-bbfc-48c7-9b51-37235bcc47a2

**Navigating to the Home support page**

https://github.com/user-attachments/assets/151a6969-b268-4bb6-be4c-1610a4eba428

## Checklist

- [x] Manual testing