### PR TITLE
AUT-4008: Fix translation to choose MFA method

### DIFF
--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -2549,8 +2549,8 @@
           "text2": "gwiriwch a allwch newid sut rydych yn cael codau diogelwch"
         },
         "chooseMfaMethod":  {
-          "text1": "Os na allwch gael cod i’r rhif ffôn hwn gallwch ",
-          "text2": "roi cynnig ar ffordd arall o gael cod diogelwch"
+          "text1": "Gallwch ",
+          "text2": "geisio ffordd arall o gael codau diogelwch"
         }
       },
       "upliftRequired": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -2548,7 +2548,7 @@
           "text2": "check if you can change how you get security codes"
         },
         "chooseMfaMethod":  {
-          "text1": "If you cannot get a code to this phone number you can ",
+          "text1": "You can ",
           "text2": "try another way to get a security code"
         }
       },


### PR DESCRIPTION
## What

Following UCD comment, fixes the content.

Accidentally missed out this change from the original PR:
https://github.com/govuk-one-login/authentication-frontend/pull/2765