### PR TITLE
AUT-5439: Cutover to DynamoDB session store (dev and staging)

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -475,6 +475,29 @@ Conditions:
                 ]
               - "Yes"
 
+  SessionDynamoExclusiveEnabled:
+    Fn::Or:
+      - Fn::And:
+          - !Condition UseSubEnvironment
+          - Fn::Equals:
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref SubEnvironment,
+                  SessionDynamoExclusiveEnabled,
+                  DefaultValue: "No",
+                ]
+              - "Yes"
+      - Fn::And:
+          - !Condition NotSubEnvironment
+          - Fn::Equals:
+              - !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  SessionDynamoExclusiveEnabled,
+                  DefaultValue: "No",
+                ]
+              - "Yes"
+
 Mappings:
 
   EnvironmentConfiguration:
@@ -501,6 +524,7 @@ Mappings:
       PasskeyPromptClientAllowList: "skwdHH2y6ERjJWTPSoAFbSt8lX04OgtI"
       SessionDualWriteEnabled: "Yes"
       SessionDynamoPrimaryEnabled: "Yes"
+      SessionDynamoExclusiveEnabled: "Yes"
     authdev2:
       cloudfrontDistributionStackName: "authdev2-cloudfront"
       frontendApiBaseUrl: https://nw0dah7bxk-vpce-0b907325ae3bfe3ce.execute-api.eu-west-2.amazonaws.com/authdev2/
@@ -524,6 +548,7 @@ Mappings:
       PasskeyPromptClientAllowList: "rPEUe0hRrHqf0i0es1gYjKxE5ceGN7VK"
       SessionDualWriteEnabled: "Yes"
       SessionDynamoPrimaryEnabled: "Yes"
+      SessionDynamoExclusiveEnabled: "Yes"
     authdev3:
       cloudfrontDistributionStackName: "authdev3-cloudfront"
       frontendApiBaseUrl: https://y3s69ubaz5-vpce-0b907325ae3bfe3ce.execute-api.eu-west-2.amazonaws.com/authdev3/
@@ -542,6 +567,7 @@ Mappings:
       PasskeyPromptClientAllowList: ""
       SessionDualWriteEnabled: "Yes"
       SessionDynamoPrimaryEnabled: "Yes"
+      SessionDynamoExclusiveEnabled: "Yes"
     dev:
       DeployServiceDownPage: "No"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -575,6 +601,7 @@ Mappings:
       PasskeyPromptClientAllowList: "J3tedNRsfssnsf4STuc2NNIV1C1gdxBB"
       SessionDualWriteEnabled: "Yes"
       SessionDynamoPrimaryEnabled: "Yes"
+      SessionDynamoExclusiveEnabled: "Yes"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       DeployServiceDownPage: "No"
@@ -608,6 +635,7 @@ Mappings:
       PasskeyPromptClientAllowList: "Ykg9fGyY76On4e8tPvFabK5BIl65EkGH"
       SessionDualWriteEnabled: "No"
       SessionDynamoPrimaryEnabled: "No"
+      SessionDynamoExclusiveEnabled: "No"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       DeployServiceDownPage: "No"
@@ -648,6 +676,7 @@ Mappings:
       PasskeyPromptClientAllowList: "nsR2wZ7EebJ2VOzE1LUa9iAVadunWQP3,EMGmY82k-92QSakDl_9keKDFmZY" # perf-test client, home client
       SessionDualWriteEnabled: "Yes"
       SessionDynamoPrimaryEnabled: "Yes"
+      SessionDynamoExclusiveEnabled: "Yes"
     integration:
       DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -682,6 +711,7 @@ Mappings:
       PasskeyPromptClientAllowList: ""
       SessionDualWriteEnabled: "No"
       SessionDynamoPrimaryEnabled: "No"
+      SessionDynamoExclusiveEnabled: "No"
     production:
       DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -719,6 +749,7 @@ Mappings:
       PasskeyPromptClientAllowList: ""
       SessionDualWriteEnabled: "No"
       SessionDynamoPrimaryEnabled: "No"
+      SessionDynamoExclusiveEnabled: "No"
 
 Globals:
   Function:
@@ -1257,6 +1288,8 @@ Resources:
               Value: !If [SessionDualWriteEnabled, "1", "0"]
             - Name: SESSION_DYNAMO_PRIMARY_ENABLED
               Value: !If [SessionDynamoPrimaryEnabled, "1", "0"]
+            - Name: SESSION_DYNAMO_EXCLUSIVE_ENABLED
+              Value: !If [SessionDynamoExclusiveEnabled, "1", "0"]
 
           Secrets:
             - Name: API_KEY

--- a/src/config.ts
+++ b/src/config.ts
@@ -219,6 +219,10 @@ export function getSessionDynamoPrimaryEnabled(): boolean {
   return process.env.SESSION_DYNAMO_PRIMARY_ENABLED === "1";
 }
 
+export function getSessionDynamoExclusiveEnabled(): boolean {
+  return process.env.SESSION_DYNAMO_EXCLUSIVE_ENABLED === "1";
+}
+
 export function getAuthJwksUrl(): string {
   return `${getApiBaseUrl()}/.well-known/auth-jwks.json`;
 }

