### PR TITLE
BAU: Extend default SESSION_EXPIRY

### DIFF
--- a/scripts/_create_env_file.py
+++ b/scripts/_create_env_file.py
@@ -46,7 +46,7 @@ DEFAULT_USER_VARIABLES: list[EnvFileSection] = [
         "header": "Local Express session configuration",
         "variables": {
             "SESSION_EXPIRY": {
-                "value": 60000,
+                "value": 3600000,
                 "comment": "Express session expiry time in milliseconds",
             },
             "SESSION_SECRET": {"value": 123456, "comment": "Express session secret"},


### PR DESCRIPTION
## What

Sets default `SESSION_EXPIRY=3600000`

Having a default expiry of 60,000 (1 min) causes confusion for anyone new to the project. I've set to 3,600,000 to match prod.

The logic being:
- I'm probably fine with a long `SESSION_EXPIRY`
- If I'm testing something and require a shorter session, that's when I'd go and seek out how to do it

## How to review

1. Code Review