### PR TITLE
AUT-4800: Collect information on if browser supports passkeys

### DIFF
--- a/src/assets/javascript/check-passkeys-supported.js
+++ b/src/assets/javascript/check-passkeys-supported.js
@@ -1,0 +1,9 @@
+/* global SimpleWebAuthnBrowser */
+document.addEventListener("DOMContentLoaded", () => {
+  if (SimpleWebAuthnBrowser.browserSupportsWebAuthn()) {
+    const browserSupportsWebAuthnEl = document.getElementById(
+      "browserSupportsWebAuthn"
+    );
+    browserSupportsWebAuthnEl.value = "true";
+  }
+});

--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -117,8 +117,10 @@ export function enterEmailPost(
   checkReauthService: CheckReauthServiceInterface = checkReauthUsersService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const email = req.body.email;
+    const { email, browserSupportsWebAuthn } = req.body;
     const { sessionId, clientSessionId, persistentSessionId } = res.locals;
+    req.session.user.browserSupportsWebAuthn =
+      browserSupportsWebAuthn === "true";
     req.session.user.email = email.toLowerCase();
 
     if (isReauth(req)) {

--- a/src/components/enter-email/index-existing-account.njk
+++ b/src/components/enter-email/index-existing-account.njk
@@ -14,6 +14,8 @@
 <form action="/enter-email" method="post" novalidate>
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
+<input type="hidden" name="browserSupportsWebAuthn" id="browserSupportsWebAuthn" value="false"/>
+
 
 {{ govukInput({
      label: {

--- a/src/components/enter-email/index-existing-account.njk
+++ b/src/components/enter-email/index-existing-account.njk
@@ -45,3 +45,9 @@
 {% set ga4Params = { nonce: scriptNonce, englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: false } %}
 {%- include "ga4-opl/template.njk" -%}
 {% endblock %}
+
+{% block scripts %}
+    {% if supportPasskeyUsage or supportPasskeyRegistration %}
+        <script defer type="text/javascript" src="/public/scripts/check-passkeys-supported.js"></script>
+    {% endif %}
+{% endblock %}

--- a/src/components/enter-email/index-re-enter-email-account.njk
+++ b/src/components/enter-email/index-re-enter-email-account.njk
@@ -54,3 +54,9 @@
 {%- include "ga4-opl/template.njk" -%}
 
 {% endblock %}
+
+{% block scripts %}
+    {% if supportPasskeyUsage or supportPasskeyRegistration %}
+        <script defer type="text/javascript" src="/public/scripts/check-passkeys-supported.js"></script>
+    {% endif %}
+{% endblock %}

--- a/src/components/enter-email/index-re-enter-email-account.njk
+++ b/src/components/enter-email/index-re-enter-email-account.njk
@@ -15,6 +15,7 @@
 
 <input type="hidden" name="_csrf" value="{{csrfToken}}"/>
 <input type="hidden" name="isApp" value="{{isApp}}"/>
+<input type="hidden" name="browserSupportsWebAuthn" id="browserSupportsWebAuthn" value="false"/>
 
     <h1 class="govuk-heading-l">
         {{ 'pages.reEnterEmailAccount.header' | translate }}

--- a/src/components/enter-email/tests/enter-email-controller.test.ts
+++ b/src/components/enter-email/tests/enter-email-controller.test.ts
@@ -14,8 +14,8 @@ import type {
   EnterEmailServiceInterface,
   LockoutInformation,
 } from "../types.js";
-import { JOURNEY_TYPE, ERROR_CODES } from "../../common/constants.js";
-import { PATH_NAMES } from "../../../app.constants.js";
+import { ERROR_CODES, JOURNEY_TYPE } from "../../common/constants.js";
+import { MFA_METHOD_TYPE, PATH_NAMES } from "../../../app.constants.js";
 import type { SendNotificationServiceInterface } from "../../common/send-notification/types.js";
 import type { RequestOutput, ResponseOutput } from "mock-req-res";
 import { mockResponse } from "mock-req-res";
@@ -36,6 +36,12 @@ describe("enter email controller", () => {
       success: true,
     }),
   } as unknown as CheckReauthServiceInterface;
+
+  const passkeysSupportedValues = [
+    { browserSupportsWebAuthn: "true", expectedValInSession: true },
+    { browserSupportsWebAuthn: "false", expectedValInSession: false },
+    { browserSupportsWebAuthn: undefined, expectedValInSession: false },
+  ];
 
   beforeEach(() => {
     res = mockResponse();
@@ -213,7 +219,7 @@ describe("enter email controller", () => {
         lockType: "codeBlock",
         lockTTL: lockTTlInSeconds.toString(),
         journeyType: "SIGN_IN",
-        mfaMethodType: "SMS",
+        mfaMethodType: MFA_METHOD_TYPE.SMS,
       };
       const fakeService: EnterEmailServiceInterface = {
         userExists: sinon.fake.returns({
@@ -472,6 +478,28 @@ describe("enter email controller", () => {
       );
 
       expect(res.redirect).to.have.calledWith(PATH_NAMES.ENTER_PASSWORD);
+    });
+
+    passkeysSupportedValues.forEach((testInput) => {
+      it(`should correctly store the browserSupportsWebAuthn result in the users session when it is ${testInput.browserSupportsWebAuthn}`, async () => {
+        req.body.browserSupportsWebAuthn = testInput.browserSupportsWebAuthn;
+
+        const fakeService: EnterEmailServiceInterface = {
+          userExists: sinon.fake.returns({
+            success: true,
+            data: {
+              doesUserExist: true,
+              needsForcedMFAResetAfterMFACheck: false,
+            },
+          }),
+        } as unknown as EnterEmailServiceInterface;
+
+        await enterEmailPost(fakeService)(req as Request, res as Response);
+
+        expect(req.session.user.browserSupportsWebAuthn).to.eq(
+          testInput.expectedValInSession
+        );
+      });
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,7 @@ export interface UserSession {
   hasActivePasskey?: boolean;
   hasSkippedPasskeyRegistration?: boolean;
   needsForcedMFAReset?: boolean;
+  browserSupportsWebAuthn?: boolean;
 }
 
 export interface UserSessionClient {

--- a/src/utils/passkeys-helper.test.ts
+++ b/src/utils/passkeys-helper.test.ts
@@ -8,65 +8,118 @@ import type { Request, Response } from "express";
 
 describe("passkeys helper", () => {
   describe("shouldPromptToRegisterPasskey", () => {
-    it(`should return true when hasActivePasskey=false and supportPasskeyRegistration=true`, () => {
-      // Arrange
-      const expected = true;
-
-      const req = {
-        session: { user: { hasActivePasskey: false } },
-      } as any as Request;
-
-      const res = {
-        locals: { supportPasskeyRegistration: true },
-      } as any as Response;
-
-      // Act
-      const actual = shouldPromptToRegisterPasskey(req, res);
-
-      // Assert
-      expect(actual).to.eq(expected);
-    });
-  });
-
-  it(`should return false when user has skipped passkey registration already in the journey`, () => {
-    // Arrange
-    const expected = false;
-
-    const req = {
-      session: {
-        user: { hasActivePasskey: true, hasSkippedPasskeyRegistration: true },
+    const testCases = [
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: false,
+        hasSkippedPasskeyRegistration: false,
+        supportPasskeyRegistration: true,
+        expected: true,
       },
-    } as any as Request;
+      {
+        browserSupportsWebAuthn: false,
+        hasActivePasskey: false,
+        hasSkippedPasskeyRegistration: false,
+        supportPasskeyRegistration: true,
+        expected: false,
+      },
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: true,
+        hasSkippedPasskeyRegistration: false,
+        supportPasskeyRegistration: true,
+        expected: false,
+      },
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: false,
+        hasSkippedPasskeyRegistration: true,
+        supportPasskeyRegistration: true,
+        expected: false,
+      },
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: false,
+        hasSkippedPasskeyRegistration: false,
+        supportPasskeyRegistration: false,
+        expected: false,
+      },
+    ];
 
-    const res = {
-      locals: { supportPasskeyUsage: true },
-    } as any as Response;
+    testCases.forEach(
+      ({
+        browserSupportsWebAuthn,
+        hasActivePasskey,
+        hasSkippedPasskeyRegistration,
+        supportPasskeyRegistration,
+        expected,
+      }) => {
+        it(`should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, hasSkippedPasskeyRegistration=${hasSkippedPasskeyRegistration}, supportPasskeyRegistration=${supportPasskeyRegistration}`, () => {
+          const req = {
+            session: {
+              user: {
+                browserSupportsWebAuthn,
+                hasActivePasskey,
+                hasSkippedPasskeyRegistration,
+              },
+            },
+          } as any as Request;
+          const res = {
+            locals: { supportPasskeyRegistration },
+          } as any as Response;
 
-    // Act
-    const actual = shouldPromptToRegisterPasskey(req, res);
-
-    // Assert
-    expect(actual).to.eq(expected);
+          expect(shouldPromptToRegisterPasskey(req, res)).to.eq(expected);
+        });
+      }
+    );
   });
 
   describe("shouldPromptToSignInWithPasskey", () => {
-    it(`should return true when hasActivePasskey=true and supportPasskeyUsage=true`, () => {
-      // Arrange
-      const expected = true;
+    const testCases = [
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: true,
+        supportPasskeyUsage: true,
+        expected: true,
+      },
+      {
+        browserSupportsWebAuthn: false,
+        hasActivePasskey: true,
+        supportPasskeyUsage: true,
+        expected: false,
+      },
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: false,
+        supportPasskeyUsage: true,
+        expected: false,
+      },
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: true,
+        supportPasskeyUsage: false,
+        expected: false,
+      },
+    ];
 
-      const req = {
-        session: { user: { hasActivePasskey: true } },
-      } as any as Request;
+    testCases.forEach(
+      ({
+        browserSupportsWebAuthn,
+        hasActivePasskey,
+        supportPasskeyUsage,
+        expected,
+      }) => {
+        it(`should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, supportPasskeyUsage=${supportPasskeyUsage}`, () => {
+          const req = {
+            session: { user: { browserSupportsWebAuthn, hasActivePasskey } },
+          } as any as Request;
+          const res = {
+            locals: { supportPasskeyUsage },
+          } as any as Response;
 
-      const res = {
-        locals: { supportPasskeyUsage: true },
-      } as any as Response;
-
-      // Act
-      const actual = shouldPromptToSignInWithPasskey(req, res);
-
-      // Assert
-      expect(actual).to.eq(expected);
-    });
+          expect(shouldPromptToSignInWithPasskey(req, res)).to.eq(expected);
+        });
+      }
+    );
   });
 });

--- a/src/utils/passkeys-helper.ts
+++ b/src/utils/passkeys-helper.ts
@@ -5,6 +5,7 @@ export function shouldPromptToRegisterPasskey(
   res: Response
 ): boolean {
   return (
+    req.session.user?.browserSupportsWebAuthn === true &&
     req.session.user?.hasActivePasskey === false &&
     req.session.user?.hasSkippedPasskeyRegistration !== true &&
     res.locals.supportPasskeyRegistration === true
@@ -16,6 +17,7 @@ export function shouldPromptToSignInWithPasskey(
   res: Response
 ): boolean {
   return (
+    req.session.user?.browserSupportsWebAuthn === true &&
     req.session.user?.hasActivePasskey === true &&
     res.locals.supportPasskeyUsage === true
   );

--- a/test/unit/check-passkeys-supported.test.ts
+++ b/test/unit/check-passkeys-supported.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from "mocha";
+import fs from "fs";
+import path from "path";
+import { JSDOM } from "jsdom";
+import { expect } from "chai";
+
+const scriptContent = fs.readFileSync(
+  path.join(process.cwd(), "src/assets/javascript/check-passkeys-supported.js"),
+  "utf-8"
+);
+
+describe("check-passkeys-supported", () => {
+  function setup(mockBrowserSupportsWebAuthnVal: boolean) {
+    const dom = new JSDOM(
+      `<!DOCTYPE html>
+      <html>
+        <body>
+          <form>
+            <input type="hidden" name="browserSupportsWebAuthn" id="browserSupportsWebAuthn" value="false"/>
+          </form>
+          <script>
+            var SimpleWebAuthnBrowser = {
+              browserSupportsWebAuthn: function() { return ${mockBrowserSupportsWebAuthnVal}; }
+            };
+          </script>
+          <script>${scriptContent}</script>
+        </body>
+      </html>`,
+      { runScripts: "dangerously", url: "http://localhost" }
+    );
+
+    const domContentLoaded = new Promise<void>((resolve) => {
+      dom.window.document.addEventListener("DOMContentLoaded", () => resolve());
+      setTimeout(resolve, 0);
+    });
+
+    return {
+      document: dom.window.document,
+      domContentLoaded: domContentLoaded,
+    };
+  }
+
+  it("should set browserSupportsWebAuthn to true if api supported", async () => {
+    const { document, domContentLoaded } = setup(true);
+    await domContentLoaded;
+
+    const input = document.getElementById(
+      "browserSupportsWebAuthn"
+    ) as HTMLInputElement;
+    expect(input.value).to.eq("true");
+  });
+
+  it("should not set browserSupportsWebAuthn to true if api not supported", async () => {
+    const { document, domContentLoaded } = setup(false);
+    await domContentLoaded;
+
+    const input = document.getElementById(
+      "browserSupportsWebAuthn"
+    ) as HTMLInputElement;
+    expect(input.value).to.eq("false");
+  });
+});


### PR DESCRIPTION
## What

- Add a new javascript module to check if the browser supports webauthn. If it does, set the value of a hidden input on the template to be "true". Handle this value in the enterEmailPost controller and set it as a boolean in the session
- Only allow `shouldPromptToRegisterPasskey` and `shouldPromptToSignInWithPasskey` if this value is `true`

## How to review

1. Code review
2. Test in a deployed dev env


