### PR TITLE
BAU: turn off passkey usage in dev

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -518,7 +518,7 @@ Mappings:
       PrivacyNoticeRedirectEnabled: "Yes"
       OrchApiBaseUrl: "https://oidc.dev.account.gov.uk"
       UseRebrand: "Yes"
-      SupportPasskeyUsage: "Yes"
+      SupportPasskeyUsage: "No"
       SupportPasskeyRegistration: "Yes"
       SupportNewInternationalSms: "No"
       EnableDwpKbvContactFormChanges: "Yes"


### PR DESCRIPTION
Turning it on requires a rethink of the acceptance tests which run in dev. To be ticketed
