### PR TITLE
AUT-4375: Change device intelligence cookie domain to production URL

### DIFF
--- a/src/components/common/layout/base.njk
+++ b/src/components/common/layout/base.njk
@@ -189,7 +189,7 @@
     {% if deviceIntelligenceEnabled %}
         <script type="text/javascript" {% if scriptNonce %} nonce="{{ scriptNonce }}"{%  endif %}>
           import("/public/scripts/device-intelligence.js").then(({setFingerprintCookie}) => {
-            setFingerprintCookie("{{ analyticsCookieDomain }}");
+            setFingerprintCookie("{{analyticsCookieDomain}}"==="localhost" ? "localhost" : ".account.gov.uk");
           })
         </script>
     {% endif %}


### PR DESCRIPTION
## What

There was an issue when testing which meant that two DI cookies from different domains (a non-prod and prod env) were being set on the browser and causing a "header to large" error. This addresses that issue by setting every env's cookie to the prod domain.

## How to review

1. Code Review
1. Deploy to env and check that cookie is attached correctly