### PR TITLE
BAU: Journey map reversible transitions

### DIFF
--- a/journey-map/public/style.css
+++ b/journey-map/public/style.css
@@ -164,6 +164,11 @@ form textarea.hidden {
   filter: drop-shadow(1px 0 0 #66ddff) drop-shadow(-1px 0 0 #66ddff)
     drop-shadow(0 1px 0 #66ddff) drop-shadow(0 -1px 0 #66ddff);
 }
+#diagramSvg .highlight.reversibleEdge {
+  stroke-width: 3px;
+  filter: drop-shadow(1px 0 0 #ff66aa) drop-shadow(-1px 0 0 #ff66aa)
+    drop-shadow(0 1px 0 #ff66aa) drop-shadow(0 -1px 0 #ff66aa);
+}
 #diagramSvg .highlight.node path {
   stroke-width: 3px;
 }

--- a/journey-map/src/index.ts
+++ b/journey-map/src/index.ts
@@ -104,7 +104,12 @@ const setupStateClickHandlers = (states: State[]): void => {
 
     // Remove existing highlights
     Array.from(document.getElementsByClassName("highlight")).forEach((edge) =>
-      edge.classList.remove("highlight", "outgoingEdge", "incomingEdge")
+      edge.classList.remove(
+        "highlight",
+        "outgoingEdge",
+        "incomingEdge",
+        "reversibleEdge"
+      )
     );
 
     // Add new highlights
@@ -114,12 +119,22 @@ const setupStateClickHandlers = (states: State[]): void => {
         const edgeStartNodeId = splitEdgeId[1];
         const edgeEndNodeId = splitEdgeId[2];
 
+        const isReversible = !!document.querySelector(
+          `[data-source="${edgeStartNodeId}"][data-target="${edgeEndNodeId}"][data-reversible="true"]`
+        );
+
         if (edgeStartNodeId === hexId) {
-          edge.classList.add("highlight", "outgoingEdge");
+          edge.classList.add(
+            "highlight",
+            isReversible ? "reversibleEdge" : "outgoingEdge"
+          );
         }
 
         if (edgeEndNodeId === hexId) {
-          edge.classList.add("highlight", "incomingEdge");
+          edge.classList.add(
+            "highlight",
+            isReversible ? "reversibleEdge" : "incomingEdge"
+          );
         }
       }
     );
@@ -135,10 +150,20 @@ const setupStateClickHandlers = (states: State[]): void => {
       .forEach((node) => node.classList.add("highlight"));
 
     Array.from(document.querySelectorAll(`[data-source="${hexId}"]`)).forEach(
-      (label) => label.classList.add("highlight", "outgoingEdge")
+      (label) => {
+        const cls = label.hasAttribute("data-reversible")
+          ? "reversibleEdge"
+          : "outgoingEdge";
+        label.classList.add("highlight", cls);
+      }
     );
     Array.from(document.querySelectorAll(`[data-target="${hexId}"]`)).forEach(
-      (label) => label.classList.add("highlight", "incomingEdge")
+      (label) => {
+        const cls = label.hasAttribute("data-reversible")
+          ? "reversibleEdge"
+          : "incomingEdge";
+        label.classList.add("highlight", cls);
+      }
     );
 
     currentHighlight = hexId;

--- a/journey-map/src/index.ts
+++ b/journey-map/src/index.ts
@@ -35,6 +35,7 @@ export interface Transition {
   event?: string;
   condition?: string;
   optional?: boolean;
+  reversible?: boolean;
 }
 
 const DOUBLE_CLICK_WINDOW_MILLIS = 1000;

--- a/journey-map/src/mermaid.ts
+++ b/journey-map/src/mermaid.ts
@@ -19,12 +19,19 @@ const renderState = (state: State): string => {
   return `    ${hexId}(${name})`;
 };
 
+const getArrow = (optional?: boolean, reversible?: boolean): string => {
+  if (optional) return "-.->";
+  if (reversible) return "--o";
+  return "-->";
+};
+
 const renderTransition = ({
   source,
   target,
   event,
   condition,
   optional,
+  reversible,
 }: Transition): string => {
   const hexSource = stringToUtf8Hex(source);
   const hexTarget = stringToUtf8Hex(target);
@@ -33,7 +40,7 @@ const renderTransition = ({
     event || condition
       ? `|<span data-source="${hexSource}" data-target="${hexTarget}">${event ?? ""}${lineBreak}${condition ?? ""}</span>|`
       : "";
-  const arrow = optional ? "-.->" : "-->";
+  const arrow = getArrow(optional, reversible);
   return `    ${hexSource}${arrow}${label}${hexTarget}`;
 };
 

--- a/journey-map/src/mermaid.ts
+++ b/journey-map/src/mermaid.ts
@@ -36,9 +36,10 @@ const renderTransition = ({
   const hexSource = stringToUtf8Hex(source);
   const hexTarget = stringToUtf8Hex(target);
   const lineBreak = event && condition ? "<br/>" : "";
+  const reversibleAttr = reversible ? ` data-reversible="true"` : "";
   const label =
     event || condition
-      ? `|<span data-source="${hexSource}" data-target="${hexTarget}">${event ?? ""}${lineBreak}${condition ?? ""}</span>|`
+      ? `|<span data-source="${hexSource}" data-target="${hexTarget}"${reversibleAttr}>${event ?? ""}${lineBreak}${condition ?? ""}</span>|`
       : "";
   const arrow = getArrow(optional, reversible);
   return `    ${hexSource}${arrow}${label}${hexTarget}`;

--- a/journey-map/src/stateMachineHelpers/auth-state-machine-helper.ts
+++ b/journey-map/src/stateMachineHelpers/auth-state-machine-helper.ts
@@ -117,6 +117,7 @@ const getTransitions = (
         target: getSingleTransitionTarget(transition),
         event: transition.eventType,
         condition: transition.cond?.name ?? undefined,
+        reversible: transition.meta?.reversible ?? undefined,
       })
     );
   }


### PR DESCRIPTION
## What

Now that 'reversible' transitions exist in the state machine (as part of the back button work), it made sense to update the journey map to reflect.

### Arrow ends

A system for arrows in the journey map:
* `-->` Means the transition is final. There is no going back.
* `--o` Means the transition is reversible. It's possible to go back

I did consider having double-ended `<-->` arrows, but that doesn't display the primary direction of travel, so settled on having a slightly different end.

### Highlight colour

Now when you click on a state that has a reversible transition in or out from it, the transition is highlighted yellow. Given that you can go both ways along these arrows, it doesn't make sense for them to be blue (where you've come from) or yellow (where you're going to), as they can be both.

### Screenshot
Showing the `/enter-password` state selected
<img width="1198" height="371" alt="image" src="https://github.com/user-attachments/assets/dc549937-623d-42e0-a6d1-bfe90f242467" />

## How to review

1. Code Review
2. Run locally