### PR TITLE
BAU: Allow the script to create passkeys for localhost

### DIFF
--- a/scripts/generate_webauthn/README.md
+++ b/scripts/generate_webauthn/README.md
@@ -30,6 +30,20 @@ Edit the variables at the top of `generate_webauthn_script.py`:
 | `USER_EMAIL`      | The user's email address                                       |
 | `CHALLENGE`       | A Base64URL-encoded challenge string (can be any random value) |
 
+You can use the following `ENV_URL` for the corresponding environments.
+
+| Env           | Env URL                       |
+| ------------- | ----------------------------- |
+| `local`       | `localhost`                   |
+| `dev`         | `dev.account.gov.uk`          |
+| `authdev1`    | `authdev1.dev.account.gov.uk` |
+| `authdev2`    | `authdev2.dev.account.gov.uk` |
+| `authdev3`    | `authdev3.dev.account.gov.uk` |
+| `build`       | `build.account.gov.uk`        |
+| `staging`     | `staging.account.gov.uk`      |
+| `integration` | `integration.account.gov.uk`  |
+| `production`  | `account.gov.uk`              |
+
 ## Usage
 
 1. **Run the script locally** to generate the JavaScript snippet:

--- a/scripts/generate_webauthn/generate_webauthn_script.py
+++ b/scripts/generate_webauthn/generate_webauthn_script.py
@@ -1,6 +1,6 @@
 # --- CONFIGURATION: Update these values ---
 ENV_NAME = "Dev"
-ENV_URL = "dev"  # e.g., 'build' for build.account.gov.uk
+ENV_URL = "dev.account.gov.uk"  # e.g., 'build.account.gov.uk' for build (see README for examples)
 USER_PUB_SUB_ID = "xxx"
 USER_EMAIL = "xxx@xxx.xxx"
 CHALLENGE = "6EP1s53M5sF7XL_G2RwbY-AbJoSNiiCIVb9DrNNITnM"  # Base64URL encoded
@@ -46,7 +46,7 @@ js_template = f"""
 
     const createOptions = {{
         challenge: bufferFromBase64("{CHALLENGE}"),
-        rp: {{ name: "GOV.UK One Login ({ENV_NAME})", id: "{ENV_URL}.account.gov.uk" }},
+        rp: {{ name: "GOV.UK One Login ({ENV_NAME})", id: "{ENV_URL}" }},
         user: {{ id: new TextEncoder().encode("{USER_PUB_SUB_ID}"), name: "{USER_EMAIL}", displayName: "" }},
         pubKeyCredParams: [{{ alg: -8, type: "public-key" }}, {{ alg: -7, type: "public-key" }}, {{ alg: -257, type: "public-key" }}],
         timeout: 60000,


### PR DESCRIPTION

## What

If you want to create a passkey for local running and then add the output to the local-authenticator table our generate webauthn script needs to support localhost as the rp ID.


## How to review

1. Code review

