### PR TITLE
BAU: start the service down page locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ You can also add an additional service with a different VTR by duplicating the `
 giving it a new name and amending the `PORT` and `VTR` environment variables. The `ports` entry, must reflect the port
 number in the `PORT` environment variable. Each service must have a unique port number.
 
+### The service down page
+
+The service down page starts up automatically when the startup script is run. It can be tested by going to [http://localhost:3005](http://localhost:3005).
+
 ### Running the tests
 
 The unit tests have been written with Mocha and Supertest.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-stub-image-name: &stub-image-name di-authentication-frontend/di-auth-stub:latest
 
 services:
@@ -69,6 +67,15 @@ services:
       - yarn
       - dummy-server-orchstub
     restart: on-failure
+    networks:
+      - di-net
+
+  service-down-page:
+    build:
+      context: ./service-down-page-config/
+      dockerfile: Dockerfile
+    ports:
+      - ${DOCKER_SERVICE_DOWN_PAGE_PORT:-3005}:8080
     networks:
       - di-net
 


### PR DESCRIPTION
## What

Start the service down page locally

- Included as a service in the docker compose file
- Runs on port 3005

## How to review

1. Code Review
1. Run './startup.sh -l' and go to localhost:3005 to see the page.

## Checklist

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [x] Documentation has been updated to reflect these changes.

## Related PRs

#2880 
