### PR TITLE
AUT-5436: Switch primary session store to DynamoDB (dev and staging) - attempt 2

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -452,6 +452,29 @@ Conditions:
                 ]
               - "Yes"
 
+  SessionDynamoPrimaryEnabled:
+    Fn::Or:
+      - Fn::And:
+          - !Condition UseSubEnvironment
+          - Fn::Equals:
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref SubEnvironment,
+                  SessionDynamoPrimaryEnabled,
+                  DefaultValue: "No",
+                ]
+              - "Yes"
+      - Fn::And:
+          - !Condition NotSubEnvironment
+          - Fn::Equals:
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  SessionDynamoPrimaryEnabled,
+                  DefaultValue: "No",
+                ]
+              - "Yes"
+
 Mappings:
 
   EnvironmentConfiguration:
@@ -477,6 +500,7 @@ Mappings:
       SupportSingleFactorAccountDeletion: "Yes"
       PasskeyPromptClientAllowList: "skwdHH2y6ERjJWTPSoAFbSt8lX04OgtI"
       SessionDualWriteEnabled: "Yes"
+      SessionDynamoPrimaryEnabled: "Yes"
     authdev2:
       cloudfrontDistributionStackName: "authdev2-cloudfront"
       frontendApiBaseUrl: https://nw0dah7bxk-vpce-0b907325ae3bfe3ce.execute-api.eu-west-2.amazonaws.com/authdev2/
@@ -499,6 +523,7 @@ Mappings:
       SupportSingleFactorAccountDeletion: "Yes"
       PasskeyPromptClientAllowList: "rPEUe0hRrHqf0i0es1gYjKxE5ceGN7VK"
       SessionDualWriteEnabled: "Yes"
+      SessionDynamoPrimaryEnabled: "Yes"
     authdev3:
       cloudfrontDistributionStackName: "authdev3-cloudfront"
       frontendApiBaseUrl: https://y3s69ubaz5-vpce-0b907325ae3bfe3ce.execute-api.eu-west-2.amazonaws.com/authdev3/
@@ -516,6 +541,7 @@ Mappings:
       SupportSingleFactorAccountDeletion: "Yes"
       PasskeyPromptClientAllowList: ""
       SessionDualWriteEnabled: "Yes"
+      SessionDynamoPrimaryEnabled: "Yes"
     dev:
       DeployServiceDownPage: "No"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -548,6 +574,7 @@ Mappings:
       SupportSingleFactorAccountDeletion: "Yes"
       PasskeyPromptClientAllowList: "J3tedNRsfssnsf4STuc2NNIV1C1gdxBB"
       SessionDualWriteEnabled: "Yes"
+      SessionDynamoPrimaryEnabled: "Yes"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       DeployServiceDownPage: "No"
@@ -580,6 +607,7 @@ Mappings:
       SupportSingleFactorAccountDeletion: "No"
       PasskeyPromptClientAllowList: "Ykg9fGyY76On4e8tPvFabK5BIl65EkGH"
       SessionDualWriteEnabled: "No"
+      SessionDynamoPrimaryEnabled: "No"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       DeployServiceDownPage: "No"
@@ -619,6 +647,7 @@ Mappings:
       SupportSingleFactorAccountDeletion: "No"
       PasskeyPromptClientAllowList: "nsR2wZ7EebJ2VOzE1LUa9iAVadunWQP3,EMGmY82k-92QSakDl_9keKDFmZY" # perf-test client, home client
       SessionDualWriteEnabled: "Yes"
+      SessionDynamoPrimaryEnabled: "Yes"
     integration:
       DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -652,6 +681,7 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       PasskeyPromptClientAllowList: ""
       SessionDualWriteEnabled: "No"
+      SessionDynamoPrimaryEnabled: "No"
     production:
       DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -688,6 +718,7 @@ Mappings:
       SupportSingleFactorAccountDeletion: "No"
       PasskeyPromptClientAllowList: ""
       SessionDualWriteEnabled: "No"
+      SessionDynamoPrimaryEnabled: "No"
 
 Globals:
   Function:
