### PR TITLE
AUT-5433: Add dual session store (and enable in dev and staging)

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -429,6 +429,29 @@ Conditions:
               ]
               - "Yes"
 
+  SessionDualWriteEnabled:
+    Fn::Or:
+      - Fn::And:
+          - !Condition UseSubEnvironment
+          - Fn::Equals:
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref SubEnvironment,
+                  SessionDualWriteEnabled,
+                  DefaultValue: "No",
+                ]
+              - "Yes"
+      - Fn::And:
+          - !Condition NotSubEnvironment
+          - Fn::Equals:
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  SessionDualWriteEnabled,
+                  DefaultValue: "No",
+                ]
+              - "Yes"
+
 Mappings:
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
@@ -456,6 +479,7 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       SupportSingleFactorAccountDeletion: "Yes"
       PasskeyPromptClientAllowList: "skwdHH2y6ERjJWTPSoAFbSt8lX04OgtI"
+      SessionDualWriteEnabled: "Yes"
     authdev2:
       cloudfrontDistributionStackName: "authdev2-cloudfront"
       frontendApiBaseUrl: https://nw0dah7bxk-vpce-0b907325ae3bfe3ce.execute-api.eu-west-2.amazonaws.com/authdev2/
@@ -477,6 +501,7 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       SupportSingleFactorAccountDeletion: "Yes"
       PasskeyPromptClientAllowList: "rPEUe0hRrHqf0i0es1gYjKxE5ceGN7VK"
+      SessionDualWriteEnabled: "Yes"
     authdev3:
       cloudfrontDistributionStackName: "authdev3-cloudfront"
       frontendApiBaseUrl: https://y3s69ubaz5-vpce-0b907325ae3bfe3ce.execute-api.eu-west-2.amazonaws.com/authdev3/
@@ -493,6 +518,7 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       SupportSingleFactorAccountDeletion: "Yes"
       PasskeyPromptClientAllowList: ""
+      SessionDualWriteEnabled: "Yes"
     dev:
       DeployServiceDownPage: "No"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -524,6 +550,7 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       SupportSingleFactorAccountDeletion: "Yes"
       PasskeyPromptClientAllowList: "J3tedNRsfssnsf4STuc2NNIV1C1gdxBB"
+      SessionDualWriteEnabled: "Yes"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       DeployServiceDownPage: "No"
@@ -555,6 +582,7 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       SupportSingleFactorAccountDeletion: "No"
       PasskeyPromptClientAllowList: "Ykg9fGyY76On4e8tPvFabK5BIl65EkGH"
+      SessionDualWriteEnabled: "No"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       DeployServiceDownPage: "No"
@@ -593,6 +621,7 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       SupportSingleFactorAccountDeletion: "No"
       PasskeyPromptClientAllowList: "nsR2wZ7EebJ2VOzE1LUa9iAVadunWQP3,EMGmY82k-92QSakDl_9keKDFmZY" # perf-test client, home client
+      SessionDualWriteEnabled: "Yes"
     integration:
       DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -625,6 +654,7 @@ Mappings:
       SupportNewInternationalSms: "No"
       EnableDwpKbvContactFormChanges: "Yes"
       PasskeyPromptClientAllowList: ""
+      SessionDualWriteEnabled: "No"
     production:
       DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -660,6 +690,7 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       SupportSingleFactorAccountDeletion: "No"
       PasskeyPromptClientAllowList: ""
+      SessionDualWriteEnabled: "No"
 
 Globals:
   Function:
@@ -1194,6 +1225,9 @@ Resources:
               Value: !If [SupportNewInternationalSms, "1", "0"]
             - Name: SUPPORT_SINGLE_FACTOR_ACCOUNT_DELETION
               Value: !If [SupportSingleFactorAccountDeletion, "1", "0"]
+            - Name: SESSION_DUAL_WRITE_ENABLED
+              Value: !If [SessionDualWriteEnabled, "1", "0"]
+
           Secrets:
             - Name: API_KEY
               ValueFrom: !If

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -1005,6 +1005,8 @@ Resources:
                   ],
                   frontendApiBaseUrl,
                 ]
+            - Name: DYNAMO_SESSION_TABLE_NAME
+              Value: !Ref FrontendSessionsTable
             - Name: ACCOUNT_MANAGEMENT_URL
               Value: !If
                 - IsNotProduction

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-dynamodb": "3.1048.0",
         "@aws-sdk/client-kms": "3.1042.0",
         "@aws-sdk/client-ssm": "3.1042.0",
         "@govuk-one-login/frontend-analytics": "4.0.5",
@@ -21,6 +22,7 @@
         "@otplib/plugin-base32-enc-dec": "12.0.1",
         "@simplewebauthn/browser": "13.3.0",
         "axios": "1.16.0",
+        "connect-dynamodb": "3.0.5",
         "connect-redis": "9.0.0",
         "cookie-parser": "1.4.7",
         "csrf-sync": "4.2.1",
@@ -152,6 +154,20 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "license": "MIT"
     },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
@@ -277,6 +293,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1048.0.tgz",
+      "integrity": "sha512-253MF+BhKKKppRp6f/zs8bFXCknR6vD+7Myd/pIsFcrsk+Yu2Koqyr5JXVsHPgxDtpFvjY90Iegtc8Q+MmaPww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/dynamodb-codec": "^3.973.11",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-kms": {
       "version": "3.1042.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1042.0.tgz",
@@ -379,24 +418,18 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
-      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.22",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -404,14 +437,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
-      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.11",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -420,20 +453,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.36",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
-      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.11",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -441,23 +471,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
-      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/credential-provider-env": "^3.972.34",
-        "@aws-sdk/credential-provider-http": "^3.972.36",
-        "@aws-sdk/credential-provider-login": "^3.972.38",
-        "@aws-sdk/credential-provider-process": "^3.972.34",
-        "@aws-sdk/credential-provider-sso": "^3.972.38",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -466,17 +495,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
-      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -485,21 +512,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
-      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.34",
-        "@aws-sdk/credential-provider-http": "^3.972.36",
-        "@aws-sdk/credential-provider-ini": "^3.972.38",
-        "@aws-sdk/credential-provider-process": "^3.972.34",
-        "@aws-sdk/credential-provider-sso": "^3.972.38",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/credential-provider-imds": "^4.2.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -508,15 +534,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.34",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
-      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/core": "^3.974.11",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -525,17 +550,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
-      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
-        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -544,16 +568,59 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
-      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.11.tgz",
+      "integrity": "sha512-9BLkRYlLwwVlFg3RWOXGkmwXM7kDz0Adi/4+O8SvvdiW9kkPiHGSKPuJHdxUAHJROop0zjlpqKVT+R6Z5CPIXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.5.tgz",
+      "integrity": "sha512-itVdge0NozgtgmtbZ25FVwWU3vGlE7x7feE/aOEJNkQfEpbkrF8Rj1QmnK+2blFfYE1xWt/iU+6/jUp/pv1+MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.13.tgz",
+      "integrity": "sha512-1r6EkFdSQ4quTP3pW8yWIcYuyDwdwdBxGr+kfuPFYE3DqR+1gBc6NyJneAyoIs+wc/cUfnyJ4ZYC0T2SQTxP9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -606,31 +673,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.37",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
-      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.17",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.972.38",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
@@ -651,49 +693,20 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
-      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/middleware-host-header": "^3.972.10",
-        "@aws-sdk/middleware-logger": "^3.972.10",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.38",
-        "@aws-sdk/region-config-resolver": "^3.972.13",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
         "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/util-endpoints": "^3.996.8",
-        "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.24",
-        "@smithy/config-resolver": "^4.4.17",
-        "@smithy/core": "^3.23.17",
-        "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/hash-node": "^4.2.14",
-        "@smithy/invalid-dependency": "^4.2.14",
-        "@smithy/middleware-content-length": "^4.2.14",
-        "@smithy/middleware-endpoint": "^4.4.32",
-        "@smithy/middleware-retry": "^4.5.7",
-        "@smithy/middleware-serde": "^4.2.20",
-        "@smithy/middleware-stack": "^4.2.14",
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/node-http-handler": "^4.6.1",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
         "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.49",
-        "@smithy/util-defaults-mode-node": "^4.2.54",
-        "@smithy/util-endpoints": "^3.4.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.6",
-        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -717,15 +730,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
-      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -734,16 +746,15 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1041.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
-      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.8",
-        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
         "@aws-sdk/types": "^3.973.8",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/core": "^3.24.2",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -758,18 +769,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -842,14 +841,14 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.22",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