--- a/src/config/session.ts
+++ b/src/config/session.ts
@@ -7,6 +7,7 @@ import { DualSessionStore } from "./dual-session-store.js";
 import { getDynamoSessionStore } from "./dynamodb-session.js";
 import {
   getSessionDualWriteEnabled,
+  getSessionDynamoExclusiveEnabled,
   getSessionDynamoPrimaryEnabled,
 } from "../config.js";
 import type { Store } from "express-session";
@@ -46,6 +47,16 @@ function getRedisStore(redisConfig: RedisConfig): RedisStore {
 }
 
 export function getSessionStore(redisConfig: RedisConfig): Store {
+  const dynamoStore = getDynamoSessionStore();
+
+  if (getSessionDynamoExclusiveEnabled()) {
+    logger.info(
+      "Session store DynamoDB exclusive feature flag enabled, using DynamoDB store."
+    );
+
+    return dynamoStore;
+  }
+
   const redisStore = getRedisStore(redisConfig);
 
   if (!getSessionDualWriteEnabled()) {
@@ -59,8 +70,6 @@ export function getSessionStore(redisConfig: RedisConfig): Store {
   logger.info(
     "Dual session store writing feature flag enabled, using dual session store."
   );
-
-  const dynamoStore = getDynamoSessionStore();
 
   if (getSessionDynamoPrimaryEnabled()) {
     logger.info(

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -21,6 +21,7 @@ import {
   getAccountDomain,
   getPasskeyPromptClientAllowList,
   getSessionDynamoPrimaryEnabled,
+  getSessionDynamoExclusiveEnabled,
 } from "../../src/config.js";
 import { CHANNEL } from "../../src/app.constants.js";
 
@@ -133,6 +134,11 @@ describe("config", () => {
         name: "getSessionDynamoPrimaryEnabled",
         envVar: "SESSION_DYNAMO_PRIMARY_ENABLED",
         fn: getSessionDynamoPrimaryEnabled,
+      },
+      {
+        name: "getSessionDynamoExclusiveEnabled",
+        envVar: "SESSION_DYNAMO_EXCLUSIVE_ENABLED",
+        fn: getSessionDynamoExclusiveEnabled,
       },
     ];
 

--- a/test/unit/session.test.ts
+++ b/test/unit/session.test.ts
@@ -145,7 +145,8 @@ describe("session", () => {
 
     async function createSessionStoreWithFlags(
       dualWriteEnabled: boolean,
-      dynamoPrimaryEnabled: boolean
+      dynamoPrimaryEnabled: boolean,
+      dynamoExclusiveEnabled = false
     ) {
       const { getSessionStore: getSessionStoreWithFlag } = await esmock(
         "../../src/config/session.js",
@@ -159,6 +160,7 @@ describe("session", () => {
           "../../src/config.js": {
             getSessionDualWriteEnabled: () => dualWriteEnabled,
             getSessionDynamoPrimaryEnabled: () => dynamoPrimaryEnabled,
+            getSessionDynamoExclusiveEnabled: () => dynamoExclusiveEnabled,
           },
           "../../src/config/dynamodb-session.js": {
             getDynamoSessionStore: () => fakeDynamoStore,
@@ -194,6 +196,16 @@ describe("session", () => {
       expect(store["secondary"]).to.be.instanceOf(RedisStore);
       expect(store["primaryLabel"]).to.equal("DynamoDB");
       expect(store["secondaryLabel"]).to.equal("Redis");
+    });
+
+    it("should return the DynamoDB store directly when Dynamo exclusive flag is enabled", async () => {
+      const store = await createSessionStoreWithFlags(false, false, true);
+      expect(store).to.equal(fakeDynamoStore);
+    });
+
+    it("should return the DynamoDB store directly when Dynamo exclusive flag is enabled regardless of other flags", async () => {
+      const store = await createSessionStoreWithFlags(true, true, true);
+      expect(store).to.equal(fakeDynamoStore);
     });
   });
 });


### PR DESCRIPTION
NOTE: Merge dependent on #3411

## What

<!-- Describe what you have changed and why -->

- Introduces a `SESSION_DYNAMO_EXCLUSIVE_ENABLED` feature flag to allow switching exclusively to the DynamoDB session store.
    - Defaults to disabled in integration and production.
- Modifies the session store initialisation logic to return the DynamoDB store when the feature flag is enabled, regardless of the state of the other flags.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-frontend/actions/workflows/build-deploy-frontend-dev.yml)
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code review.
1. Deploy to a dev environment.
1. Run through a few journeys (e.g., sign in) to verify that session creation and active user journeys function correctly with the feature flag enabled. Journeys should behave as normal.
1. Optionally review the ECS application logs to check that the expected store is being used as the primary and that reads are successful on the primary.

## Testing

Followed the above steps, logs showing as expected.

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

- [ ] Performance analyst has been notified of the change. **- N/A, up to staging only**

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [ ] A UCD review has been performed. **- N/A, backend work only**

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. **- N/A, backend work only**

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [ ] Documentation has been updated to reflect these changes.

- [ ] Local running `./startup -L` still works.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->

- Add dual session store (and use in dev and staging - https://github.com/govuk-one-login/authentication-frontend/pull/3400
- Switch primary store to DynamoDB (and use in dev and staging) - https://github.com/govuk-one-login/authentication-frontend/pull/3411
