### PR TITLE
AUT-4519: bump cosign version in upload-action-ecr

### DIFF
--- a/.github/workflows/build-deploy-frontend-dev.yml
+++ b/.github/workflows/build-deploy-frontend-dev.yml
@@ -23,7 +23,7 @@ jobs:
   #     contents: read
   #   steps:
   #     - name: Build and push service down page image
-  #       uses: govuk-one-login/devplatform-upload-action-ecr@224346cd422f5bdfb6b68d0f8e189e55354b2804 # v1.4.0
+  #       uses: govuk-one-login/devplatform-upload-action-ecr@3931602236c176dd4ec2c11dceb38002110b5d87 # v1.3.0
   #       with:
   #         role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
   #         container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_ARN }}
@@ -43,7 +43,7 @@ jobs:
       contents: read
     steps:
       - name: Build, push and deploy frontend
-        uses: govuk-one-login/devplatform-upload-action-ecr@224346cd422f5bdfb6b68d0f8e189e55354b2804 # v1.4.0
+        uses: govuk-one-login/devplatform-upload-action-ecr@3931602236c176dd4ec2c11dceb38002110b5d87 # v1.3.0
         with:
           role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_ARN }}

--- a/.github/workflows/build-deploy-frontend.yml
+++ b/.github/workflows/build-deploy-frontend.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
     steps:
       - name: Build and push service down page image
-        uses: govuk-one-login/devplatform-upload-action-ecr@224346cd422f5bdfb6b68d0f8e189e55354b2804 # v1.4.0
+        uses: govuk-one-login/devplatform-upload-action-ecr@3931602236c176dd4ec2c11dceb38002110b5d87 # v1.3.0
         with:
           role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_ARN }}
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: Build, push and deploy frontend
-        uses: govuk-one-login/devplatform-upload-action-ecr@224346cd422f5bdfb6b68d0f8e189e55354b2804 # v1.4.0
+        uses: govuk-one-login/devplatform-upload-action-ecr@3931602236c176dd4ec2c11dceb38002110b5d87 # v1.3.0
         with:
           role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_ARN }}


### PR DESCRIPTION
## What

bump cosign version in upload-action-ecr on branch [BAU/add-context-option](https://github.com/govuk-one-login/devplatform-upload-action-ecr/commits/BAU/add-context-option/) that's used by frontend deploy workflows

## How to review

Verify deploy to dev/authdevs from the branch has been successful