-      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@nodable/entities": "2.1.0",
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.2",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2489,20 +2488,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.17",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
-        "@smithy/util-base64": "^4.3.2",
-        "@smithy/util-body-length-browser": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.25",
-        "@smithy/util-utf8": "^4.2.2",
-        "@smithy/uuid": "^1.1.2",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2510,15 +2502,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
-      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.14",
-        "@smithy/property-provider": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/url-parser": "^4.2.14",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2526,15 +2516,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
-      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-base64": "^4.3.2",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2679,14 +2667,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
-      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/querystring-builder": "^4.2.14",
-        "@smithy/types": "^4.14.1",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2713,20 +2700,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
-      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2772,18 +2745,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.14",
-        "@smithy/types": "^4.14.1",
-        "@smithy/util-hex-encoding": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-uri-escape": "^4.2.2",
-        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2809,9 +2777,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2996,18 +2964,6 @@
         "@smithy/util-buffer-from": "^4.2.2",
         "@smithy/util-hex-encoding": "^4.2.2",
         "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4447,6 +4403,17 @@
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
+    "node_modules/connect-dynamodb": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/connect-dynamodb/-/connect-dynamodb-3.0.5.tgz",
+      "integrity": "sha512-AQtXLmfpC/YMT7mJlxsgCrpfeXdgKQ2A7cbTBSE/HsRbJXf/d0ZhB3HmKT+JQaObI5DqnK/d0XlUBbFrcqlwTQ==",
+      "engines": {
+        "node": "*"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.218.0"
+      }
+    },
     "node_modules/connect-redis": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-9.0.0.tgz",
@@ -5442,9 +5409,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.8.tgz",
-      "integrity": "sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -5453,13 +5420,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "funding": [
         {
           "type": "github",
@@ -5469,9 +5437,10 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
+        "fast-xml-builder": "^1.2.0",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -6689,6 +6658,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/mocha": {
       "version": "11.7.5",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
@@ -6976,6 +6954,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -8499,9 +8483,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -9341,6 +9325,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "semi": true
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "3.1048.0",
     "@aws-sdk/client-kms": "3.1042.0",
     "@aws-sdk/client-ssm": "3.1042.0",
     "@govuk-one-login/frontend-analytics": "4.0.5",
@@ -72,6 +73,7 @@
     "@otplib/plugin-base32-enc-dec": "12.0.1",
     "@simplewebauthn/browser": "13.3.0",
     "axios": "1.16.0",
+    "connect-dynamodb": "3.0.5",
     "connect-redis": "9.0.0",
     "cookie-parser": "1.4.7",
     "csrf-sync": "4.2.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -211,6 +211,10 @@ export function supportSingleFactorAccountDeletion(): boolean {
   return process.env.SUPPORT_SINGLE_FACTOR_ACCOUNT_DELETION === "1";
 }
 
+export function getSessionDualWriteEnabled(): boolean {
+  return process.env.SESSION_DUAL_WRITE_ENABLED === "1";
+}
+
 export function getAuthJwksUrl(): string {
   return `${getApiBaseUrl()}/.well-known/auth-jwks.json`;
 }

--- a/src/config/dual-session-store.ts
+++ b/src/config/dual-session-store.ts
@@ -189,11 +189,16 @@ export class DualSessionStore extends Store {
       if (
         !isDeepStrictEqual(primarySession ?? null, secondarySession ?? null)
       ) {
+        const mismatchDetails = this.getKeyDiffs(
+          primarySession,
+          secondarySession
+        );
         logger.warn(
           {
             sid,
             primaryExists: !!primarySession,
             secondaryExists: !!secondarySession,
+            mismatchDetails,
           },
           "Session consistency mismatch"
         );
@@ -201,5 +206,68 @@ export class DualSessionStore extends Store {
     } catch (err) {
       logger.warn({ err }, "Error performing session store consistency checks");
     }
+  }
+
+  private getKeyDiffs(
+    primary: SessionData | null,
+    secondary: SessionData | null
+  ): {
+    keysOnlyInPrimary: string[];
+    keysOnlyInSecondary: string[];
+    keysDiffering: string[];
+  } {
+    const primaryKeys = primary ? Object.keys(primary) : [];
+    const secondaryKeys = secondary ? Object.keys(secondary) : [];
+    const allKeys = Array.from(new Set(primaryKeys.concat(secondaryKeys)));
+
+    const keysOnlyInPrimary: string[] = [];
+    const keysOnlyInSecondary: string[] = [];
+    const keysDiffering: string[] = [];
+
+    for (const key of allKeys) {
+      const inPrimary = primary && key in primary;
+      const inSecondary = secondary && key in secondary;
+
+      if (inPrimary && !inSecondary) {
+        keysOnlyInPrimary.push(key);
+      } else if (!inPrimary && inSecondary) {
+        keysOnlyInSecondary.push(key);
+      } else if (
+        !isDeepStrictEqual(
+          primary[key as keyof SessionData],
+          secondary[key as keyof SessionData]
+        )
+      ) {
+        const subDiffs = this.getDifferingPaths(
+          primary[key as keyof SessionData],
+          secondary[key as keyof SessionData],
+          key
+        );
+        keysDiffering.push(...subDiffs);
+      }
+    }
+
+    return { keysOnlyInPrimary, keysOnlyInSecondary, keysDiffering };
+  }
+
+  private getDifferingPaths(a: unknown, b: unknown, prefix: string): string[] {
+    if (
+      a &&
+      b &&
+      typeof a === "object" &&
+      typeof b === "object" &&
+      !Array.isArray(a) &&
+      !Array.isArray(b)
+    ) {
+      const aObj = a as Record<string, unknown>;
+      const bObj = b as Record<string, unknown>;
+      const keys = Array.from(
+        new Set(Object.keys(aObj).concat(Object.keys(bObj)))
+      );
+      return keys
+        .filter((k) => !isDeepStrictEqual(aObj[k], bObj[k]))
+        .map((k) => `${prefix}.${k}`);
+    }
+    return [prefix];
   }
 }

--- a/src/config/dual-session-store.ts
+++ b/src/config/dual-session-store.ts
@@ -1,5 +1,6 @@
 import { type SessionData, Store } from "express-session";
 import { logger } from "../utils/logger.js";
+import { isDeepStrictEqual } from "node:util";
 
 export class DualSessionStore extends Store {
   constructor(
@@ -10,9 +11,28 @@ export class DualSessionStore extends Store {
   }
 
   get(sid: string, cb: (err?: any, session?: SessionData | null) => void): void {
-    this.redis.get(sid, (err, redisSession) => {
-      logger.info({ sid }, "Session read from Redis");
-      cb(err, redisSession);
+    this.redis.get(sid, (redisErr, redisSession) => {
+      if (redisErr) {
+        logger.warn({ err: redisErr, sid }, "Redis session read failed, falling back to DynamoDB");
+      } else {
+        logger.info({ sid }, "Session read from Redis");
+        cb(null, redisSession);
+      }
+
+      this.dynamo.get(sid, (dynamoErr, dynamoSession) => {
+        if (redisErr) {
+          cb(dynamoErr, dynamoSession);
+          return;
+        }
+
+        if (dynamoErr) {
+          logger.warn({ err: dynamoErr, sid }, "DynamoDB consistency check read failed");
+          return;
+        }
+
+        logger.info({ sid }, "Session read from DynamoDB");
+        this.performConsistencyChecks(redisSession, dynamoSession, sid);
+      });
     });
   }
 
@@ -60,6 +80,16 @@ export class DualSessionStore extends Store {
       });
     } catch (err) {
       logger.warn({ err, sid, operation }, "DynamoDB session write threw unexpectedly");
+    }
+  }
+
+  private performConsistencyChecks(redisSession: SessionData, dynamoSession: SessionData, sid: string): void {
+    try {
+      if (!isDeepStrictEqual(redisSession ?? null, dynamoSession ?? null)) {
+        logger.warn({ sid, redisExists: !!redisSession, dynamoExists: !!dynamoSession }, "Session consistency mismatch");
+      }
+    } catch (err) {
+      logger.warn({ err }, "Error performing session store consistency checks");
     }
   }
 }

--- a/src/config/dual-session-store.ts
+++ b/src/config/dual-session-store.ts
@@ -1,0 +1,65 @@
+import { type SessionData, Store } from "express-session";
+import { logger } from "../utils/logger.js";
+
+export class DualSessionStore extends Store {
+  constructor(
+    private redis: Store,
+    private dynamo: Store
+  ) {
+    super();
+  }
+
+  get(sid: string, cb: (err?: any, session?: SessionData | null) => void): void {
+    this.redis.get(sid, (err, redisSession) => {
+      logger.info({ sid }, "Session read from Redis");
+      cb(err, redisSession);
+    });
+  }
+
+  set(sid: string, sess: SessionData, cb: (err?: any) => void): void {
+    this.redis.set(sid, sess, (err) => {
+      logger.info({ sid }, "Session written to Redis");
+      cb(err);
+    });
+
+    this.writeToDynamo("set", sid, sess);
+  }
+
+  destroy(sid: string, cb: (err?: any) => void): void {
+    this.redis.destroy(sid, (err) => {
+      logger.info({ sid }, "Session destroyed in Redis");
+      cb(err);
+    });
+
+    this.dynamo.destroy(sid, (dynamoErr) => {
+      if (dynamoErr) {
+        logger.warn({ err: dynamoErr, sid }, "DynamoDB session destroy failed");
+        return;
+      }
+      logger.info({ sid }, "Session destroyed in DynamoDB");
+    });
+  }
+
+  touch(sid: string, sess: SessionData, cb: () => void): void {
+    this.redis.touch(sid, sess, () => {
+      logger.info({ sid }, "Session touched in Redis");
+      cb();
+    });
+
+    this.writeToDynamo("touch", sid, sess);
+  }
+
+  private writeToDynamo(operation: "set" | "touch", sid: string, sess: SessionData): void {
+    try {
+      this.dynamo[operation](sid, sess, (dynamoErr) => {
+        if (dynamoErr) {
+          logger.warn({ err: dynamoErr, sid, operation }, "DynamoDB session write failed");
+          return;
+        }
+        logger.info({ sid, operation }, "Session written to DynamoDB");
+      });
+    } catch (err) {
+      logger.warn({ err, sid, operation }, "DynamoDB session write threw unexpectedly");
+    }
+  }
+}

