### PR TITLE
BAU: Remove duplicate uglify-js from production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "pino-http": "11.0.0",
         "qrcode": "1.5.4",
         "redis": "5.12.1",
-        "uglify-js": "3.19.3",
         "uid-safe": "2.1.5",
         "xss": "1.0.15",
         "xstate": "4.26.1"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "pino-http": "11.0.0",
     "qrcode": "1.5.4",
     "redis": "5.12.1",
-    "uglify-js": "3.19.3",
     "uid-safe": "2.1.5",
     "xss": "1.0.15",
     "xstate": "4.26.1"


### PR DESCRIPTION
## What

- Removes `uglify-js` from `dependencies` in `package.json` — it is already declared in `devDependencies`
- `uglify-js` is only used as a CLI build tool (in the `minfiy-build-js` npm script) and is never imported in source code
- The Dockerfile runs `npm ci` (which installs all deps including devDeps) before building, then prunes with `--omit=dev`, so the build tool is available when needed
- Having it in both `dependencies` and `devDependencies` is redundant and causes it to be included in the production image unnecessarily

## How to review

1. Code Review
2. Verify no compile/test failures