### PR TITLE
BAU: Dependabot to run twice a month only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: daily
-      time: "03:00"
+      interval: "cron"
+      cronjob: "0 3 1,15 * *"
     cooldown:
       default-days: 7
     target-branch: main
@@ -108,7 +108,8 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: "cron"
+      cronjob: "0 3 1,15 * *"
     open-pull-requests-limit: 10
     groups:
       gha-all-dependencies:


### PR DESCRIPTION


## What

Dependabot to run twice a month only

Dependabot doesn't support a 'fornightly' frequency so use a cronjob to run on the 1st and 15th of each month

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review