@@ -1224,6 +1255,8 @@ Resources:
               Value: !If [SupportSingleFactorAccountDeletion, "1", "0"]
             - Name: SESSION_DUAL_WRITE_ENABLED
               Value: !If [SessionDualWriteEnabled, "1", "0"]
+            - Name: SESSION_DYNAMO_PRIMARY_ENABLED
+              Value: !If [SessionDynamoPrimaryEnabled, "1", "0"]
 
           Secrets:
             - Name: API_KEY

--- a/src/config.ts
+++ b/src/config.ts
@@ -215,6 +215,10 @@ export function getSessionDualWriteEnabled(): boolean {
   return process.env.SESSION_DUAL_WRITE_ENABLED === "1";
 }
 
+export function getSessionDynamoPrimaryEnabled(): boolean {
+  return process.env.SESSION_DYNAMO_PRIMARY_ENABLED === "1";
+}
+
 export function getAuthJwksUrl(): string {
   return `${getApiBaseUrl()}/.well-known/auth-jwks.json`;
 }

--- a/src/config/session.ts
+++ b/src/config/session.ts
@@ -5,7 +5,10 @@ import type { RedisConfig } from "../utils/types.js";
 import { logger } from "../utils/logger.js";
 import { DualSessionStore } from "./dual-session-store.js";
 import { getDynamoSessionStore } from "./dynamodb-session.js";
-import { getSessionDualWriteEnabled } from "../config.js";
+import {
+  getSessionDualWriteEnabled,
+  getSessionDynamoPrimaryEnabled,
+} from "../config.js";
 import type { Store } from "express-session";
 
 let redisClient: ReturnType<typeof createClient> | undefined;
@@ -58,6 +61,18 @@ export function getSessionStore(redisConfig: RedisConfig): Store {
   );
 
   const dynamoStore = getDynamoSessionStore();
+
+  if (getSessionDynamoPrimaryEnabled()) {
+    logger.info(
+      "Dual session store DynamoDB primary feature flag enabled, using dual session store with DynamoDB as primary."
+    );
+
+    return new DualSessionStore(dynamoStore, redisStore, "DynamoDB", "Redis");
+  }
+
+  logger.info(
+    "Dual session store DynamoDB primary feature flag disabled, using dual session store with Redis as primary."
+  );
 
   return new DualSessionStore(redisStore, dynamoStore, "Redis", "DynamoDB");
 }

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -20,6 +20,7 @@ import {
   showTestBanner,
   getAccountDomain,
   getPasskeyPromptClientAllowList,
+  getSessionDynamoPrimaryEnabled,
 } from "../../src/config.js";
 import { CHANNEL } from "../../src/app.constants.js";
 
@@ -127,6 +128,11 @@ describe("config", () => {
         name: "getSessionDualWriteEnabled",
         envVar: "SESSION_DUAL_WRITE_ENABLED",
         fn: getSessionDualWriteEnabled,
+      },
+      {
+        name: "getSessionDynamoPrimaryEnabled",
+        envVar: "SESSION_DYNAMO_PRIMARY_ENABLED",
+        fn: getSessionDynamoPrimaryEnabled,
       },
     ];
 

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -136,16 +136,18 @@ describe("session", () => {
     });
   });
 
