### PR TITLE
AUT-4939: Accept possibly null hasActivePasskey from API

### DIFF
--- a/src/components/enter-email/types.ts
+++ b/src/components/enter-email/types.ts
@@ -8,7 +8,7 @@ export interface UserExists extends DefaultApiResponse {
   mfaMethodType: MFA_METHOD_TYPE;
   phoneNumberLastThree?: string;
   lockoutInformation?: LockoutInformation[];
-  hasActivePasskey: boolean;
+  hasActivePasskey: boolean | null;
   needsForcedMFAResetAfterMFACheck: boolean;
 }
 export interface LockoutInformation {

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,7 +92,7 @@ export interface UserSession {
   isMfaRequired?: boolean;
   activeMfaMethodId?: string;
   sentOtpMfaMethodIds?: string[];
-  hasActivePasskey?: boolean;
+  hasActivePasskey?: boolean | null;
   hasSkippedPasskeyRegistration?: boolean;
   needsForcedMFAReset?: boolean;
   browserSupportsWebAuthn?: boolean;

--- a/src/utils/passkeys-helper.test.ts
+++ b/src/utils/passkeys-helper.test.ts
@@ -66,6 +66,14 @@ describe("passkeys helper", () => {
         rpClientId: "invalid-rp-client-id",
         expected: false,
       },
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: null,
+        hasSkippedPasskeyRegistration: false,
+        supportPasskeyRegistration: true,
+        rpClientId: "valid-rp-client-id",
+        expected: false,
+      },
     ];
 
     testCases.forEach(
@@ -128,6 +136,12 @@ describe("passkeys helper", () => {
         browserSupportsWebAuthn: true,
         hasActivePasskey: true,
         supportPasskeyUsage: false,
+        expected: false,
+      },
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: null,
+        supportPasskeyUsage: true,
         expected: false,
       },
     ];


### PR DESCRIPTION
## What

Now, in cases where the backend was unable to determine if the user had a passkey, it returns `null`. In this situation, we shouldn't display any passkey journeys to the user.

## How to review

1. Code Review
2. Test

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/8290