### PR TITLE
BAU: Constrain uuid to >=11.1.1 to fix CVE-2026-41907

### DIFF
--- a/journey-map/package-lock.json
+++ b/journey-map/package-lock.json
@@ -33,8 +33,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@aws-sdk/client-kms": "3.1038.0",
-        "@aws-sdk/client-ssm": "3.1038.0",
+        "@aws-sdk/client-kms": "3.1042.0",
+        "@aws-sdk/client-ssm": "3.1042.0",
         "@govuk-one-login/frontend-analytics": "4.0.5",
         "@govuk-one-login/frontend-device-intelligence": "1.2.0",
         "@govuk-one-login/frontend-language-toggle": "2.2.2",
@@ -44,22 +44,22 @@
         "@otplib/core": "12.0.1",
         "@otplib/plugin-base32-enc-dec": "12.0.1",
         "@simplewebauthn/browser": "13.3.0",
-        "axios": "1.15.2",
+        "axios": "1.16.0",
         "connect-redis": "9.0.0",
         "cookie-parser": "1.4.7",
         "csrf-sync": "4.2.1",
-        "dompurify": "3.4.1",
+        "dompurify": "3.4.2",
         "express": "5.2.1",
         "express-session": "1.19.0",
         "express-validator": "7.3.2",
         "govuk-frontend": "5.11.2",
         "helmet": "8.1.0",
-        "i18next": "26.0.8",
+        "i18next": "26.0.10",
         "i18next-fs-backend": "2.6.5",
         "i18next-http-middleware": "3.9.6",
         "jose": "6.2.3",
-        "jsdom": "26.1.0",
-        "libphonenumber-js": "1.12.42",
+        "jsdom": "29.1.1",
+        "libphonenumber-js": "1.12.43",
         "nunjucks": "3.2.4",
         "overload-protection": "1.2.3",
         "pino": "10.3.1",
@@ -77,7 +77,7 @@
         "@eslint/js": "9.39.4",
         "@playwright/test": "1.59.1",
         "@types/chai": "5.2.3",
-        "@types/cheerio": "0.22.35",
+        "@types/cheerio": "1.0.0",
         "@types/cookie-parser": "1.4.10",
         "@types/express": "5.0.6",
         "@types/express-session": "1.19.0",
@@ -98,13 +98,13 @@
         "@typescript-eslint/parser": "8.59.1",
         "c8": "11.0.0",
         "chai": "6.2.2",
-        "cheerio": "1.0.0",
+        "cheerio": "1.2.0",
         "concurrently": "9.2.1",
         "dotenv": "17.4.1",
         "eslint": "9.39.2",
-        "eslint-plugin-no-only-tests": "3.3.0",
+        "eslint-plugin-no-only-tests": "3.4.0",
         "esmock": "2.7.3",
-        "globals": "17.5.0",
+        "globals": "17.6.0",
         "mocha": "11.7.5",
         "mock-req-res": "1.2.1",
         "nock": "15.0.0",
@@ -112,7 +112,7 @@
         "pino-pretty": "13.0.0",
         "prettier": "3.8.1",
         "sass": "1.99.0",
-        "sinon": "21.1.2",
+        "sinon": "22.0.0",
         "sinon-chai": "4.0.1",
         "supertest": "7.2.2",
         "ts-node": "10.9.2",
@@ -1286,6 +1286,7 @@
       "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.34.0",
         "@typescript-eslint/types": "8.34.0",
@@ -1526,6 +1527,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1808,6 +1810,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -2220,6 +2223,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2510,6 +2514,7 @@
       "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4229,16 +4234,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/esm/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/journey-map/package.json
+++ b/journey-map/package.json
@@ -38,6 +38,7 @@
   },
   "overrides": {
     "lodash-es": "4.18.1",
-    "dompurify": ">=3.4.0"
+    "dompurify": ">=3.4.0",
+    "uuid": ">=11.1.1"
   }
 }

--- a/playwright-acceptance-tests/package-lock.json
+++ b/playwright-acceptance-tests/package-lock.json
@@ -139,6 +139,7 @@
       "integrity": "sha512-iRSiK8YAIHAmLrn/mUfpAx7OXZ7LyNlh1zT89RoziSVCbqSVDxJS6ckEzW8loxs+EEXl0dKPQOXiDmbHV+C/fA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cucumber/messages": ">=19.1.4 <=22"
       }
@@ -245,6 +246,7 @@
       "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@cucumber/messages": ">=17.1.1"
       }
@@ -255,6 +257,7 @@
       "integrity": "sha512-EuaUtYte9ilkxcKmfqGF9pJsHRUU0jwie5ukuZ/1NPTuHS1LxHPsGEODK17RPRbZHOFhqybNzG2rHAwThxEymg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/uuid": "9.0.1",
         "class-transformer": "0.5.1",
@@ -634,6 +637,7 @@
       "integrity": "sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -681,6 +685,7 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -899,6 +904,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1297,6 +1303,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2293,20 +2300,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/multiple-cucumber-html-reporter/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -2519,6 +2512,7 @@
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -3019,6 +3013,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3072,13 +3067,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/playwright-acceptance-tests/package.json
+++ b/playwright-acceptance-tests/package.json
@@ -29,5 +29,8 @@
     "prettier": "3.6.2",
     "ts-node": "10.9.2",
     "typescript": "5.9.3"
+  },
+  "overrides": {
+    "uuid": ">=11.1.1"
   }
 }


### PR DESCRIPTION
## What

- CVE-2026-41907: uuid has a missing buffer bounds check in v3/v5/v6 when buf is provided. Constraining to >=11.1.1 in playwright-acceptance-tests and journey-map sub-projects where the vulnerable transitive dependency was resolved.

## How to review

1. Code Review