### PR TITLE
AUT-4653: Add translations for unselected Wallet subtheme error

### DIFF
--- a/src/components/contact-us/tests/contact-us-controller-integration.test.ts
+++ b/src/components/contact-us/tests/contact-us-controller-integration.test.ts
@@ -245,8 +245,7 @@ describe("Integration:: contact us - public user", () => {
     );
   });
 
-  // TODO - AUT-4497 - Unskip this once the content is agreed
-  it.skip("should return validation error when no radio boxes are selected on the wallet contact-us-further-information page", async () => {
+  it("should return validation error when no radio boxes are selected on the wallet contact-us-further-information page", async () => {
     const data = {
       _csrf: token,
       theme: "wallet",
@@ -255,7 +254,7 @@ describe("Integration:: contact us - public user", () => {
       "/contact-us-further-information",
       data,
       "#subtheme-error",
-      "XXXXX"
+      "Select the problem you had with your digital HM Armed Forces Veteran Card"
     );
   });
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -1988,7 +1988,7 @@
           "radio3": "Rydych wedi cael problem gweld eich Cerdyn Cyn-filwr yn yr ap GOV.UK One Login",
           "radio4": "Roedd problem dechnegol (er enghraifft, fe welsoch neges gwall)",
           "radio5": "Rhywbeth arall",
-          "errorMessage": "CY TODO - AUT-4497 - Error message"
+          "errorMessage": "Dewiswch y broblem a gawsoch gyda’ch Cerdyn Cyn-filwr Lluoedd Arfog Ei Fawrhydi digidol"
         }
       }
     },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1987,7 +1987,7 @@
           "radio3": "You had a problem viewing your Veteran Card in the GOV.UK One Login app",
           "radio4": "There was a technical problem (for example you saw an error message)",
           "radio5": "Something else",
-          "errorMessage": "TODO - AUT-4497 - Error message"
+          "errorMessage": "Select the problem you had with your digital HM Armed Forces Veteran Card"
         }
       }
     },


### PR DESCRIPTION
## What

Adds in a missing error message translation that was skipped in the original PR.
https://github.com/govuk-one-login/authentication-frontend/pull/2918

## How to review

1. Code Review

### Screenshots

| English 🏴󠁧󠁢󠁥󠁮󠁧󠁿 | Welsh 🏴󠁧󠁢󠁷󠁬󠁳󠁿 |
|--------|--------|
| <img width="697" height="845" alt="image" src="https://github.com/user-attachments/assets/af59a6f2-9720-40f7-978a-19a5679f7a32" /> | <img width="687" height="819" alt="image" src="https://github.com/user-attachments/assets/c392dd43-1f4c-4bb1-94ce-26794fb71b09" /> |