### PR TITLE
AUT-4563: Return status code 400 when provided session ID invalid

### DIFF
--- a/src/handlers/internal-server-error-handler.ts
+++ b/src/handlers/internal-server-error-handler.ts
@@ -1,6 +1,8 @@
 import type { NextFunction, Request, Response } from "express";
 import { getAccountManagementUrl } from "../config.js";
 import { ERROR_MESSAGES, HTTP_STATUS_CODES } from "../app.constants.js";
+import { BadRequestError } from "../utils/error.js";
+import { ERROR_CODES } from "../components/common/constants.js";
 
 export function serverErrorHandler(
   err: any,
@@ -25,6 +27,14 @@ export function serverErrorHandler(
 
   if (res.statusCode == HTTP_STATUS_CODES.UNAUTHORIZED) {
     return res.render("common/errors/session-expired.njk");
+  }
+
+  if (
+    err instanceof BadRequestError &&
+    err.code === ERROR_CODES.SESSION_ID_MISSING_OR_INVALID.toString()
+  ) {
+    res.status(HTTP_STATUS_CODES.BAD_REQUEST);
+    return res.render("common/errors/500.njk");
   }
 
   res.status(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);

--- a/src/handlers/tests/internal-server-error-handler.test.ts
+++ b/src/handlers/tests/internal-server-error-handler.test.ts
@@ -4,6 +4,8 @@ import type { NextFunction, Request, Response } from "express";
 import { sinon } from "../../../test/utils/test-utils.js";
 import { ERROR_MESSAGES, HTTP_STATUS_CODES } from "../../app.constants.js";
 import { serverErrorHandler } from "../internal-server-error-handler.js";
+import { BadRequestError } from "../../utils/error.js";
+import { ERROR_CODES } from "../../components/common/constants.js";
 describe("serverErrorHandler", () => {
   let req: Request;
   let res: Response;
@@ -82,6 +84,22 @@ describe("serverErrorHandler", () => {
 
     expect(renderSpy).to.have.been.calledOnceWith(expectedTemplate);
     expect(res.statusCode).to.equal(HTTP_STATUS_CODES.UNAUTHORIZED);
+  });
+
+  it("should render 500 template with BAD_REQUEST status for BadRequestError with SESSION_ID_MISSING_OR_INVALID code", () => {
+    const err = new BadRequestError(
+      "Session invalid",
+      ERROR_CODES.SESSION_ID_MISSING_OR_INVALID
+    );
+    const renderSpy = sinon.spy(res, "render");
+    const statusSpy = sinon.spy(res, "status");
+
+    serverErrorHandler(err, req, res, next);
+
+    expect(statusSpy).to.have.been.calledOnceWith(
+      HTTP_STATUS_CODES.BAD_REQUEST
+    );
+    expect(renderSpy).to.have.been.calledOnceWith("common/errors/500.njk");
   });
 
   it("should render 500 template if error is not unauthorized and headers have not been sent", () => {

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,8 +1,10 @@
 export class BadRequestError extends Error {
   private status: number;
+  public code: string;
   level?: string;
   constructor(message: string, code?: number | string) {
     super(code ? `${code}:${message}` : `${message}`);
+    this.code = code?.toString();
     this.status = 400;
   }
 }


### PR DESCRIPTION
## What

We get the `sessionId` from the `gs` cookie at the moment. We break the value up in the `session-middleware.ts` to get the `sessionId` and `clientSessionId`.

When the cookie is not provided, those values are not set in `req.locals`.

We then attempt to send those values to the backend, but if they are not provided then the backend returns error 1000, `SESSION_ID_MISSING_OR_INVALID`.

This is a client side error as far as authentication is concerned. The client should provide the cookie, and it did not.

So instead of returning an internal server error 500 status code, return a 400 which is more appropriate.

We are still using the existing 500 error template to render to the user while we await new content to show.

## How to review

1. Code Review

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

- [ ] Performance analyst has been notified of the change.

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [ ] Documentation has been updated to reflect these changes.
