### PR TITLE
ATO-1769: Send RP Sector identifier host to backend

### DIFF
--- a/src/components/authorize/authorize-service.ts
+++ b/src/components/authorize/authorize-service.ts
@@ -90,5 +90,6 @@ function createStartBody(startRequestParameters: StartRequestParameters) {
   body["subject_type"] = startRequestParameters.subject_type;
   body["is_identity_verification_required"] =
     startRequestParameters.is_identity_verification_required;
+  body["rp_sector_identifier_host"] = startRequestParameters.rp_sector_host;
   return body;
 }

--- a/src/components/authorize/tests/authorize-service.test.ts
+++ b/src/components/authorize/tests/authorize-service.test.ts
@@ -57,6 +57,7 @@ describe("authorize service", () => {
       is_one_login_service: false,
       subject_type: "pairwise",
       is_identity_verification_required: false,
+      rp_sector_host: "example.com",
     });
 
     expect(
@@ -77,6 +78,7 @@ describe("authorize service", () => {
           is_one_login_service: false,
           subject_type: "pairwise",
           is_identity_verification_required: false,
+          rp_sector_identifier_host: "example.com",
         },
         {
           headers: {
@@ -106,6 +108,7 @@ describe("authorize service", () => {
       is_one_login_service: false,
       subject_type: "pairwise",
       is_identity_verification_required: false,
+      rp_sector_host: "example.com",
     });
 
     expect(
@@ -125,6 +128,7 @@ describe("authorize service", () => {
           is_one_login_service: false,
           subject_type: "pairwise",
           is_identity_verification_required: false,
+          rp_sector_identifier_host: "example.com",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -150,6 +154,7 @@ describe("authorize service", () => {
       is_one_login_service: false,
       subject_type: "pairwise",
       is_identity_verification_required: false,
+      rp_sector_host: "example.com",
     });
 
     expect(
@@ -169,6 +174,7 @@ describe("authorize service", () => {
           is_one_login_service: false,
           subject_type: "pairwise",
           is_identity_verification_required: false,
+          rp_sector_identifier_host: "example.com",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },
@@ -196,6 +202,7 @@ describe("authorize service", () => {
       is_one_login_service: false,
       subject_type: "pairwise",
       is_identity_verification_required: false,
+      rp_sector_host: "example.com",
     });
 
     expect(
@@ -216,6 +223,7 @@ describe("authorize service", () => {
           is_one_login_service: false,
           subject_type: "pairwise",
           is_identity_verification_required: false,
+          rp_sector_identifier_host: "example.com",
         },
         {
           headers: {
@@ -246,6 +254,7 @@ describe("authorize service", () => {
       is_one_login_service: false,
       subject_type: "pairwise",
       is_identity_verification_required: false,
+      rp_sector_host: "example.com",
     });
 
     expect(
@@ -267,6 +276,7 @@ describe("authorize service", () => {
           is_one_login_service: false,
           subject_type: "pairwise",
           is_identity_verification_required: false,
+          rp_sector_identifier_host: "example.com",
         },
         {
           headers: {
@@ -299,6 +309,7 @@ describe("authorize service", () => {
       is_one_login_service: false,
       subject_type: "pairwise",
       is_identity_verification_required: false,
+      rp_sector_host: "example.com",
     });
 
     expect(
@@ -321,6 +332,7 @@ describe("authorize service", () => {
           is_one_login_service: false,
           subject_type: "pairwise",
           is_identity_verification_required: false,
+          rp_sector_identifier_host: "example.com",
         },
         {
           headers: { ...expectedHeadersFromCommonVarsWithSecurityHeaders },

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -23,6 +23,7 @@ export interface StartRequestParameters {
   is_one_login_service: boolean;
   subject_type: string;
   is_identity_verification_required: boolean;
+  rp_sector_host: string;
 }
 
 export interface StartAuthResponse extends DefaultApiResponse {


### PR DESCRIPTION
## What:
Orchestration already send this value to authentication in the JAR sent to the authorize endpoint. As we aim to remove reading this value from the RP Sector Identifier from the client registry, we need to pass this value to the backend to set on the backend session, so we can use it instead of reading the client registry


## How to review: 
- Code review 

Tested in sandpit, orch - auth handover was successful and could perform a full auth only journey

## Checklist

- [x] Performance analyst has been notified of the change. n/a 
- [x] A UCD review has been performed. n/a
- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. n/a
- [x] Documentation has been updated to reflect these changes. n/a

