### PR TITLE
AUT-5309: Run detect-secrets as a pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,3 +76,10 @@ repos:
         args:
           - "--fix"
       - id: ruff-format
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]
+        exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,787 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    ".env.local": [
+      {
+        "type": "Private Key",
+        "filename": ".env.local",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 44
+      }
+    ],
+    ".github/workflows/analyse-on-merge.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/analyse-on-merge.yml",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 59
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/analyse-on-merge.yml",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 60
+      }
+    ],
+    ".github/workflows/pre-merge-checks.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/pre-merge-checks.yml",
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/pre-merge-checks.yml",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 65
+      }
+    ],
+    "cloudformation/deploy/template.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "cloudformation/deploy/template.yaml",
+        "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
+        "is_verified": false,
+        "line_number": 495
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "cloudformation/deploy/template.yaml",
+        "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
+        "is_verified": false,
+        "line_number": 623
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "cloudformation/deploy/template.yaml",
+        "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
+        "is_verified": false,
+        "line_number": 662
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "cloudformation/deploy/template.yaml",
+        "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
+        "is_verified": false,
+        "line_number": 670
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "cloudformation/deploy/template.yaml",
+        "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
+        "is_verified": false,
+        "line_number": 678
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "cloudformation/deploy/template.yaml",
+        "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
+        "is_verified": false,
+        "line_number": 686
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "cloudformation/deploy/template.yaml",
+        "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
+        "is_verified": false,
+        "line_number": 694
+      }
+    ],
+    "scripts/_create_env_file.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "scripts/_create_env_file.py",
+        "hashed_secret": "9cf1038e1ae87e2a2f7bea13cb548ccfffb92a34",
+        "is_verified": false,
+        "line_number": 181
+      }
+    ],
+    "src/app.constants.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/app.constants.ts",
+        "hashed_secret": "2a7ab6c8700d9ef886653468a2ea6cc99fd6f161",
+        "is_verified": false,
+        "line_number": 168
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/app.constants.ts",
+        "hashed_secret": "cf3774dd01c0f67621fa89c933e82354369883ff",
+        "is_verified": false,
+        "line_number": 242
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/app.constants.ts",
+        "hashed_secret": "cfd64983365c3b32e56647b0642e79115fd9ea67",
+        "is_verified": false,
+        "line_number": 261
+      }
+    ],
+    "src/components/amc-service/tests/amc-result-service.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/amc-service/tests/amc-result-service.test.ts",
+        "hashed_secret": "fca71afec681b7c2932610046e8e524820317e47",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    "src/components/auth-code/tests/auth-code-service.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/auth-code/tests/auth-code-service.test.ts",
+        "hashed_secret": "fca71afec681b7c2932610046e8e524820317e47",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/components/auth-code/tests/auth-code-service.test.ts",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "src/components/authorize/tests/kms-decryption-service.test.ts": [
+      {
+        "type": "JSON Web Token",
+        "filename": "src/components/authorize/tests/kms-decryption-service.test.ts",
+        "hashed_secret": "a1da29c70a7c1b0b9c5f9c7b15e387c2c4d9ba5a",
+        "is_verified": false,
+        "line_number": 29
+      }
+    ],
+    "src/components/authorize/tests/test-data.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/components/authorize/tests/test-data.ts",
+        "hashed_secret": "05d143b821b091e7421b25d33544880bb6cbc96d",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Private Key",
+        "filename": "src/components/authorize/tests/test-data.ts",
+        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
+        "is_verified": false,
+        "line_number": 47
+      }
+    ],
+    "src/components/common/constants.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/common/constants.ts",
+        "hashed_secret": "c77868e76dd5562ce510551470099d8b4787025d",
+        "is_verified": false,
+        "line_number": 21
+      }
+    ],
+    "src/components/common/state-machine/state-machine.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/common/state-machine/state-machine.ts",
+        "hashed_secret": "c9d7604f59c5935d2003c580a7dacc80d636c475",
+        "is_verified": false,
+        "line_number": 6
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/common/state-machine/state-machine.ts",
+        "hashed_secret": "4017db32509e88699c71b0e35c78c1bbaf688422",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/common/state-machine/state-machine.ts",
+        "hashed_secret": "10746f3de877efcacb883b8ab8fb91a54bf38b26",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/common/state-machine/state-machine.ts",
+        "hashed_secret": "e4518b9940baabb8aa6b6d70937b652ec36cff1e",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/common/state-machine/state-machine.ts",
+        "hashed_secret": "132bc9c32d8b36d1adf41f4eb642eed606bec0b6",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/common/state-machine/state-machine.ts",
+        "hashed_secret": "c27400c2141e02b3cb730f5dc7b7b3c45342e292",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/common/state-machine/state-machine.ts",
+        "hashed_secret": "502f056350b6cecd4783b22e0fedc5c419e05317",
+        "is_verified": false,
+        "line_number": 56
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/common/state-machine/state-machine.ts",
+        "hashed_secret": "2871ae3325393579fa6799b51c5b8b58ca3532ae",
+        "is_verified": false,
+        "line_number": 57
+      }
+    ],
+    "src/components/create-password/tests/create-password-controller.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/create-password/tests/create-password-controller.test.ts",
+        "hashed_secret": "e38ad214943daad1d64c102faec29de4afe9da3d",
+        "is_verified": false,
+        "line_number": 45
+      }
+    ],
+    "src/components/create-password/tests/create-password-integration.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/create-password/tests/create-password-integration.test.ts",
+        "hashed_secret": "a6ad00ac113a19d953efb91820d8788e2263b28a",
+        "is_verified": false,
+        "line_number": 74
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/create-password/tests/create-password-integration.test.ts",
+        "hashed_secret": "a02271ba652f9cd148095797b463e3395ef96243",
+        "is_verified": false,
+        "line_number": 106
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/create-password/tests/create-password-integration.test.ts",
+        "hashed_secret": "fffcee4a43529bd0a847ca40c5855d7ac3140495",
+        "is_verified": false,
+        "line_number": 107
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/create-password/tests/create-password-integration.test.ts",
+        "hashed_secret": "0da19b540f7c3526f24acba988b03df43b3c5cf3",
+        "is_verified": false,
+        "line_number": 125
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/create-password/tests/create-password-integration.test.ts",
+        "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
+        "is_verified": false,
+        "line_number": 144
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/create-password/tests/create-password-integration.test.ts",
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_verified": false,
+        "line_number": 187
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/create-password/tests/create-password-integration.test.ts",
+        "hashed_secret": "c2addf027d098b985050c898eb28c5428479a88c",
+        "is_verified": false,
+        "line_number": 211
+      }
+    ],
+    "src/components/enter-password/enter-password-controller.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/enter-password/enter-password-controller.ts",
+        "hashed_secret": "ea15bfcf15d792eb40cd842b1a55eeef5dd11a37",
+        "is_verified": false,
+        "line_number": 30
+      }
+    ],
+    "src/components/enter-password/tests/enter-password-controller.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/enter-password/tests/enter-password-controller.test.ts",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 62
+      }
+    ],
+    "src/components/enter-password/tests/enter-password-integration.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/enter-password/tests/enter-password-integration.test.ts",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 80
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/enter-password/tests/enter-password-integration.test.ts",
+        "hashed_secret": "bebc9abc131b0154cf2af9a52f6421936d41b661",
+        "is_verified": false,
+        "line_number": 110
+      }
+    ],
+    "src/components/enter-password/tests/enter-password-reauth-integration.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/enter-password/tests/enter-password-reauth-integration.test.ts",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 84
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/enter-password/tests/enter-password-reauth-integration.test.ts",
+        "hashed_secret": "bebc9abc131b0154cf2af9a52f6421936d41b661",
+        "is_verified": false,
+        "line_number": 114
+      }
+    ],
+    "src/components/enter-password/tests/enter-password-service.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/enter-password/tests/enter-password-service.test.ts",
+        "hashed_secret": "505032eaf8a3acf9b094a326dfb1cd0537c75a0d",
+        "is_verified": false,
+        "line_number": 22
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/components/enter-password/tests/enter-password-service.test.ts",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/enter-password/tests/enter-password-service.test.ts",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 55
+      }
+    ],
+    "src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/components/enter-phone-number/tests/enter-phone-number-integration.test.ts",
+        "hashed_secret": "29c90bf6597a17f53ab28181a5e6013a2cb3d080",
+        "is_verified": false,
+        "line_number": 127
+      }
+    ],
+    "src/components/prove-identity-callback/tests/prove-identity-callback-service.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/prove-identity-callback/tests/prove-identity-callback-service.test.ts",
+        "hashed_secret": "fca71afec681b7c2932610046e8e524820317e47",
+        "is_verified": false,
+        "line_number": 85
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/components/prove-identity-callback/tests/prove-identity-callback-service.test.ts",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 90
+      }
+    ],
+    "src/components/reset-password/reset-password-controller.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/reset-password/reset-password-controller.ts",
+        "hashed_secret": "19fcd3064264ae9e13cf7fea983245ac128cf7cc",
+        "is_verified": false,
+        "line_number": 18
+      }
+    ],
+    "src/components/reset-password/tests/reset-password-controller.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/reset-password/tests/reset-password-controller.test.ts",
+        "hashed_secret": "70ccd9007338d6d81dd3b6271621b9cf9a97ea00",
+        "is_verified": false,
+        "line_number": 73
+      }
+    ],
+    "src/components/reset-password/tests/reset-password-integration.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/reset-password/tests/reset-password-integration.test.ts",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 125
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/reset-password/tests/reset-password-integration.test.ts",
+        "hashed_secret": "a02271ba652f9cd148095797b463e3395ef96243",
+        "is_verified": false,
+        "line_number": 154
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/reset-password/tests/reset-password-integration.test.ts",
+        "hashed_secret": "fffcee4a43529bd0a847ca40c5855d7ac3140495",
+        "is_verified": false,
+        "line_number": 155
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/reset-password/tests/reset-password-integration.test.ts",
+        "hashed_secret": "0da19b540f7c3526f24acba988b03df43b3c5cf3",
+        "is_verified": false,
+        "line_number": 173
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/reset-password/tests/reset-password-integration.test.ts",
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_verified": false,
+        "line_number": 194
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/reset-password/tests/reset-password-integration.test.ts",
+        "hashed_secret": "19faf6bb5e27a0e95fcb7a63bec7952cd66e0e58",
+        "is_verified": false,
+        "line_number": 215
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/reset-password/tests/reset-password-integration.test.ts",
+        "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
+        "is_verified": false,
+        "line_number": 234
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/reset-password/tests/reset-password-integration.test.ts",
+        "hashed_secret": "a4abe91512306f1e4f1f8e06d0b6684ac4cd5b66",
+        "is_verified": false,
+        "line_number": 288
+      }
+    ],
+    "src/components/setup-authenticator-app/tests/setup-authenticator-app-controller.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/components/setup-authenticator-app/tests/setup-authenticator-app-controller.test.ts",
+        "hashed_secret": "dcc4a6fbee930b0b34cf9fc2131b6b70c89e6b9b",
+        "is_verified": false,
+        "line_number": 40
+      }
+    ],
+    "src/config/helmet.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/config/helmet.ts",
+        "hashed_secret": "71ecb7a9026acd0b5c75ce1cd543c411eaa78a75",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "src/locales/cy/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/cy/translation.json",
+        "hashed_secret": "e86660789cc4b73af27925cf742e2eb18bdedb9b",
+        "is_verified": false,
+        "line_number": 255
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/cy/translation.json",
+        "hashed_secret": "944d4a6ed5456f978ce48e60b88da6c60a4d3461",
+        "is_verified": false,
+        "line_number": 368
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/cy/translation.json",
+        "hashed_secret": "a994b3edd6f3856b006b87566c11a701299d0405",
+        "is_verified": false,
+        "line_number": 384
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/cy/translation.json",
+        "hashed_secret": "5632f47f0f209e611c9d9e5133005983d0c860f6",
+        "is_verified": false,
+        "line_number": 439
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/cy/translation.json",
+        "hashed_secret": "9a66c467a4931b24ead493b89c3cf43843609acb",
+        "is_verified": false,
+        "line_number": 1806
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/cy/translation.json",
+        "hashed_secret": "2deed36ce01be488ce9df73f011a09c1f9c65407",
+        "is_verified": false,
+        "line_number": 1852
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/cy/translation.json",
+        "hashed_secret": "d4546997b9ca02ed0040cd835301895b7f5a9220",
+        "is_verified": false,
+        "line_number": 2098
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/cy/translation.json",
+        "hashed_secret": "a1ea3aa78505fb28433e08a7912dbb97dca9957f",
+        "is_verified": false,
+        "line_number": 2099
+      }
+    ],
+    "src/locales/en/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/en/translation.json",
+        "hashed_secret": "bf8804f07772036fc47c44e60c9c3ce7073e6891",
+        "is_verified": false,
+        "line_number": 255
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/en/translation.json",
+        "hashed_secret": "19c985e4fb85af254a208511b6e33b75a69dbc57",
+        "is_verified": false,
+        "line_number": 368
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/en/translation.json",
+        "hashed_secret": "883c0fd42f189462668d8f5d3a5412011c035da5",
+        "is_verified": false,
+        "line_number": 439
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/en/translation.json",
+        "hashed_secret": "170ec8610dba74be0854d47db3a93c64b2222ec0",
+        "is_verified": false,
+        "line_number": 1806
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/en/translation.json",
+        "hashed_secret": "afc9105809cd11edcdd11534cccd867d797d16a8",
+        "is_verified": false,
+        "line_number": 1852
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/en/translation.json",
+        "hashed_secret": "295536fe06ba0b378a677f131337ce03f9736d3d",
+        "is_verified": false,
+        "line_number": 2098
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/locales/en/translation.json",
+        "hashed_secret": "2b029deb0a37fcdf72d3f060b8579fe723d0675b",
+        "is_verified": false,
+        "line_number": 2099
+      }
+    ],
+    "test/helpers/common-test-variables.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test/helpers/common-test-variables.ts",
+        "hashed_secret": "fca71afec681b7c2932610046e8e524820317e47",
+        "is_verified": false,
+        "line_number": 8
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/helpers/common-test-variables.ts",
+        "hashed_secret": "46c0222178bd5e9795849bf479f7adfc236ff9dc",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "test/unit/session.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test/unit/session.test.ts",
+        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test/unit/session.test.ts",
+        "hashed_secret": "6c03ac0ea7241c3b2e2b7d54ff1db5f5539dc198",
+        "is_verified": false,
+        "line_number": 117
+      }
+    ],
+    "test/unit/utils/redis.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test/unit/utils/redis.test.ts",
+        "hashed_secret": "76a9dd53f4353a5a782d87d55e59fdedad6998ba",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test/unit/utils/redis.test.ts",
+        "hashed_secret": "ce4f8c58735848e9fa0f9129c91dbe13fe64f3d6",
+        "is_verified": false,
+        "line_number": 75
+      }
+    ],
+    "test/unit/utils/strings.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "test/unit/utils/strings.test.ts",
+        "hashed_secret": "0fc376857c1a1678e8faf8e47755d73616cfd4e2",
+        "is_verified": false,
+        "line_number": 64
+      }
+    ]
+  },
+  "generated_at": "2026-04-08T14:31:52Z"
+}


### PR DESCRIPTION


## What

**Run detect-secrets as a pre-commit check**

Required by Quality Gates: https://govukverify.atlassian.net/wiki/spaces/DID/pages/6069321729/Account+Pod+Clinics#Authentication

- Add a baseline file for the current state

## How to review

1. Code Review
1. Check that the pre-commit github action runs correctly with the current baseline
1. Run the check locally:

   ```
   pre-commit run detect-secrets --all-files
   ```





