### PR TITLE
BAU: Make the intermediate states orange on the journey map

### DIFF
--- a/journey-map/src/mermaid.ts
+++ b/journey-map/src/mermaid.ts
@@ -1,7 +1,8 @@
 import type { AnyEventObject, StateNode, TransitionDefinition } from "xstate";
-import type {
+import {
   AuthStateContext,
   AuthStateMachine,
+  INTERMEDIATE_STATES,
 } from "di-auth/src/components/common/state-machine/state-machine.js";
 import { authStateMachine } from "di-auth/src/components/common/state-machine/state-machine.js";
 import { pages } from "di-auth/src/components/templates/pages.js";
@@ -26,11 +27,15 @@ interface Transition {
 
 const getMermaidHeader = (graphDirection: "TD" | "LR"): string =>
   `flowchart ${graphDirection}
-    classDef page fill:#ae8,stroke:#000;`;
+    classDef page fill:#ae8,stroke:#000;
+    classDef intermediateState fill:#ec8,stroke:#000`;
 
 const renderState = ({ name, id }: State): string => {
   if (pages[name]) {
     return `    ${id}(${name}):::page`;
+  }
+  if (Object.values(INTERMEDIATE_STATES).includes(name)) {
+    return `    ${id}(${name}):::intermediateState`;
   }
   return `    ${id}(${name})`;
 };

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -6,7 +6,7 @@ import {
   PATH_NAMES,
 } from "../../../app.constants.js";
 
-const INTERMEDIATE_STATES = {
+export const INTERMEDIATE_STATES = {
   PASSWORD_VERIFIED: "password-verified",
   SIGN_IN_END: "sign-in-end",
 };


### PR DESCRIPTION
## What

Makes the intermediate states orange, so that they stand out from pages (white) and pages with a live template view (green).

<img width="1674" height="447" alt="Screenshot 2025-09-09 at 10 43 47" src="https://github.com/user-attachments/assets/d0c6c242-5234-4714-97d6-a5b54ba9891e" />

## How to review

1. Code Review
2. Run locally