### PR TITLE
BAU: Remove unecessary detail from readme

### DIFF
--- a/playwright-acceptance-tests/README.md
+++ b/playwright-acceptance-tests/README.md
@@ -9,15 +9,11 @@ with built-in support for reporting, flaky-test analysis, environment configurat
 ### Table of Contents
 
 - Overview
-- Tech Stack
-- Project Structure
 - Environment Variables
 - Installation
 - Running Tests
 - Tags & Filtering
 - Reporting
-- Scripts
-- Adding New Tests
 - Development Standards
 - Troubleshooting
 - Roadmap
@@ -36,61 +32,6 @@ This project provides automated acceptance coverage for user journeys in GOV.UK 
 The suite is intentionally lightweight and modular, supporting migration from Selenium-Java to Playwright-TypeScript.
 
 Tests will run locally or in CI (GitHub Actions / AWS CodeBuild), using environment variables to configure runtime behaviour.
-
-### Tech Stack
-
-```
-Component	Version / Notes
-Playwright	1.56.1
-Cucumber.js	9.6.0
-TypeScript	5.9.3
-Node	Recommended: Node 20 LTS
-ESLint	Enabled
-Prettier	Enabled
-dotenv	.env loading
-multiple-cucumber-html-reporter	HTML reporting
-axe-core/playwright	Optional a11y testing
-```
-
-### Project Structure
-
-```
-playwright-acceptance-tests/
-│
-├── features/
-│   ├── create-or-signin.feature
-│   └── stub-journey.feature
-│
-├── reports/
-│   ├── cucumber-json/
-│   ├── html/
-│   └── screenshots/
-│
-├── src/
-│   ├── pages/
-│   │   ├── BasePage.ts
-│   │   ├── StubStartPage.ts
-│   │   ├── CreateOrSignInPage.ts
-│   │   └── EnterEmailPage.ts
-│   │
-│   ├── steps/
-│   │   └── stub-journey.steps.ts
-│   │
-│   ├── support/
-│   │   ├── hooks.ts
-│   │   └── world.ts
-│   │
-│   ├── clean-json.js
-│   ├── clean-reports.js
-│   ├── run-test-with-report.js
-│   └── cucumber.js
-│
-├── .env
-├── .gitignore
-├── package.json
-├── tsconfig.json
-└── .eslintrc.cjs
-```
 
 ### Environment Variables
 
@@ -219,53 +160,9 @@ Overall pass/failure metrics
 Handled by: run-test-with-report.js
 ```
 
-### Scripts
-
-From package.json:
-
-```
-"scripts": {
-"clean:reports": "node clean-reports.js",
-"bdd": "cucumber-js",
-"bdd:report": "node run-test-with-report.js",
-"test": "npm run bdd:report",
-"lint": "eslint . --ext .ts",
-"format": "prettier --write ."
-}
-```
-
-### Adding New Tests
-
-**Create feature file**
-
-```
-features/new-journey.feature
-```
-
-**Create page objects**
-Place inside:
-
-```
-src/pages/
-```
-
-**Create step definitions**
-Place inside:
-
-```
-src/steps/
-```
-
-**Test configuration**
-Reuse:
-
-- BasePage
-- PlaywrightWorld
-- Hooks for browser open/close + screenshot on fail
-
 ### Development Standards
 
-Developers commit normally from the root repository — formatting needs to be run manually.
+Developers should consider the following when working on these tests:
 
 - Code quality
 - ESLint must pass
@@ -279,12 +176,6 @@ Run the following to format staged files:
 cd playwright-acceptance-tests
 npx lint-staged
 ```
-
-**Page Object Model**
-
-- One class per page
-- Define locators at the top
-- No assertions inside page objects
 
 **Accessibility**
 


### PR DESCRIPTION
Improve maintainability of repo by removing unnecessary details from readme that can easily go out of sync with the codebase.

* Project structure is subject to change and is obvious from looking at the repo anyway
* Ditto for scripts, and tech stack
* Remove reference to how to create tests - this should be apparent from existing files and can easily get out of date if we change our way of doing things

## How to review

* Code review

