### PR TITLE
BAU: Changing Vcpu Ecs task size to match Staging Env

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -469,8 +469,8 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       frontendAutoScalingMinCount: 4
       frontendAutoScalingMaxCount: 240
-      frontendTaskDefinitionCpu: 2048
-      frontendTaskDefinitionMemory: 4096
+      frontendTaskDefinitionCpu: 1024
+      frontendTaskDefinitionMemory: 2048
       cloudwatchLogRetentionInDays: 30
       orchToAuthSigningPublicKey: |
         -----BEGIN PUBLIC KEY-----


### PR DESCRIPTION
## What

BAU: changing vcpu ecs task to 1cpu in prod to match the configuration in  staging which has been perf tested to improve performance and Scale 

## How to review

1. Code Review
