### PR TITLE
AUT-4374: Add new content id to "how do you want security codes" page

### DIFF
--- a/src/components/how-do-you-want-security-codes/tests/__snapshots__/how-do-you-want-security-codes-integration.test.ts.snap
+++ b/src/components/how-do-you-want-security-codes/tests/__snapshots__/how-do-you-want-security-codes-integration.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Integration::how do you want security codes GET /how-do-you-want-security-codes should return page as expected for AUTH APP user with SMS backup 1`] = `
 Object {
-  "contentId": "",
+  "contentId": "5c2256e7-a704-4da7-8cb4-0249fd8da0c4",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
   "taxonomyLevel3": "",
@@ -13,7 +13,7 @@ Object {
 
 exports[`Integration::how do you want security codes GET /how-do-you-want-security-codes should return page as expected for SMS user with AUTH APP backup 1`] = `
 Object {
-  "contentId": "",
+  "contentId": "5c2256e7-a704-4da7-8cb4-0249fd8da0c4",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
   "taxonomyLevel3": "",
@@ -24,7 +24,7 @@ Object {
 
 exports[`Integration::how do you want security codes GET /how-do-you-want-security-codes should return page as expected for SMS user with SMS backup 1`] = `
 Object {
-  "contentId": "",
+  "contentId": "5c2256e7-a704-4da7-8cb4-0249fd8da0c4",
   "taxonomyLevel1": "authentication",
   "taxonomyLevel2": "",
   "taxonomyLevel3": "",

--- a/src/utils/contentId.ts
+++ b/src/utils/contentId.ts
@@ -75,7 +75,8 @@ const CONTENT_IDS: {
     }
     return "19601dd7-be55-4ab6-aa44-a6358c4239dc";
   },
-  [PATH_NAMES.HOW_DO_YOU_WANT_SECURITY_CODES]: () => "",
+  [PATH_NAMES.HOW_DO_YOU_WANT_SECURITY_CODES]: () =>
+    "5c2256e7-a704-4da7-8cb4-0249fd8da0c4",
   [PATH_NAMES.ENTER_PASSWORD]: (req: Request) =>
     isReauth(req)
       ? "c6f4fed1-ee6d-4d23-a14f-4466e9c1349c"


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Add new content id to "how do you want security codes" page

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

- [ ] Performance analyst has been notified of the change. **- N/A**

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [ ] A UCD review has been performed. **- N/A**

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. **- N/A**

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [ ] Documentation has been updated to reflect these changes. **- N/A**