### PR TITLE
AUT-4248: Set activeMfaMethodId on session initialisation

### DIFF
--- a/src/middleware/session-middleware.ts
+++ b/src/middleware/session-middleware.ts
@@ -8,6 +8,8 @@ import {
   PATH_NAMES,
 } from "../app.constants.js";
 import { logger } from "../utils/logger.js";
+import type { MfaMethod } from "../types.js";
+import { MfaMethodPriority } from "../types.js";
 
 export function initialiseSessionMiddleware(
   req: Request,
@@ -20,6 +22,9 @@ export function initialiseSessionMiddleware(
     req.session.user = {
       email: req.session?.user?.email,
       mfaMethods: req.session?.user?.mfaMethods,
+      activeMfaMethodId: req.session?.user?.mfaMethods?.find(
+        (method: MfaMethod) => method.priority === MfaMethodPriority.DEFAULT
+      )?.id,
     };
 
     req.session.sessionRestored = true;


### PR DESCRIPTION
## What

When a user visits the /authorize path they may already have a session with some user session data.

We previously carried over their email and phoneNumber. For method management work we moved phoneNumber into mfaMethods.

In recent commits we set an activeMfaMethodId to indicate which mfaMethods item is in use for the journey (a user can now change those).

However, we need to also set it here when we uplift a user, so when they go straight to the /enter-code screen we can render the page correctly (by knowing which MFA to use)

## How to review

1. Code Review

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->
- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged 

Delete this item if the PR does not change the UI. 
-->
- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure. 
-->
- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
- [ ] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
