### PR TITLE
BAU: revert pino-pretty to 13.0.0 and ignore minor version updates (until issue is fixed)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,7 +56,8 @@ updates:
       - dependency-name: "nodemon"
         update-types: ["version-update:semver-patch"]
       - dependency-name: "pino-pretty"
-        update-types: ["version-update:semver-patch"]
+        update-types:
+          ["version-update:semver-patch", "version-update:semver-minor"]
       - dependency-name: "prettier"
         update-types: ["version-update:semver-patch"]
       - dependency-name: "sass"

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "mock-req-res": "1.2.1",
         "nock": "15.0.0",
         "nodemon": "3.1.11",
-        "pino-pretty": "13.1.3",
+        "pino-pretty": "13.0.0",
         "prettier": "3.8.1",
         "sass": "1.99.0",
         "sinon": "21.0.0",
@@ -5298,9 +5298,9 @@
       "license": "MIT"
     },
     "node_modules/fast-copy": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
-      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.2.tgz",
+      "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7272,41 +7272,38 @@
       }
     },
     "node_modules/pino-pretty": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
-      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.0.0.tgz",
+      "integrity": "sha512-cQBBIVG3YajgoUjo1FdKVRX6t9XPxwB9lcNJVD5GCnNM4Y6T12YYx8c6zEejxQsU0wrg9TwmDulcE9LR7qcJqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.7",
         "dateformat": "^4.6.3",
-        "fast-copy": "^4.0.0",
+        "fast-copy": "^3.0.2",
         "fast-safe-stringify": "^2.1.1",
         "help-me": "^5.0.0",
         "joycon": "^3.1.1",
         "minimist": "^1.2.6",
         "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^3.0.0",
+        "pino-abstract-transport": "^2.0.0",
         "pump": "^3.0.0",
-        "secure-json-parse": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
         "sonic-boom": "^4.0.1",
-        "strip-json-comments": "^5.0.2"
+        "strip-json-comments": "^3.1.1"
       },
       "bin": {
         "pino-pretty": "bin.js"
       }
     },
-    "node_modules/pino-pretty/node_modules/strip-json-comments": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
-      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+    "node_modules/pino-pretty/node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+      "dependencies": {
+        "split2": "^4.0.0"
       }
     },
     "node_modules/pino-std-serializers": {
@@ -7988,20 +7985,10 @@
       }
     },
     "node_modules/secure-json-parse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
-      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "mock-req-res": "1.2.1",
     "nock": "15.0.0",
     "nodemon": "3.1.11",
-    "pino-pretty": "13.1.3",
+    "pino-pretty": "13.0.0",
     "prettier": "3.8.1",
     "sass": "1.99.0",
     "sinon": "21.0.0",


### PR DESCRIPTION
## What

- Revert pino-pretty to 13.0.0
- Given the issue with pino-pretty 13.0.0 stop dependabot from upgrading.

A transitive dependency in 13.1.3 has migrated to ESM but pino-pretty does not support it.

pino-pretty is crashing immediately on startup with an ERR_REQUIRE_ESM error — it's trying to require() an ESM-only module (strip-json-comments). So the pipe breaks instantly and nodemon gets EPIPE.

This is causing local startup of frontend to fail.

```
[Node] Emitted 'error' event on Socket instance at:
[Node] at emitErrorNT (node:internal/streams/destroy:169:8)
[Node] at emitErrorCloseNT (node:internal/streams/destroy:128:3)
[Node] at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
[Node] errno: -32,
[Node] code: 'EPIPE',
[Node] syscall: 'write'
[Node] }
```

## How to review

1. Code Review
1. Test local startup with `./startup.sh -L` (not there is another issue on the api side with local startup, but this fixes the frontend side)



