### PR TITLE
AUT-5068: Track history from enter email to enter password

### DIFF
--- a/@types/express/index.d.ts
+++ b/@types/express/index.d.ts
@@ -55,6 +55,9 @@ declare global {
       showTestBanner?: boolean;
       accountManagementUrl?: string;
       contactUsLinkUrl?: string;
+
+      // History
+      goBackHistory?: string[];
     }
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -114,6 +114,7 @@ import { createPasskeyRouter } from "./components/create-passkey/create-passkey-
 import { createPasskeyCallbackRouter } from "./components/create-passkey-callback/create-passkey-callback-routes.js";
 import { sessionEndedRouter } from "./components/session-ended/session-ended-routes.js";
 import { passkeyCreatedRouter } from "./components/passkey-created/passkey-created-routes.js";
+import { setGoBackHistoryMiddleware } from "./middleware/set-go-back-history-middleware.js";
 
 const directory_name = dirname(fileURLToPath(import.meta.url));
 
@@ -312,6 +313,7 @@ async function createApp(): Promise<express.Application> {
     app.use(setCurrentUrlMiddleware);
   }
   app.use(getAnalyticsPropertiesMiddleware);
+  app.use(setGoBackHistoryMiddleware);
 
   // Attach context to request logs
   app.use((req, res, next) => {

--- a/src/components/common/state-machine/go-back-history.ts
+++ b/src/components/common/state-machine/go-back-history.ts
@@ -1,0 +1,35 @@
+import type { Request, Response } from "express";
+import type { AuthState } from "./state-machine.js";
+
+export function getGoBackHistoryForTransition(
+  req: Request,
+  res: Response,
+  currentState: string,
+  nextState: AuthState
+): string[] {
+  const isReversibleTransition =
+    (nextState.transitions.length > 0 &&
+      nextState.transitions.every((t) => t.meta?.reversible === true)) ??
+    false;
+  const passkeysEnabled =
+    res.locals.supportPasskeyRegistration || res.locals.supportPasskeyUsage;
+  return buildGoBackHistoryForTransition(
+    req.session.user?.journey?.goBackHistory ?? [],
+    passkeysEnabled,
+    currentState,
+    isReversibleTransition
+  );
+}
+
+export function buildGoBackHistoryForTransition(
+  currentGoBackHistory: string[],
+  passkeysEnabled: boolean,
+  previousState: string,
+  isReversibleTransition: boolean
+): string[] {
+  if (!passkeysEnabled || !isReversibleTransition) {
+    return currentGoBackHistory;
+  }
+
+  return [...currentGoBackHistory, previousState];
+}

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -10,6 +10,7 @@ import {
   shouldPromptToSignInWithPasskey,
 } from "../../../utils/passkeys-helper.js";
 import { needsForcedMFAReset } from "../../../utils/request.js";
+import { getGoBackHistoryForTransition } from "./go-back-history.js";
 
 export async function getNextPathAndUpdateJourney(
   req: Request,
@@ -38,6 +39,12 @@ export async function getNextPathAndUpdateJourney(
   };
 
   const nextState = getNextState(currentState, event, context);
+  const goBackHistory = getGoBackHistoryForTransition(
+    req,
+    res,
+    currentState,
+    nextState
+  );
 
   req.session.user.journey = {
     nextPath: nextState.value,
@@ -46,6 +53,7 @@ export async function getNextPathAndUpdateJourney(
         ? nextState.meta[`${authStateMachine.id}.${nextState.value}`]
             .optionalPaths
         : [],
+    goBackHistory,
   };
 
   await saveSessionState(req);
@@ -59,6 +67,7 @@ export async function getNextPathAndUpdateJourney(
         sessionState,
       },
       sessionId,
+      goBackHistory,
     },
     `User journey transition`
   );

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -133,7 +133,7 @@ const authStateMachine = createMachine<AuthStateContext>(
               target: [PATH_NAMES.SIGN_IN_WITH_PASSKEY],
               cond: "shouldPromptToSignInWithPasskey",
             },
-            { target: [PATH_NAMES.ENTER_PASSWORD] },
+            { target: [PATH_NAMES.ENTER_PASSWORD], meta: { reversible: true } },
           ],
           [USER_JOURNEY_EVENTS.ACCOUNT_NOT_FOUND]: [
             PATH_NAMES.ACCOUNT_NOT_FOUND,

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -771,7 +771,7 @@ const authStateMachine = createMachine<AuthStateContext>(
 );
 
 // Extend the state interface to be more precise
-interface AuthState extends State<AuthStateContext> {
+export interface AuthState extends State<AuthStateContext> {
   value: string;
   meta: {
     [id: string]: {

--- a/src/components/common/state-machine/tests/go-back-history.test.ts
+++ b/src/components/common/state-machine/tests/go-back-history.test.ts
@@ -1,0 +1,263 @@
+import { expect } from "chai";
+import { describe } from "mocha";
+import {
+  buildGoBackHistoryForTransition,
+  getGoBackHistoryForTransition,
+} from "../go-back-history.js";
+import { createMockRequest } from "../../../../../test/helpers/mock-request-helper.js";
+import { mockResponse } from "mock-req-res";
+import type { AuthState } from "../state-machine.js";
+
+describe("go-back-history", () => {
+  describe("buildGoBackHistoryForTransition", () => {
+    const testCases = [
+      {
+        currentGoBackHistory: [] as string[],
+        passkeysEnabled: true,
+        previousState: "/first-path",
+        isReversibleTransition: true,
+        expected: ["/first-path"],
+      },
+      {
+        currentGoBackHistory: ["/first-path"],
+        passkeysEnabled: true,
+        previousState: "/second-path",
+        isReversibleTransition: true,
+        expected: ["/first-path", "/second-path"],
+      },
+      {
+        currentGoBackHistory: ["/first-path"],
+        passkeysEnabled: true,
+        previousState: "/second-path",
+        isReversibleTransition: false,
+        expected: ["/first-path"],
+      },
+      {
+        currentGoBackHistory: ["/first-path"],
+        passkeysEnabled: false,
+        previousState: "/second-path",
+        isReversibleTransition: true,
+        expected: ["/first-path"],
+      },
+      {
+        currentGoBackHistory: ["/first-path"],
+        passkeysEnabled: false,
+        previousState: "/second-path",
+        isReversibleTransition: false,
+        expected: ["/first-path"],
+      },
+    ];
+
+    testCases.forEach(
+      ({
+        currentGoBackHistory,
+        passkeysEnabled,
+        previousState,
+        isReversibleTransition,
+        expected,
+      }) => {
+        it(`should return ${expected} when currentGoBackHistory=${currentGoBackHistory}, passkeysEnabled=${passkeysEnabled}, previousState=${previousState}, isReversibleTransition=${isReversibleTransition} `, () => {
+          expect(
+            buildGoBackHistoryForTransition(
+              currentGoBackHistory,
+              passkeysEnabled,
+              previousState,
+              isReversibleTransition
+            )
+          ).to.deep.equal(expected);
+        });
+      }
+    );
+  });
+
+  describe("getGoBackHistoryForTransition", () => {
+    function createNextState(
+      transitions: { meta?: { reversible?: boolean } }[]
+    ): AuthState {
+      return { transitions: transitions } as unknown as AuthState;
+    }
+
+    it("should append currentState when passkeys enabled and all transitions are reversible", () => {
+      const req = createMockRequest("/enter-password");
+      req.session.user = {
+        journey: {
+          nextPath: "/enter-email",
+          optionalPaths: [],
+          goBackHistory: [],
+        },
+      };
+      const res = mockResponse({ locals: { supportPasskeyUsage: true } });
+
+      const result = getGoBackHistoryForTransition(
+        req,
+        res,
+        "/enter-email",
+        createNextState([{ meta: { reversible: true } }])
+      );
+
+      expect(result).to.deep.equal(["/enter-email"]);
+    });
+
+    it("should not append when passkeys disabled even if transition is reversible", () => {
+      const req = createMockRequest("/enter-password");
+      req.session.user = {
+        journey: {
+          nextPath: "/enter-email",
+          optionalPaths: [],
+          goBackHistory: [],
+        },
+      };
+      const res = mockResponse({ locals: {} });
+
+      const result = getGoBackHistoryForTransition(
+        req,
+        res,
+        "/enter-email",
+        createNextState([{ meta: { reversible: true } }])
+      );
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it("should not append when any transition in the array is not reversible", () => {
+      const req = createMockRequest("/enter-password");
+      req.session.user = {
+        journey: {
+          nextPath: "/enter-email",
+          optionalPaths: [],
+          goBackHistory: [],
+        },
+      };
+      const res = mockResponse({
+        locals: { supportPasskeyRegistration: true },
+      });
+
+      const result = getGoBackHistoryForTransition(
+        req,
+        res,
+        "/enter-email",
+        createNextState([
+          { meta: { reversible: true } },
+          { meta: { reversible: false } },
+        ])
+      );
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it("should not append when transitions have no meta at all", () => {
+      const req = createMockRequest("/enter-password");
+      req.session.user = {
+        journey: {
+          nextPath: "/enter-email",
+          optionalPaths: [],
+          goBackHistory: [],
+        },
+      };
+      const res = mockResponse({ locals: { supportPasskeyUsage: true } });
+
+      const result = getGoBackHistoryForTransition(
+        req,
+        res,
+        "/enter-email",
+        createNextState([{}])
+      );
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it("should preserve existing goBackHistory and append currentState", () => {
+      const req = createMockRequest("/enter-password");
+      req.session.user = {
+        journey: {
+          nextPath: "/enter-email",
+          optionalPaths: [],
+          goBackHistory: ["/sign-in-or-create"],
+        },
+      };
+      const res = mockResponse({ locals: { supportPasskeyUsage: true } });
+
+      const result = getGoBackHistoryForTransition(
+        req,
+        res,
+        "/enter-email",
+        createNextState([{ meta: { reversible: true } }])
+      );
+
+      expect(result).to.deep.equal(["/sign-in-or-create", "/enter-email"]);
+    });
+
+    it("should treat supportPasskeyRegistration as passkeys enabled", () => {
+      const req = createMockRequest("/enter-password");
+      req.session.user = {
+        journey: {
+          nextPath: "/enter-email",
+          optionalPaths: [],
+          goBackHistory: [],
+        },
+      };
+      const res = mockResponse({
+        locals: {
+          supportPasskeyRegistration: true,
+          supportPasskeyUsage: false,
+        },
+      });
+
+      const result = getGoBackHistoryForTransition(
+        req,
+        res,
+        "/enter-email",
+        createNextState([{ meta: { reversible: true } }])
+      );
+
+      expect(result).to.deep.equal(["/enter-email"]);
+    });
+
+    it("should treat supportPasskeyUsage as passkeys enabled", () => {
+      const req = createMockRequest("/enter-password");
+      req.session.user = {
+        journey: {
+          nextPath: "/enter-email",
+          optionalPaths: [],
+          goBackHistory: [],
+        },
+      };
+      const res = mockResponse({
+        locals: {
+          supportPasskeyRegistration: false,
+          supportPasskeyUsage: true,
+        },
+      });
+
+      const result = getGoBackHistoryForTransition(
+        req,
+        res,
+        "/enter-email",
+        createNextState([{ meta: { reversible: true } }])
+      );
+
+      expect(result).to.deep.equal(["/enter-email"]);
+    });
+
+    it("should not append when transitions array is empty", () => {
+      const req = createMockRequest("/enter-password");
+      req.session.user = {
+        journey: {
+          nextPath: "/enter-email",
+          optionalPaths: [],
+          goBackHistory: [],
+        },
+      };
+      const res = mockResponse({ locals: { supportPasskeyUsage: true } });
+
+      const result = getGoBackHistoryForTransition(
+        req,
+        res,
+        "/enter-email",
+        createNextState([])
+      );
+
+      expect(result).to.deep.equal([]);
+    });
+  });
+});

--- a/src/components/common/state-machine/tests/state-machine.test.ts
+++ b/src/components/common/state-machine/tests/state-machine.test.ts
@@ -78,6 +78,7 @@ describe("state-machine", () => {
         DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.ENTER_PASSWORD);
+      expect(nextState.transitions[0]?.meta?.reversible).to.be.true;
     });
 
     it("should move from enter password to enter mfa code when user event is credentials validated", () => {

--- a/src/components/common/state-machine/tests/state-machine.test.ts
+++ b/src/components/common/state-machine/tests/state-machine.test.ts
@@ -78,7 +78,8 @@ describe("state-machine", () => {
         DEFAULT_CONTEXT
       );
       expect(nextState.value).to.equal(PATH_NAMES.ENTER_PASSWORD);
-      expect(nextState.transitions[0]?.meta?.reversible).to.be.true;
+      expect(nextState.transitions.every((t) => t.meta?.reversible === true)).to
+        .be.true;
     });
 
     it("should move from enter password to enter mfa code when user event is credentials validated", () => {

--- a/src/components/enter-email/tests/enter-email-integration.test.ts
+++ b/src/components/enter-email/tests/enter-email-integration.test.ts
@@ -21,6 +21,7 @@ describe("Integration::enter email", () => {
   let cookies: string;
   let app: any;
   let baseApi: string;
+  let capturedSession: any;
 
   before(async () => {
     const { createApp } = await esmock(
@@ -45,9 +46,19 @@ describe("Integration::enter email", () => {
               req.session.user.reauthenticate = "12345";
             }
 
+            if (process.env.SUPPORT_PASSKEY_USAGE === "1") {
+              res.locals.supportPasskeyUsage = true;
+            }
+
+            if (process.env.SUPPORT_PASSKEY_REGISTRATION === "1") {
+              res.locals.supportPasskeyRegistration = true;
+            }
+
             req.session.client = {
               redirectUri: REDIRECT_URI,
             };
+
+            capturedSession = req.session;
 
             next();
           }),
@@ -68,6 +79,8 @@ describe("Integration::enter email", () => {
     sinon.restore(); // Restore all stubs before each test
     process.env.SUPPORT_REAUTHENTICATION = "0";
     process.env.TEST_SETUP_REAUTH_SESSION = "0";
+    process.env.SUPPORT_PASSKEY_USAGE = "0";
+    process.env.SUPPORT_PASSKEY_REGISTRATION = "0";
   });
 
   afterEach(() => {
@@ -187,6 +200,36 @@ describe("Integration::enter email", () => {
       })
       .expect("Location", PATH_NAMES.ENTER_PASSWORD)
       .expect(302);
+
+    expect(capturedSession.user.journey.goBackHistory).to.be.empty;
+  });
+
+  it("should redirect to /enter-password and save enter-email in goBackHistory when passkeys are enabled", async () => {
+    process.env.SUPPORT_PASSKEY_REGISTRATION = "1";
+    process.env.SUPPORT_PASSKEY_USAGE = "1";
+
+    nock(baseApi)
+      .post(API_ENDPOINTS.USER_EXISTS)
+      .once()
+      .reply(HTTP_STATUS_CODES.OK, {
+        email: "test@test.com",
+        doesUserExist: true,
+      });
+
+    await request(app)
+      .post(PATH_NAMES.ENTER_EMAIL_SIGN_IN)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        email: "test@test.com",
+      })
+      .expect("Location", PATH_NAMES.ENTER_PASSWORD)
+      .expect(302);
+
+    expect(capturedSession.user.journey.goBackHistory).to.deep.equal([
+      PATH_NAMES.ENTER_EMAIL_SIGN_IN,
+    ]);
   });
 
   it("should redirect to /account-not-found when email address not found", async () => {

--- a/src/middleware/set-go-back-history-middleware.ts
+++ b/src/middleware/set-go-back-history-middleware.ts
@@ -1,0 +1,10 @@
+import type { NextFunction, Request, Response } from "express";
+
+export async function setGoBackHistoryMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  res.locals.goBackHistory = req.session.user?.journey?.goBackHistory ?? [];
+  next();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export interface PlaceholderReplacement {
 export interface UserJourney {
   nextPath: string;
   optionalPaths: string[];
+  goBackHistory?: string[];
 }
 
 export interface UserSession {


### PR DESCRIPTION
## What

- Add goBackHistory to session and res.locals so it can be exposed for templates
- Make transition from enter-email to enter-password reversible
- Add the previousPath to goBackHistory if passkeys are enabled and the transition was reversible


## How to review

1. Code review
2. Deploy to dev env, run through a journey and check that the `goBackHistory` is what you expect it to be (ie enter-email once we get to enter-password and then it should stay as that as the journey progresses)


## Checklist

