### PR TITLE
BAU: Add missing `govuk-link` styling to "create account" page links

### DIFF
--- a/src/components/enter-email/index-create-account.njk
+++ b/src/components/enter-email/index-create-account.njk
@@ -35,11 +35,11 @@
 <h1 class="govuk-heading-s govuk-!-margin-top-0 govuk-!-margin-bottom-3">{{'pages.createPassword.termsAndConditions.header' | translate}}</h1>
 
 <p class="govuk-body">
-    {{ 'pages.createPassword.termsAndConditions.paragraph1.text1' | translate }}<a {% if not isApp %}target="_blank" rel="noopener noreferrer"{% endif %} href="{{ 'pages.createPassword.termsAndConditions.paragraph1.termsAndConditionsHref' | translate }}">{% if isApp %}{{ 'pages.createPassword.termsAndConditions.paragraph1.termsAndConditionsTextApp' | translate }}{% else %}{{ 'pages.createPassword.termsAndConditions.paragraph1.termsAndConditionsText' | translate }}{% endif %}</a>{{ 'pages.createPassword.termsAndConditions.paragraph1.text2' | translate }}
+    {{ 'pages.createPassword.termsAndConditions.paragraph1.text1' | translate }}<a {% if not isApp %}target="_blank" rel="noopener noreferrer"{% endif %} href="{{ 'pages.createPassword.termsAndConditions.paragraph1.termsAndConditionsHref' | translate }}" class="govuk-link">{% if isApp %}{{ 'pages.createPassword.termsAndConditions.paragraph1.termsAndConditionsTextApp' | translate }}{% else %}{{ 'pages.createPassword.termsAndConditions.paragraph1.termsAndConditionsText' | translate }}{% endif %}</a>{{ 'pages.createPassword.termsAndConditions.paragraph1.text2' | translate }}
 </p>
 
 <p class="govuk-body">
-    {{ 'pages.createPassword.termsAndConditions.paragraph2.text1' | translate }}<a {% if not isApp %}target="_blank" rel="noopener noreferrer"{% endif %} href="{{ 'pages.createPassword.termsAndConditions.paragraph2.privacyNoticeHref' | translate }}">{% if isApp %}{{ 'pages.createPassword.termsAndConditions.paragraph2.privacyNoticeTextApp' | translate }}{% else %}{{ 'pages.createPassword.termsAndConditions.paragraph2.privacyNoticeText' | translate }}{% endif %}</a>{{ 'pages.createPassword.termsAndConditions.paragraph2.text2' | translate }}
+    {{ 'pages.createPassword.termsAndConditions.paragraph2.text1' | translate }}<a {% if not isApp %}target="_blank" rel="noopener noreferrer"{% endif %} href="{{ 'pages.createPassword.termsAndConditions.paragraph2.privacyNoticeHref' | translate }}" class="govuk-link">{% if isApp %}{{ 'pages.createPassword.termsAndConditions.paragraph2.privacyNoticeTextApp' | translate }}{% else %}{{ 'pages.createPassword.termsAndConditions.paragraph2.privacyNoticeText' | translate }}{% endif %}</a>{{ 'pages.createPassword.termsAndConditions.paragraph2.text2' | translate }}
 </p>
 
 {{ govukButton({


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

The "terms and conditions" and "privacy notice" links on the "create account" page were missing `govuk-link` styling, leading them to fallback to the browser default (bright blue).

This PR adds the `govuk-link` class to both of these links.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy to a dev env (or run locally), visit the "create account" page, check the link styling has updated.

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

- [ ] Performance analyst has been notified of the change. **- N/A, styling only**

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [x] A UCD review has been performed. **- UCD have signed off - [Slack](https://gds.slack.com/archives/C02KUCT0ZAS/p1755272158281759?thread_ts=1755268368.019469&cid=C02KUCT0ZAS)**

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. **- N/A, styling only**

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [ ] Documentation has been updated to reflect these changes. **- N/A, styling only**

## Screenshots

Before:

<img width="2516" height="1742" alt="Screenshot 2025-08-15 at 15 43 43" src="https://github.com/user-attachments/assets/6c038a7f-7353-4fc3-9fd0-79355ac5e4ac" />

After:

<img width="2512" height="1738" alt="Screenshot 2025-08-15 at 15 42 38" src="https://github.com/user-attachments/assets/329c6dc8-0c95-4253-879e-cf531e87d91a" />