--- a/src/config/dual-session-store.ts
+++ b/src/config/dual-session-store.ts
@@ -4,89 +4,147 @@ import { isDeepStrictEqual } from "node:util";
 
 export class DualSessionStore extends Store {
   constructor(
-    private redis: Store,
-    private dynamo: Store
+    private readonly primary: Store,
+    private readonly secondary: Store,
+    private readonly primaryLabel: string,
+    private readonly secondaryLabel: string
   ) {
     super();
   }
 
-  get(sid: string, cb: (err?: any, session?: SessionData | null) => void): void {
-    this.redis.get(sid, (redisErr, redisSession) => {
-      if (redisErr) {
-        logger.warn({ err: redisErr, sid }, "Redis session read failed, falling back to DynamoDB");
+  get(
+    sid: string,
+    cb: (err?: any, session?: SessionData | null) => void
+  ): void {
+    this.primary.get(sid, (primaryErr, primarySession) => {
+      if (primaryErr) {
+        logger.warn(
+          { err: primaryErr, sid, store: this.primaryLabel },
+          "Primary session read failed, falling back to secondary"
+        );
       } else {
-        logger.info({ sid }, "Session read from Redis");
-        cb(null, redisSession);
+        logger.info(
+          { sid, store: this.primaryLabel },
+          "Session read from primary"
+        );
+        cb(null, primarySession);
       }
 
-      this.dynamo.get(sid, (dynamoErr, dynamoSession) => {
-        if (redisErr) {
-          cb(dynamoErr, dynamoSession);
+      this.secondary.get(sid, (secondaryErr, secondarySession) => {
+        if (primaryErr) {
+          cb(secondaryErr, secondarySession);
           return;
         }
 
-        if (dynamoErr) {
-          logger.warn({ err: dynamoErr, sid }, "DynamoDB consistency check read failed");
+        if (secondaryErr) {
+          logger.warn(
+            { err: secondaryErr, sid, store: this.secondaryLabel },
+            "Secondary consistency check read failed"
+          );
           return;
         }
 
-        logger.info({ sid }, "Session read from DynamoDB");
-        this.performConsistencyChecks(redisSession, dynamoSession, sid);
+        logger.info(
+          { sid, store: this.secondaryLabel },
+          "Session read from secondary"
+        );
+        this.performConsistencyChecks(primarySession, secondarySession, sid);
       });
     });
   }
 
   set(sid: string, sess: SessionData, cb: (err?: any) => void): void {
-    this.redis.set(sid, sess, (err) => {
-      logger.info({ sid }, "Session written to Redis");
+    this.primary.set(sid, sess, (err) => {
+      logger.info(
+        { sid, store: this.primaryLabel },
+        "Session written to primary"
+      );
       cb(err);
     });
 
-    this.writeToDynamo("set", sid, sess);
+    this.writeToSecondary("set", sid, sess);
   }
 
   destroy(sid: string, cb: (err?: any) => void): void {
-    this.redis.destroy(sid, (err) => {
-      logger.info({ sid }, "Session destroyed in Redis");
+    this.primary.destroy(sid, (err) => {
+      logger.info(
+        { sid, store: this.primaryLabel },
+        "Session destroyed in primary"
+      );
       cb(err);
     });
 
-    this.dynamo.destroy(sid, (dynamoErr) => {
-      if (dynamoErr) {
-        logger.warn({ err: dynamoErr, sid }, "DynamoDB session destroy failed");
+    this.secondary.destroy(sid, (secondaryErr) => {
+      if (secondaryErr) {
+        logger.warn(
+          { err: secondaryErr, sid, store: this.secondaryLabel },
+          "Secondary session destroy failed"
+        );
         return;
       }
-      logger.info({ sid }, "Session destroyed in DynamoDB");
+      logger.info(
+        { sid, store: this.secondaryLabel },
+        "Session destroyed in secondary"
+      );
     });
   }
 
   touch(sid: string, sess: SessionData, cb: () => void): void {
-    this.redis.touch(sid, sess, () => {
-      logger.info({ sid }, "Session touched in Redis");
+    this.primary.touch(sid, sess, () => {
+      logger.info(
+        { sid, store: this.primaryLabel },
+        "Session touched in primary"
+      );
       cb();
     });
 
-    this.writeToDynamo("touch", sid, sess);
+    this.writeToSecondary("touch", sid, sess);
   }
 
-  private writeToDynamo(operation: "set" | "touch", sid: string, sess: SessionData): void {
+  private writeToSecondary(
+    operation: "set" | "touch",
+    sid: string,
+    sess: SessionData
+  ): void {
     try {
-      this.dynamo[operation](sid, sess, (dynamoErr) => {
-        if (dynamoErr) {
-          logger.warn({ err: dynamoErr, sid, operation }, "DynamoDB session write failed");
+      this.secondary[operation](sid, sess, (secondaryErr) => {
+        if (secondaryErr) {
+          logger.warn(
+            { err: secondaryErr, sid, operation, store: this.secondaryLabel },
+            "Secondary session write failed"
+          );
           return;
         }
-        logger.info({ sid, operation }, "Session written to DynamoDB");
+        logger.info(
+          { sid, operation, store: this.secondaryLabel },
+          "Session written to secondary"
+        );
       });
     } catch (err) {
-      logger.warn({ err, sid, operation }, "DynamoDB session write threw unexpectedly");
+      logger.warn(
+        { err, sid, operation, store: this.secondaryLabel },
+        "Secondary session write threw unexpectedly"
+      );
     }
   }
 
-  private performConsistencyChecks(redisSession: SessionData, dynamoSession: SessionData, sid: string): void {
+  private performConsistencyChecks(
+    primarySession: SessionData,
+    secondarySession: SessionData,
+    sid: string
+  ): void {
     try {
-      if (!isDeepStrictEqual(redisSession ?? null, dynamoSession ?? null)) {
-        logger.warn({ sid, redisExists: !!redisSession, dynamoExists: !!dynamoSession }, "Session consistency mismatch");
+      if (
+        !isDeepStrictEqual(primarySession ?? null, secondarySession ?? null)
+      ) {
+        logger.warn(
+          {
+            sid,
+            primaryExists: !!primarySession,
+            secondaryExists: !!secondarySession,
+          },
+          "Session consistency mismatch"
+        );
       }
     } catch (err) {
       logger.warn({ err }, "Error performing session store consistency checks");

--- a/src/config/dual-session-store.ts
+++ b/src/config/dual-session-store.ts
@@ -36,7 +36,6 @@ export class DualSessionStore extends Store {
           { sid, store: this.primaryLabel },
           "Session read from primary"
         );
-        cb(null, primarySession);
       }
 
       this.secondary.get(sid, (secondaryErr, secondarySession) => {
@@ -59,51 +58,92 @@ export class DualSessionStore extends Store {
             { err: secondaryErr, sid, store: this.secondaryLabel },
             "Secondary consistency check read failed"
           );
-          return;
+        } else {
+          logger.info(
+            { sid, store: this.secondaryLabel },
+            "Session read from secondary"
+          );
+          this.performConsistencyChecks(primarySession, secondarySession, sid);
         }
 
-        logger.info(
-          { sid, store: this.secondaryLabel },
-          "Session read from secondary"
-        );
-        this.performConsistencyChecks(primarySession, secondarySession, sid);
+        cb(null, primarySession);
       });
     });
   }
 
   set(sid: string, sess: SessionData, cb: (err?: any) => void): void {
-    this.primary.set(sid, sess, (err) => {
-      logger.info(
-        { sid, store: this.primaryLabel },
-        "Session written to primary"
-      );
-      cb(err);
-    });
+    this.primary.set(sid, sess, (primaryErr) => {
+      if (primaryErr) {
+        logger.warn(
+          { err: primaryErr, sid, store: this.primaryLabel },
+          "Primary session write failed"
+        );
+      } else {
+        logger.info(
+          { sid, store: this.primaryLabel },
+          "Session written to primary"
+        );
+      }
 
-    this.writeToSecondary("set", sid, sess);
+      this.secondary.set(sid, sess, (secondaryErr) => {
+        if (secondaryErr) {
+          logger.warn(
+            { err: secondaryErr, sid, store: this.secondaryLabel },
+            "Secondary session write failed"
+          );
+        } else {
+          logger.info(
+            { sid, store: this.secondaryLabel },
+            "Session written to secondary"
+          );
+        }
+
+        if (primaryErr && secondaryErr) {
+          cb(new DualStoreError(primaryErr, secondaryErr));
+        } else if (primaryErr) {
+          cb(primaryErr);
+        } else {
+          cb();
+        }
+      });
+    });
   }
 
   destroy(sid: string, cb: (err?: any) => void): void {
-    this.primary.destroy(sid, (err) => {
-      logger.info(
-        { sid, store: this.primaryLabel },
-        "Session destroyed in primary"
-      );
-      cb(err);
-    });
-
-    this.secondary.destroy(sid, (secondaryErr) => {
-      if (secondaryErr) {
+    this.primary.destroy(sid, (primaryErr) => {
+      if (primaryErr) {
         logger.warn(
-          { err: secondaryErr, sid, store: this.secondaryLabel },
-          "Secondary session destroy failed"
+          { err: primaryErr, sid, store: this.primaryLabel },
+          "Primary session destroy failed"
         );
-        return;
+      } else {
+        logger.info(
+          { sid, store: this.primaryLabel },
+          "Session destroyed in primary"
+        );
       }
-      logger.info(
-        { sid, store: this.secondaryLabel },
-        "Session destroyed in secondary"
-      );
+
+      this.secondary.destroy(sid, (secondaryErr) => {
+        if (secondaryErr) {
+          logger.warn(
+            { err: secondaryErr, sid, store: this.secondaryLabel },
+            "Secondary session destroy failed"
+          );
+        } else {
+          logger.info(
+            { sid, store: this.secondaryLabel },
+            "Session destroyed in secondary"
+          );
+        }
+
+        if (primaryErr && secondaryErr) {
+          cb(new DualStoreError(primaryErr, secondaryErr));
+        } else if (primaryErr) {
+          cb(primaryErr);
+        } else {
+          cb();
+        }
+      });
     });
   }
 
@@ -113,36 +153,30 @@ export class DualSessionStore extends Store {
         { sid, store: this.primaryLabel },
         "Session touched in primary"
       );
-      cb();
-    });
 
-    this.writeToSecondary("touch", sid, sess);
+      this.touchSecondary(sid, sess, cb);
+    });
   }
 
-  private writeToSecondary(
-    operation: "set" | "touch",
-    sid: string,
-    sess: SessionData
-  ): void {
+  private touchSecondary(sid: string, sess: SessionData, cb: () => void): void {
     try {
-      this.secondary[operation](sid, sess, (secondaryErr) => {
-        if (secondaryErr) {
-          logger.warn(
-            { err: secondaryErr, sid, operation, store: this.secondaryLabel },
-            "Secondary session write failed"
+      if (this.secondary.touch) {
+        this.secondary.touch(sid, sess, () => {
+          logger.info(
+            { sid, store: this.secondaryLabel },
+            "Session touched in secondary"
           );
-          return;
-        }
-        logger.info(
-          { sid, operation, store: this.secondaryLabel },
-          "Session written to secondary"
-        );
-      });
+          cb();
+        });
+      } else {
+        cb();
+      }
     } catch (err) {
       logger.warn(
-        { err, sid, operation, store: this.secondaryLabel },
-        "Secondary session write threw unexpectedly"
+        { err, sid, store: this.secondaryLabel },
+        "Secondary session touch threw unexpectedly"
       );
+      cb();
     }
   }
 

--- a/src/config/dual-session-store.ts
+++ b/src/config/dual-session-store.ts
@@ -2,6 +2,15 @@ import { type SessionData, Store } from "express-session";
 import { logger } from "../utils/logger.js";
 import { isDeepStrictEqual } from "node:util";
 
+export class DualStoreError extends Error {
+  constructor(
+    public readonly primary: Error,
+    public readonly secondary: Error
+  ) {
+    super("Both session stores failed");
+  }
+}
+
 export class DualSessionStore extends Store {
   constructor(
     private readonly primary: Store,
@@ -32,7 +41,16 @@ export class DualSessionStore extends Store {
 
       this.secondary.get(sid, (secondaryErr, secondarySession) => {
         if (primaryErr) {
-          cb(secondaryErr, secondarySession);
+          if (secondaryErr) {
+            logger.warn(
+              { err: secondaryErr, sid, store: this.secondaryLabel },
+              "Secondary session read failed"
+            );
+          }
+          const error = secondaryErr
+            ? new DualStoreError(primaryErr, secondaryErr)
+            : null;
+          cb(error, secondarySession);
           return;
         }
 

--- a/src/config/dynamodb-session.ts
+++ b/src/config/dynamodb-session.ts
@@ -1,0 +1,21 @@
+import type { Store } from "express-session";
+import session from "express-session";
+import connectDynamoDB from "connect-dynamodb";
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+
+const DynamoDBStore = connectDynamoDB(session);
+
+export function getDynamoSessionStore(): Store {
+  const clientOptions: ConstructorParameters<typeof DynamoDBClient>[0] = {};
+  if (process.env.DYNAMODB_ENDPOINT) {
+    clientOptions.endpoint = process.env.DYNAMODB_ENDPOINT;
+  }
+
+  return new DynamoDBStore({
+    table: process.env.DYNAMO_SESSION_TABLE_NAME || "frontend-sessions",
+    hashKey: "id",
+    prefix: "",
+    client: new DynamoDBClient(clientOptions),
+    initialized: true,
+  });
+}

--- a/src/config/session.ts
+++ b/src/config/session.ts
@@ -5,6 +5,8 @@ import type { RedisConfig } from "../utils/types.js";
 import { logger } from "../utils/logger.js";
 import { DualSessionStore } from "./dual-session-store.js";
 import { getDynamoSessionStore } from "./dynamodb-session.js";
+import { getSessionDualWriteEnabled } from "../config.js";
+import type { Store } from "express-session";
 
 let redisClient: ReturnType<typeof createClient> | undefined;
 let usedRedisConfig: RedisConfig | undefined;
@@ -40,8 +42,21 @@ function getRedisStore(redisConfig: RedisConfig): RedisStore {
   });
 }
 
-export function getSessionStore(redisConfig: RedisConfig): DualSessionStore {
+export function getSessionStore(redisConfig: RedisConfig): Store {
   const redisStore = getRedisStore(redisConfig);
+
+  if (!getSessionDualWriteEnabled()) {
+    logger.info(
+      "Dual session store writing feature flag disabled, using Redis store."
+    );
+
+    return redisStore;
+  }
+
+  logger.info(
+    "Dual session store writing feature flag enabled, using dual session store."
+  );
+
   const dynamoStore = getDynamoSessionStore();
 
   return new DualSessionStore(redisStore, dynamoStore);

--- a/src/config/session.ts
+++ b/src/config/session.ts
@@ -59,7 +59,7 @@ export function getSessionStore(redisConfig: RedisConfig): Store {
 
   const dynamoStore = getDynamoSessionStore();
 
-  return new DualSessionStore(redisStore, dynamoStore);
+  return new DualSessionStore(redisStore, dynamoStore, "Redis", "DynamoDB");
 }
 
 export async function disconnectRedisClient(): Promise<void> {

--- a/src/config/session.ts
+++ b/src/config/session.ts
@@ -1,13 +1,15 @@
 import type { RedisClientOptions } from "redis";
 import { createClient } from "redis";
 import { RedisStore } from "connect-redis";
-import type { RedisConfig } from "src/utils/types.js";
+import type { RedisConfig } from "../utils/types.js";
 import { logger } from "../utils/logger.js";
+import { DualSessionStore } from "./dual-session-store.js";
+import { getDynamoSessionStore } from "./dynamodb-session.js";
 
 let redisClient: ReturnType<typeof createClient> | undefined;
 let usedRedisConfig: RedisConfig | undefined;
 
-export function getSessionStore(redisConfig: RedisConfig): RedisStore {
+function getRedisStore(redisConfig: RedisConfig): RedisStore {
   if (redisClient && !isRedisConfigEqual(redisConfig, usedRedisConfig)) {
     throw new Error("Redis client already established with different config");
   } else if (!redisClient) {
@@ -36,6 +38,13 @@ export function getSessionStore(redisConfig: RedisConfig): RedisStore {
   return new RedisStore({
     client: redisClient,
   });
+}
+
+export function getSessionStore(redisConfig: RedisConfig): DualSessionStore {
+  const redisStore = getRedisStore(redisConfig);
+  const dynamoStore = getDynamoSessionStore();
+
+  return new DualSessionStore(redisStore, dynamoStore);
 }
 
 export async function disconnectRedisClient(): Promise<void> {

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -15,6 +15,7 @@ import {
   enableDwpKbvContactFormChanges,
   supportNewInternationalSms,
   supportSingleFactorAccountDeletion,
+  getSessionDualWriteEnabled,
   getDefaultChannel,
   showTestBanner,
   getAccountDomain,
@@ -39,6 +40,7 @@ describe("config", () => {
     delete process.env.ENABLE_DWP_KBV_CONTACT_FORM_CHANGES;
     delete process.env.SUPPORT_NEW_INTERNATIONAL_SMS;
     delete process.env.SUPPORT_SINGLE_FACTOR_ACCOUNT_DELETION;
+    delete process.env.SESSION_DUAL_WRITE_ENABLED;
     delete process.env.DEFAULT_CHANNEL;
     delete process.env.APP_ENV;
     delete process.env.SERVICE_DOMAIN;
@@ -120,6 +122,11 @@ describe("config", () => {
         name: "supportSingleFactorAccountDeletion",
         envVar: "SUPPORT_SINGLE_FACTOR_ACCOUNT_DELETION",
         fn: supportSingleFactorAccountDeletion,
+      },
+      {
+        name: "getSessionDualWriteEnabled",
+        envVar: "SESSION_DUAL_WRITE_ENABLED",
+        fn: getSessionDualWriteEnabled,
       },
     ];
 

--- a/test/unit/dual-session-store.test.ts
+++ b/test/unit/dual-session-store.test.ts
@@ -32,6 +32,31 @@ describe("DualSessionStore", () => {
       });
     });
 
+    it("should fallback to dynamo when redis fails", (done) => {
+      const dynamoSession = { cookie: { originalMaxAge: 9999 } } as SessionData;
+      redis.get = sinon.fake((_sid, cb) => cb(new Error("redis failure")));
+      dynamo.get = sinon.fake((_sid, cb) => cb(null, dynamoSession));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.get(sid, (err, sess) => {
+        expect(err).to.be.null;
+        expect(sess).to.deep.equal(dynamoSession);
+        done();
+      });
+    });
+
+    it("should return dynamo error when both redis and dynamo fail", (done) => {
+      const dynamoErr = new Error("dynamo failure");
+      redis.get = sinon.fake((_sid, cb) => cb(new Error("redis failure")));
+      dynamo.get = sinon.fake((_sid, cb) => cb(dynamoErr));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.get(sid, (err) => {
+        expect(err).to.equal(dynamoErr);
+        done();
+      });
+    });
+
     it("should perform dynamo consistency check read", (done) => {
       redis.get = sinon.fake((_sid, cb) => cb(null, session));
       dynamo.get = sinon.fake((_sid, cb) => {

--- a/test/unit/dual-session-store.test.ts
+++ b/test/unit/dual-session-store.test.ts
@@ -342,5 +342,27 @@ describe("DualSessionStore", () => {
         setTimeout(done, 10);
       });
     });
+
+    it("should safely handle key diffs with missing keys and nested differences", (done) => {
+      const primarySession = {
+        cookie: { originalMaxAge: 3600000 },
+        user: { id: 7777, role: "admin" },
+        token: "tokenValueOnlyInPrimary",
+      } as unknown as SessionData;
+      const secondarySession = {
+        cookie: { originalMaxAge: 9999 },
+        user: { id: 7777, role: "user" },
+        extra: "extraValueOnlyInSecondary",
+      } as unknown as SessionData;
+      primary.get = sinon.fake((_sid, cb) => cb(null, primarySession));
+      secondary.get = sinon.fake((_sid, cb) => cb(null, secondarySession));
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
+
+      store.get(sid, (err, sess) => {
+        expect(err).to.be.null;
+        expect(sess).to.deep.equal(primarySession);
+        setTimeout(done, 10);
+      });
+    });
   });
 });

--- a/test/unit/dual-session-store.test.ts
+++ b/test/unit/dual-session-store.test.ts
@@ -103,12 +103,17 @@ describe("DualSessionStore", () => {
       store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.set(sid, session, (err) => {
-        expect(err).to.be.null;
+        expect(err).to.be.undefined;
+        expect(primary.set).to.have.been.calledOnce;
+        expect(primary.set).to.have.been.calledWith(sid, session);
+
+        expect(secondary.set).to.have.been.calledOnce;
+        expect(secondary.set).to.have.been.calledWith(sid, session);
         done();
       });
     });
 
-    it("should return primary error to callback", (done) => {
+    it("should return primary error to callback and still write to secondary", (done) => {
       const error = new Error("primary write failure");
       primary.set = sinon.fake(
         (_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(error)
@@ -120,23 +125,9 @@ describe("DualSessionStore", () => {
 
       store.set(sid, session, (err) => {
         expect(err).to.equal(error);
+        expect(secondary.set).to.have.been.calledOnce;
         done();
       });
-    });
-
-    it("should also write to secondary", (done) => {
-      primary.set = sinon.fake(
-        (_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null)
-      );
-      secondary.set = sinon.fake(
-        (_sid: string, _sess: SessionData, cb: (err?: any) => void) => {
-          cb(null);
-          done();
-        }
-      );
-      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
-
-      store.set(sid, session, () => {});
     });
 
     it("should not throw when secondary write fails", (done) => {
@@ -150,14 +141,35 @@ describe("DualSessionStore", () => {
       store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.set(sid, session, (err) => {
-        expect(err).to.be.null;
-        setTimeout(done, 10);
+        expect(err).to.be.undefined;
+        done();
+      });
+    });
+
+    it("should return DualStoreError when both stores fail", (done) => {
+      const primaryErr = new Error("primary write failure");
+      const secondaryErr = new Error("secondary write failure");
+      primary.set = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: (err?: any) => void) =>
+          cb(primaryErr)
+      );
+      secondary.set = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: (err?: any) => void) =>
+          cb(secondaryErr)
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
+
+      store.set(sid, session, (err) => {
+        expect(err).to.be.instanceOf(DualStoreError);
+        expect(err.primary).to.equal(primaryErr);
+        expect(err.secondary).to.equal(secondaryErr);
+        done();
       });
     });
   });
 
   describe("destroy", () => {
-    it("should destroy in primary and call back", (done) => {
+    it("should destroy in both stores and call back", (done) => {
       primary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
         cb(null)
       );
@@ -167,12 +179,17 @@ describe("DualSessionStore", () => {
       store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.destroy(sid, (err) => {
-        expect(err).to.be.null;
+        expect(err).to.be.undefined;
+        expect(primary.destroy).to.have.been.calledOnce;
+        expect(primary.destroy).to.have.been.calledWith(sid);
+
+        expect(secondary.destroy).to.have.been.calledOnce;
+        expect(secondary.destroy).to.have.been.calledWith(sid);
         done();
       });
     });
 
-    it("should return primary error to callback", (done) => {
+    it("should return primary error and still destroy in secondary", (done) => {
       const error = new Error("primary destroy failure");
       primary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
         cb(error)
@@ -184,23 +201,9 @@ describe("DualSessionStore", () => {
 
       store.destroy(sid, (err) => {
         expect(err).to.equal(error);
+        expect(secondary.destroy).to.have.been.calledOnce;
         done();
       });
-    });
-
-    it("should also destroy in secondary", (done) => {
-      primary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
-        cb(null)
-      );
-      secondary.destroy = sinon.fake(
-        (_sid: string, cb: (err?: any) => void) => {
-          cb(null);
-          done();
-        }
-      );
-      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
-
-      store.destroy(sid, () => {});
     });
 
     it("should not throw when secondary destroy fails", (done) => {
@@ -213,14 +216,33 @@ describe("DualSessionStore", () => {
       store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.destroy(sid, (err) => {
-        expect(err).to.be.null;
-        setTimeout(done, 10);
+        expect(err).to.be.undefined;
+        done();
+      });
+    });
+
+    it("should return DualStoreError when both stores fail", (done) => {
+      const primaryErr = new Error("primary destroy failure");
+      const secondaryErr = new Error("secondary destroy failure");
+      primary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
+        cb(primaryErr)
+      );
+      secondary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
+        cb(secondaryErr)
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
+
+      store.destroy(sid, (err) => {
+        expect(err).to.be.instanceOf(DualStoreError);
+        expect(err.primary).to.equal(primaryErr);
+        expect(err.secondary).to.equal(secondaryErr);
+        done();
       });
     });
   });
 
   describe("touch", () => {
-    it("should touch in primary and call back", (done) => {
+    it("should touch in both stores and call back", (done) => {
       primary.touch = sinon.fake(
         (_sid: string, _sess: SessionData, cb: () => void) => cb()
       );
@@ -230,23 +252,10 @@ describe("DualSessionStore", () => {
       store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.touch(sid, session, () => {
+        expect(primary.touch).to.have.been.calledOnce;
+        expect(secondary.touch).to.have.been.calledOnce;
         done();
       });
-    });
-
-    it("should also touch in secondary", (done) => {
-      primary.touch = sinon.fake(
-        (_sid: string, _sess: SessionData, cb: () => void) => cb()
-      );
-      secondary.touch = sinon.fake(
-        (_sid: string, _sess: SessionData, cb: () => void) => {
-          cb();
-          done();
-        }
-      );
-      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
-
-      store.touch(sid, session, () => {});
     });
 
     it("should not throw when secondary touch fails", (done) => {
@@ -260,7 +269,7 @@ describe("DualSessionStore", () => {
       store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.touch(sid, session, () => {
-        setTimeout(done, 10);
+        done();
       });
     });
   });
@@ -313,6 +322,23 @@ describe("DualSessionStore", () => {
       store.get(sid, (err, sess) => {
         expect(err).to.be.null;
         expect(sess).to.be.null;
+        setTimeout(done, 10);
+      });
+    });
+
+    it("should catch exceptions thrown during consistency checks", (done) => {
+      const badSession = {
+        get cookie() {
+          throw new Error("unexpected error");
+        },
+      } as unknown as SessionData;
+      primary.get = sinon.fake((_sid, cb) => cb(null, session));
+      secondary.get = sinon.fake((_sid, cb) => cb(null, badSession));
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
+
+      store.get(sid, (err, sess) => {
+        expect(err).to.be.null;
+        expect(sess).to.deep.equal(session);
         setTimeout(done, 10);
       });
     });

--- a/test/unit/dual-session-store.test.ts
+++ b/test/unit/dual-session-store.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, it } from "mocha";
+import { expect, sinon } from "../utils/test-utils.js";
+import { DualSessionStore } from "../../src/config/dual-session-store.js";
+import { type SessionData, Store } from "express-session";
+
+describe("DualSessionStore", () => {
+  let redis: Store;
+  let dynamo: Store;
+  let store: DualSessionStore;
+  const sid = "test-session-id";
+  const session = { cookie: { originalMaxAge: 3600000 } } as SessionData;
+
+  beforeEach(() => {
+    redis = Object.create(Store.prototype);
+    dynamo = Object.create(Store.prototype);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("get", () => {
+    it("should return session from redis", (done) => {
+      redis.get = sinon.fake((_sid, cb) => cb(null, session));
+      dynamo.get = sinon.fake((_sid, cb) => cb(null, session));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.get(sid, (err, sess) => {
+        expect(err).to.be.null;
+        expect(sess).to.deep.equal(session);
+        done();
+      });
+    });
+
+    it("should perform dynamo consistency check read", (done) => {
+      redis.get = sinon.fake((_sid, cb) => cb(null, session));
+      dynamo.get = sinon.fake((_sid, cb) => {
+        cb(null, session);
+        done();
+      });
+      store = new DualSessionStore(redis, dynamo);
+
+      store.get(sid, () => {});
+    });
+
+    it("should not throw when dynamo consistency check fails", (done) => {
+      redis.get = sinon.fake((_sid, cb) => cb(null, session));
+      dynamo.get = sinon.fake((_sid, cb) => cb(new Error("dynamo failure")));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.get(sid, (err, sess) => {
+        expect(err).to.be.null;
+        expect(sess).to.deep.equal(session);
+        setTimeout(done, 10);
+      });
+    });
+  });
+
+  describe("set", () => {
+    it("should write to redis and call back", (done) => {
+      redis.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null));
+      dynamo.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.set(sid, session, (err) => {
+        expect(err).to.be.null;
+        done();
+      });
+    });
+
+    it("should return redis error to callback", (done) => {
+      const error = new Error("redis write failure");
+      redis.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(error));
+      dynamo.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.set(sid, session, (err) => {
+        expect(err).to.equal(error);
+        done();
+      });
+    });
+
+    it("should also write to dynamo", (done) => {
+      redis.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null));
+      dynamo.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => {
+        cb(null);
+        done();
+      });
+      store = new DualSessionStore(redis, dynamo);
+
+      store.set(sid, session, () => {});
+    });
+
+    it("should not throw when dynamo write fails", (done) => {
+      redis.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null));
+      dynamo.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) =>
+        cb(new Error("dynamo failure"))
+      );
+      store = new DualSessionStore(redis, dynamo);
+
+      store.set(sid, session, (err) => {
+        expect(err).to.be.null;
+        setTimeout(done, 10);
+      });
+    });
+  });
+
+  describe("destroy", () => {
+    it("should destroy in redis and call back", (done) => {
+      redis.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(null));
+      dynamo.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(null));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.destroy(sid, (err) => {
+        expect(err).to.be.null;
+        done();
+      });
+    });
+
+    it("should return redis error to callback", (done) => {
+      const error = new Error("redis destroy failure");
+      redis.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(error));
+      dynamo.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(null));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.destroy(sid, (err) => {
+        expect(err).to.equal(error);
+        done();
+      });
+    });
+
+    it("should also destroy in dynamo", (done) => {
+      redis.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(null));
+      dynamo.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => {
+        cb(null);
+        done();
+      });
+      store = new DualSessionStore(redis, dynamo);
+
+      store.destroy(sid, () => {});
+    });
+
+    it("should not throw when dynamo destroy fails", (done) => {
+      redis.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(null));
+      dynamo.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
+        cb(new Error("dynamo failure"))
+      );
+      store = new DualSessionStore(redis, dynamo);
+
+      store.destroy(sid, (err) => {
+        expect(err).to.be.null;
+        setTimeout(done, 10);
+      });
+    });
+  });
+
+  describe("touch", () => {
+    it("should touch in redis and call back", (done) => {
+      redis.touch = sinon.fake((_sid: string, _sess: SessionData, cb: () => void) => cb());
+      dynamo.touch = sinon.fake((_sid: string, _sess: SessionData, cb: () => void) => cb());
+      store = new DualSessionStore(redis, dynamo);
+
+      store.touch(sid, session, () => {
+        done();
+      });
+    });
+
+    it("should also touch in dynamo", (done) => {
+      redis.touch = sinon.fake((_sid: string, _sess: SessionData, cb: () => void) => cb());
+      dynamo.touch = sinon.fake((_sid: string, _sess: SessionData, cb: () => void) => {
+        cb();
+        done();
+      });
+      store = new DualSessionStore(redis, dynamo);
+
+      store.touch(sid, session, () => {});
+    });
+
+    it("should not throw when dynamo touch fails", (done) => {
+      redis.touch = sinon.fake((_sid: string, _sess: SessionData, cb: () => void) => cb());
+      dynamo.touch = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) =>
+        cb(new Error("dynamo failure"))
+      );
+      store = new DualSessionStore(redis, dynamo);
+
+      store.touch(sid, session, () => {
+        setTimeout(done, 10);
+      });
+    });
+  });
+
+  describe("consistency checks", () => {
+    it("should not error when sessions match", (done) => {
+      redis.get = sinon.fake((_sid, cb) => cb(null, session));
+      dynamo.get = sinon.fake((_sid, cb) => cb(null, session));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.get(sid, (err, sess) => {
+        expect(err).to.be.null;
+        expect(sess).to.deep.equal(session);
+        setTimeout(done, 10);
+      });
+    });
+
+    it("should not throw when sessions differ", (done) => {
+      const differentSession = {
+        cookie: { originalMaxAge: 9999 },
+      } as SessionData;
+      redis.get = sinon.fake((_sid, cb) => cb(null, session));
+      dynamo.get = sinon.fake((_sid, cb) => cb(null, differentSession));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.get(sid, (err, sess) => {
+        expect(err).to.be.null;
+        expect(sess).to.deep.equal(session);
+        setTimeout(done, 10);
+      });
+    });
+
+    it("should not throw when redis has session but dynamo does not", (done) => {
+      redis.get = sinon.fake((_sid, cb) => cb(null, session));
+      dynamo.get = sinon.fake((_sid, cb) => cb(null, null));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.get(sid, (err, sess) => {
+        expect(err).to.be.null;
+        expect(sess).to.deep.equal(session);
+        setTimeout(done, 10);
+      });
+    });
+
+    it("should not throw when both stores return null", (done) => {
+      redis.get = sinon.fake((_sid, cb) => cb(null, null));
+      dynamo.get = sinon.fake((_sid, cb) => cb(null, null));
+      store = new DualSessionStore(redis, dynamo);
+
+      store.get(sid, (err, sess) => {
+        expect(err).to.be.null;
+        expect(sess).to.be.null;
+        setTimeout(done, 10);
+      });
+    });
+  });
+});

--- a/test/unit/dual-session-store.test.ts
+++ b/test/unit/dual-session-store.test.ts
@@ -4,15 +4,15 @@ import { DualSessionStore } from "../../src/config/dual-session-store.js";
 import { type SessionData, Store } from "express-session";
 
 describe("DualSessionStore", () => {
-  let redis: Store;
-  let dynamo: Store;
+  let primary: Store;
+  let secondary: Store;
   let store: DualSessionStore;
   const sid = "test-session-id";
   const session = { cookie: { originalMaxAge: 3600000 } } as SessionData;
 
   beforeEach(() => {
-    redis = Object.create(Store.prototype);
-    dynamo = Object.create(Store.prototype);
+    primary = Object.create(Store.prototype);
+    secondary = Object.create(Store.prototype);
   });
 
   afterEach(() => {
@@ -20,10 +20,10 @@ describe("DualSessionStore", () => {
   });
 
   describe("get", () => {
-    it("should return session from redis", (done) => {
-      redis.get = sinon.fake((_sid, cb) => cb(null, session));
-      dynamo.get = sinon.fake((_sid, cb) => cb(null, session));
-      store = new DualSessionStore(redis, dynamo);
+    it("should return session from primary", (done) => {
+      primary.get = sinon.fake((_sid, cb) => cb(null, session));
+      secondary.get = sinon.fake((_sid, cb) => cb(null, session));
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.get(sid, (err, sess) => {
         expect(err).to.be.null;
@@ -32,46 +32,50 @@ describe("DualSessionStore", () => {
       });
     });
 
-    it("should fallback to dynamo when redis fails", (done) => {
-      const dynamoSession = { cookie: { originalMaxAge: 9999 } } as SessionData;
-      redis.get = sinon.fake((_sid, cb) => cb(new Error("redis failure")));
-      dynamo.get = sinon.fake((_sid, cb) => cb(null, dynamoSession));
-      store = new DualSessionStore(redis, dynamo);
+    it("should fallback to secondary when primary fails", (done) => {
+      const secondarySession = {
+        cookie: { originalMaxAge: 9999 },
+      } as SessionData;
+      primary.get = sinon.fake((_sid, cb) => cb(new Error("primary failure")));
+      secondary.get = sinon.fake((_sid, cb) => cb(null, secondarySession));
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.get(sid, (err, sess) => {
         expect(err).to.be.null;
-        expect(sess).to.deep.equal(dynamoSession);
+        expect(sess).to.deep.equal(secondarySession);
         done();
       });
     });
 
-    it("should return dynamo error when both redis and dynamo fail", (done) => {
-      const dynamoErr = new Error("dynamo failure");
-      redis.get = sinon.fake((_sid, cb) => cb(new Error("redis failure")));
-      dynamo.get = sinon.fake((_sid, cb) => cb(dynamoErr));
-      store = new DualSessionStore(redis, dynamo);
+    it("should return secondary error when both primary and secondary fail", (done) => {
+      const secondaryErr = new Error("secondary failure");
+      primary.get = sinon.fake((_sid, cb) => cb(new Error("primary failure")));
+      secondary.get = sinon.fake((_sid, cb) => cb(secondaryErr));
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.get(sid, (err) => {
-        expect(err).to.equal(dynamoErr);
+        expect(err).to.equal(secondaryErr);
         done();
       });
     });
 
-    it("should perform dynamo consistency check read", (done) => {
-      redis.get = sinon.fake((_sid, cb) => cb(null, session));
-      dynamo.get = sinon.fake((_sid, cb) => {
+    it("should perform secondary consistency check read", (done) => {
+      primary.get = sinon.fake((_sid, cb) => cb(null, session));
+      secondary.get = sinon.fake((_sid, cb) => {
         cb(null, session);
         done();
       });
-      store = new DualSessionStore(redis, dynamo);
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.get(sid, () => {});
     });
 
-    it("should not throw when dynamo consistency check fails", (done) => {
-      redis.get = sinon.fake((_sid, cb) => cb(null, session));
-      dynamo.get = sinon.fake((_sid, cb) => cb(new Error("dynamo failure")));
-      store = new DualSessionStore(redis, dynamo);
+    it("should not throw when secondary consistency check fails", (done) => {
+      primary.get = sinon.fake((_sid, cb) => cb(null, session));
+      secondary.get = sinon.fake((_sid, cb) =>
+        cb(new Error("secondary failure"))
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.get(sid, (err, sess) => {
         expect(err).to.be.null;
@@ -82,10 +86,14 @@ describe("DualSessionStore", () => {
   });
 
   describe("set", () => {
-    it("should write to redis and call back", (done) => {
-      redis.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null));
-      dynamo.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null));
-      store = new DualSessionStore(redis, dynamo);
+    it("should write to primary and call back", (done) => {
+      primary.set = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null)
+      );
+      secondary.set = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null)
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.set(sid, session, (err) => {
         expect(err).to.be.null;
@@ -93,11 +101,15 @@ describe("DualSessionStore", () => {
       });
     });
 
-    it("should return redis error to callback", (done) => {
-      const error = new Error("redis write failure");
-      redis.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(error));
-      dynamo.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null));
-      store = new DualSessionStore(redis, dynamo);
+    it("should return primary error to callback", (done) => {
+      const error = new Error("primary write failure");
+      primary.set = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(error)
+      );
+      secondary.set = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null)
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.set(sid, session, (err) => {
         expect(err).to.equal(error);
@@ -105,23 +117,30 @@ describe("DualSessionStore", () => {
       });
     });
 
-    it("should also write to dynamo", (done) => {
-      redis.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null));
-      dynamo.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => {
-        cb(null);
-        done();
-      });
-      store = new DualSessionStore(redis, dynamo);
+    it("should also write to secondary", (done) => {
+      primary.set = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null)
+      );
+      secondary.set = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: (err?: any) => void) => {
+          cb(null);
+          done();
+        }
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.set(sid, session, () => {});
     });
 
-    it("should not throw when dynamo write fails", (done) => {
-      redis.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null));
-      dynamo.set = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) =>
-        cb(new Error("dynamo failure"))
+    it("should not throw when secondary write fails", (done) => {
+      primary.set = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: (err?: any) => void) => cb(null)
       );
-      store = new DualSessionStore(redis, dynamo);
+      secondary.set = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: (err?: any) => void) =>
+          cb(new Error("secondary failure"))
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.set(sid, session, (err) => {
         expect(err).to.be.null;
@@ -131,10 +150,14 @@ describe("DualSessionStore", () => {
   });
 
   describe("destroy", () => {
-    it("should destroy in redis and call back", (done) => {
-      redis.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(null));
-      dynamo.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(null));
-      store = new DualSessionStore(redis, dynamo);
+    it("should destroy in primary and call back", (done) => {
+      primary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
+        cb(null)
+      );
+      secondary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
+        cb(null)
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.destroy(sid, (err) => {
         expect(err).to.be.null;
@@ -142,11 +165,15 @@ describe("DualSessionStore", () => {
       });
     });
 
-    it("should return redis error to callback", (done) => {
-      const error = new Error("redis destroy failure");
-      redis.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(error));
-      dynamo.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(null));
-      store = new DualSessionStore(redis, dynamo);
+    it("should return primary error to callback", (done) => {
+      const error = new Error("primary destroy failure");
+      primary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
+        cb(error)
+      );
+      secondary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
+        cb(null)
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.destroy(sid, (err) => {
         expect(err).to.equal(error);
@@ -154,23 +181,29 @@ describe("DualSessionStore", () => {
       });
     });
 
-    it("should also destroy in dynamo", (done) => {
-      redis.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(null));
-      dynamo.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => {
-        cb(null);
-        done();
-      });
-      store = new DualSessionStore(redis, dynamo);
+    it("should also destroy in secondary", (done) => {
+      primary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
+        cb(null)
+      );
+      secondary.destroy = sinon.fake(
+        (_sid: string, cb: (err?: any) => void) => {
+          cb(null);
+          done();
+        }
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.destroy(sid, () => {});
     });
 
-    it("should not throw when dynamo destroy fails", (done) => {
-      redis.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) => cb(null));
-      dynamo.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
-        cb(new Error("dynamo failure"))
+    it("should not throw when secondary destroy fails", (done) => {
+      primary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
+        cb(null)
       );
-      store = new DualSessionStore(redis, dynamo);
+      secondary.destroy = sinon.fake((_sid: string, cb: (err?: any) => void) =>
+        cb(new Error("secondary failure"))
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.destroy(sid, (err) => {
         expect(err).to.be.null;
@@ -180,33 +213,44 @@ describe("DualSessionStore", () => {
   });
 
   describe("touch", () => {
-    it("should touch in redis and call back", (done) => {
-      redis.touch = sinon.fake((_sid: string, _sess: SessionData, cb: () => void) => cb());
-      dynamo.touch = sinon.fake((_sid: string, _sess: SessionData, cb: () => void) => cb());
-      store = new DualSessionStore(redis, dynamo);
+    it("should touch in primary and call back", (done) => {
+      primary.touch = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: () => void) => cb()
+      );
+      secondary.touch = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: () => void) => cb()
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.touch(sid, session, () => {
         done();
       });
     });
 
-    it("should also touch in dynamo", (done) => {
-      redis.touch = sinon.fake((_sid: string, _sess: SessionData, cb: () => void) => cb());
-      dynamo.touch = sinon.fake((_sid: string, _sess: SessionData, cb: () => void) => {
-        cb();
-        done();
-      });
-      store = new DualSessionStore(redis, dynamo);
+    it("should also touch in secondary", (done) => {
+      primary.touch = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: () => void) => cb()
+      );
+      secondary.touch = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: () => void) => {
+          cb();
+          done();
+        }
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.touch(sid, session, () => {});
     });
 
-    it("should not throw when dynamo touch fails", (done) => {
-      redis.touch = sinon.fake((_sid: string, _sess: SessionData, cb: () => void) => cb());
-      dynamo.touch = sinon.fake((_sid: string, _sess: SessionData, cb: (err?: any) => void) =>
-        cb(new Error("dynamo failure"))
+    it("should not throw when secondary touch fails", (done) => {
+      primary.touch = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: () => void) => cb()
       );
-      store = new DualSessionStore(redis, dynamo);
+      secondary.touch = sinon.fake(
+        (_sid: string, _sess: SessionData, cb: (err?: any) => void) =>
+          cb(new Error("secondary failure"))
+      );
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.touch(sid, session, () => {
         setTimeout(done, 10);
@@ -216,9 +260,9 @@ describe("DualSessionStore", () => {
 
   describe("consistency checks", () => {
     it("should not error when sessions match", (done) => {
-      redis.get = sinon.fake((_sid, cb) => cb(null, session));
-      dynamo.get = sinon.fake((_sid, cb) => cb(null, session));
-      store = new DualSessionStore(redis, dynamo);
+      primary.get = sinon.fake((_sid, cb) => cb(null, session));
+      secondary.get = sinon.fake((_sid, cb) => cb(null, session));
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.get(sid, (err, sess) => {
         expect(err).to.be.null;
@@ -231,9 +275,9 @@ describe("DualSessionStore", () => {
       const differentSession = {
         cookie: { originalMaxAge: 9999 },
       } as SessionData;
-      redis.get = sinon.fake((_sid, cb) => cb(null, session));
-      dynamo.get = sinon.fake((_sid, cb) => cb(null, differentSession));
-      store = new DualSessionStore(redis, dynamo);
+      primary.get = sinon.fake((_sid, cb) => cb(null, session));
+      secondary.get = sinon.fake((_sid, cb) => cb(null, differentSession));
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.get(sid, (err, sess) => {
         expect(err).to.be.null;
@@ -242,10 +286,10 @@ describe("DualSessionStore", () => {
       });
     });
 
-    it("should not throw when redis has session but dynamo does not", (done) => {
-      redis.get = sinon.fake((_sid, cb) => cb(null, session));
-      dynamo.get = sinon.fake((_sid, cb) => cb(null, null));
-      store = new DualSessionStore(redis, dynamo);
+    it("should not throw when primary has session but secondary does not", (done) => {
+      primary.get = sinon.fake((_sid, cb) => cb(null, session));
+      secondary.get = sinon.fake((_sid, cb) => cb(null, null));
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.get(sid, (err, sess) => {
         expect(err).to.be.null;
@@ -255,9 +299,9 @@ describe("DualSessionStore", () => {
     });
 
     it("should not throw when both stores return null", (done) => {
-      redis.get = sinon.fake((_sid, cb) => cb(null, null));
-      dynamo.get = sinon.fake((_sid, cb) => cb(null, null));
-      store = new DualSessionStore(redis, dynamo);
+      primary.get = sinon.fake((_sid, cb) => cb(null, null));
+      secondary.get = sinon.fake((_sid, cb) => cb(null, null));
+      store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.get(sid, (err, sess) => {
         expect(err).to.be.null;

--- a/test/unit/dual-session-store.test.ts
+++ b/test/unit/dual-session-store.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, beforeEach, describe, it } from "mocha";
 import { expect, sinon } from "../utils/test-utils.js";
-import { DualSessionStore } from "../../src/config/dual-session-store.js";
+import {
+  DualSessionStore,
+  DualStoreError,
+} from "../../src/config/dual-session-store.js";
 import { type SessionData, Store } from "express-session";
 
 describe("DualSessionStore", () => {
@@ -47,14 +50,18 @@ describe("DualSessionStore", () => {
       });
     });
 
-    it("should return secondary error when both primary and secondary fail", (done) => {
+    it("should return combined error when both primary and secondary fail", (done) => {
+      const primaryErr = new Error("primary failure");
       const secondaryErr = new Error("secondary failure");
-      primary.get = sinon.fake((_sid, cb) => cb(new Error("primary failure")));
+      primary.get = sinon.fake((_sid, cb) => cb(primaryErr));
       secondary.get = sinon.fake((_sid, cb) => cb(secondaryErr));
       store = new DualSessionStore(primary, secondary, "Redis", "DynamoDB");
 
       store.get(sid, (err) => {
-        expect(err).to.equal(secondaryErr);
+        expect(err).to.be.instanceOf(DualStoreError);
+        expect(err.message).to.equal("Both session stores failed");
+        expect(err.primary).to.equal(primaryErr);
+        expect(err.secondary).to.equal(secondaryErr);
         done();
       });
     });

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -1,7 +1,9 @@
-import { beforeEach, describe, it } from "mocha";
+import { afterEach, beforeEach, describe, it } from "mocha";
 import type { RedisConfig } from "../../src/utils/types.js";
 import { isRedisConfigEqual } from "../../src/config/session.js";
 import { expect, sinon } from "../utils/test-utils.js";
+import { DualSessionStore } from "../../src/config/dual-session-store.js";
+import { RedisStore } from "connect-redis";
 import esmock from "esmock";
 
 describe("session", () => {
@@ -131,6 +133,61 @@ describe("session", () => {
           expectation.equal
         );
       });
+    });
+  });
+
+  describe("getSessionStore dual-write feature flag", () => {
+    const fakeDynamoStore = { fake: "dynamo-store" };
+    let getSessionStoreWithFlag: any;
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should return a RedisStore when dual write is disabled", async () => {
+      ({ getSessionStore: getSessionStoreWithFlag } = await esmock(
+        "../../src/config/session.js",
+        {
+          redis: {
+            createClient: sinon.fake(() => ({
+              connect: sinon.fake(),
+              on: sinon.fake(),
+            })),
+          },
+          "../../src/config.js": {
+            getSessionDualWriteEnabled: () => false,
+          },
+          "../../src/config/dynamodb-session.js": {
+            getDynamoSessionStore: () => fakeDynamoStore,
+          },
+        }
+      ));
+
+      const store = getSessionStoreWithFlag(redisConfig);
+      expect(store).to.be.instanceOf(RedisStore);
+    });
+
+    it("should return a DualSessionStore when dual write is enabled", async () => {
+      ({ getSessionStore: getSessionStoreWithFlag } = await esmock(
+        "../../src/config/session.js",
+        {
+          redis: {
+            createClient: sinon.fake(() => ({
+              connect: sinon.fake(),
+              on: sinon.fake(),
+            })),
+          },
+          "../../src/config.js": {
+            getSessionDualWriteEnabled: () => true,
+          },
+          "../../src/config/dynamodb-session.js": {
+            getDynamoSessionStore: () => fakeDynamoStore,
+          },
+        }
+      ));
+
+      const store = getSessionStoreWithFlag(redisConfig);
+      expect(store).to.be.instanceOf(DualSessionStore);
     });
   });
 });


### PR DESCRIPTION
**DONE: ~~NOTE: DO NOT MERGE, DEPENDENCIES ON:~~**
- ~~https://github.com/govuk-one-login/authentication-frontend/pull/3395~~
- ~~https://github.com/govuk-one-login/authentication-infrastructure/pull/151~~
    - DONE: ~~**NOT JUST PR MERGE**, these stack changes will need deploying to all environments post-merge~~

## What

<!-- Describe what you have changed and why -->

- Introduces a `DualSessionStore` to support writing session data to both Redis (primary) and DynamoDB (secondary).
- Implements session read fallbacks to the secondary store if the primary store fails, and logs any consistency mismatches.
- Wraps the dual session store functionality behind a new environment feature flag (`SESSION_DUAL_WRITE_ENABLED`), initially enabled in the dev and staging environments (this ticket).

See description of bae7b53f23eafde11122874568526a45548f780f for details around callback ordering.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
    - Suggested commit-by-commit, reviewing the commit messages
1. Deploy to a dev environment using the [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-frontend/actions/workflows/build-deploy-frontend-dev.yml)
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code review.
1. Ensure unit tests pass for the new `DualSessionStore` and updated configuration logic.
1. Deploy to a dev environment.
1. Run through a few journeys (e.g., sign in) to verify that session creation and active user journeys function correctly with the feature flag enabled. Journeys should behave as normal.
1. Check the dev environments CloudWatch logs to verify session consistency checks and ensure no unexpected read/write errors are occurring.
1. Ask if you'd like any clarifications around the wider plan etc.

## Testing

Ran through the above steps and confirmed no session consistency issues observed with the latest changes.

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

- [ ] Performance analyst has been notified of the change. **- N/A, dev and staging only**

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [ ] A UCD review has been performed. **- N/A, backend work only**

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. **- N/A, backend work only**

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [ ] Documentation has been updated to reflect these changes.

- [ ] Local running `./startup -L` still works.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->

- https://github.com/govuk-one-login/authentication-frontend/pull/3395
- https://github.com/govuk-one-login/authentication-infrastructure/pull/150
- https://github.com/govuk-one-login/authentication-infrastructure/pull/151