-  describe("getSessionStore dual-write feature flag", () => {
+  describe("getSessionStore feature flags", () => {
     const fakeDynamoStore = { fake: "dynamo-store" };
-    let getSessionStoreWithFlag: any;
 
     afterEach(() => {
       sinon.restore();
     });
 
-    it("should return a RedisStore when dual write is disabled", async () => {
-      ({ getSessionStore: getSessionStoreWithFlag } = await esmock(
+    async function createSessionStoreWithFlags(
+      dualWriteEnabled: boolean,
+      dynamoPrimaryEnabled: boolean
+    ) {
+      const { getSessionStore: getSessionStoreWithFlag } = await esmock(
         "../../src/config/session.js",
         {
           redis: {
@@ -155,39 +157,43 @@ describe("session", () => {
             })),
           },
           "../../src/config.js": {
-            getSessionDualWriteEnabled: () => false,
+            getSessionDualWriteEnabled: () => dualWriteEnabled,
+            getSessionDynamoPrimaryEnabled: () => dynamoPrimaryEnabled,
           },
           "../../src/config/dynamodb-session.js": {
             getDynamoSessionStore: () => fakeDynamoStore,
           },
         }
-      ));
+      );
+      return getSessionStoreWithFlag(redisConfig);
+    }
 
-      const store = getSessionStoreWithFlag(redisConfig);
+    it("should return a RedisStore when dual write is disabled", async () => {
+      const store = await createSessionStoreWithFlags(false, false);
       expect(store).to.be.instanceOf(RedisStore);
     });
 
-    it("should return a DualSessionStore when dual write is enabled", async () => {
-      ({ getSessionStore: getSessionStoreWithFlag } = await esmock(
-        "../../src/config/session.js",
-        {
-          redis: {
-            createClient: sinon.fake(() => ({
-              connect: sinon.fake(),
-              on: sinon.fake(),
-            })),
-          },
-          "../../src/config.js": {
-            getSessionDualWriteEnabled: () => true,
-          },
-          "../../src/config/dynamodb-session.js": {
-            getDynamoSessionStore: () => fakeDynamoStore,
-          },
-        }
-      ));
+    it("should return a RedisStore when dual write is disabled even if dynamo primary is enabled", async () => {
+      const store = await createSessionStoreWithFlags(false, true);
+      expect(store).to.be.instanceOf(RedisStore);
+    });
 
-      const store = getSessionStoreWithFlag(redisConfig);
+    it("should return a DualSessionStore with Redis as primary when dual write enabled and dynamo primary disabled", async () => {
+      const store = await createSessionStoreWithFlags(true, false);
       expect(store).to.be.instanceOf(DualSessionStore);
+      expect(store["primary"]).to.be.instanceOf(RedisStore);
+      expect(store["secondary"]).to.equal(fakeDynamoStore);
+      expect(store["primaryLabel"]).to.equal("Redis");
+      expect(store["secondaryLabel"]).to.equal("DynamoDB");
+    });
+
+    it("should return a DualSessionStore with DynamoDB as primary when both flags enabled", async () => {
+      const store = await createSessionStoreWithFlags(true, true);
+      expect(store).to.be.instanceOf(DualSessionStore);
+      expect(store["primary"]).to.equal(fakeDynamoStore);
+      expect(store["secondary"]).to.be.instanceOf(RedisStore);
+      expect(store["primaryLabel"]).to.equal("DynamoDB");
+      expect(store["secondaryLabel"]).to.equal("Redis");
     });
   });
 });


### PR DESCRIPTION
Duplicate of #3405, no changes.

#3405 had to be reverted (#3410) due to some GitHub issues.

# Description copied from #3405 follows:

(Merged) ~~NOTE: Merge dependent on #3400~~

## What

<!-- Describe what you have changed and why -->

- Introduces a `SESSION_DYNAMO_PRIMARY_ENABLED` feature flag to allow switching the primary session store to DynamoDB while dual-writing is active.
    - Defaults to disabled in integration and production.
- Modifies the session store initialisation logic to swap the primary and secondary stores when the feature flag is enabled.
- Updates existing unit tests to cover the full interaction matrix between the `SESSION_DUAL_WRITE_ENABLED` and `SESSION_DYNAMO_PRIMARY_ENABLED` (new) feature flags.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-frontend/actions/workflows/build-deploy-frontend-dev.yml)
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code review.
1. Deploy to a dev environment.
1. Run through a few journeys (e.g., sign in) to verify that session creation and active user journeys function correctly with the feature flag enabled. Journeys should behave as normal.
1. Optionally review the ECS application logs to check that the expected store is being used as the primary and that reads are successful on the primary.

## Testing

Followed the above steps, logs showing as expected.

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

- [ ] Performance analyst has been notified of the change. **- N/A, up to staging only**

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [ ] A UCD review has been performed. **- N/A, backend work only**

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. **- N/A, backend work only**

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [ ] Documentation has been updated to reflect these changes.

- [ ] Local running `./startup -L` still works.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->

- Add dual session store and use up staging - https://github.com/govuk-one-login/authentication-frontend/pull/3400
