### PR TITLE
BAU: Remove ecdsa sig formatter from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "cookie-parser": "1.4.7",
         "csrf-sync": "4.2.1",
         "dompurify": "3.3.2",
-        "ecdsa-sig-formatter": "1.0.11",
         "express": "4.22.1",
         "express-async-errors": "3.1.1",
         "express-session": "1.18.2",
@@ -4732,15 +4731,6 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "cookie-parser": "1.4.7",
     "csrf-sync": "4.2.1",
     "dompurify": "3.3.2",
-    "ecdsa-sig-formatter": "1.0.11",
     "express": "4.22.1",
     "express-async-errors": "3.1.1",
     "express-session": "1.18.2",


### PR DESCRIPTION
This is no longer used directly as of: b2c799240fd015e581bd77353697ba628d240c5d

