### PR TITLE
AUT-5002: Successful passkey authentication

### DIFF
--- a/scripts/generate_webauthn/README.md
+++ b/scripts/generate_webauthn/README.md
@@ -30,6 +30,20 @@ Edit the variables at the top of `generate_webauthn_script.py`:
 | `USER_EMAIL`      | The user's email address                                       |
 | `CHALLENGE`       | A Base64URL-encoded challenge string (can be any random value) |
 
+You can use the following `ENV_URL` for the corresponding environments.
+
+| Env           | Env URL                       |
+| ------------- | ----------------------------- |
+| `local`       | `localhost`                   |
+| `dev`         | `dev.account.gov.uk`          |
+| `authdev1`    | `authdev1.dev.account.gov.uk` |
+| `authdev2`    | `authdev2.dev.account.gov.uk` |
+| `authdev3`    | `authdev3.dev.account.gov.uk` |
+| `build`       | `build.account.gov.uk`        |
+| `staging`     | `staging.account.gov.uk`      |
+| `integration` | `integration.account.gov.uk`  |
+| `production`  | `account.gov.uk`              |
+
 ## Usage
 
 1. **Run the script locally** to generate the JavaScript snippet:

--- a/scripts/generate_webauthn/generate_webauthn_script.py
+++ b/scripts/generate_webauthn/generate_webauthn_script.py
@@ -1,10 +1,8 @@
-# --- CONFIGURATION: Update these values ---
 ENV_NAME = "Dev"
-ENV_URL = "dev"  # e.g., 'build' for build.account.gov.uk
 USER_PUB_SUB_ID = "xxx"
 USER_EMAIL = "xxx@xxx.xxx"
-CHALLENGE = "6EP1s53M5sF7XL_G2RwbY-AbJoSNiiCIVb9DrNNITnM"  # Base64URL encoded
-# ------------------------------------------
+ENV_URL = "dev.account.gov.uk"  # e.g., 'build.account.gov.uk' for build (see README for examples)
+CHALLENGE = "6EP1s53M5sF7XL_G2RwbY-AbJoSNiiCIVb9DrNNITnM"
 
 js_template = f"""
 (async () => {{
@@ -27,7 +25,7 @@ js_template = f"""
 
     const parseAttestation = (buffer) => {{
         const view = new Uint8Array(buffer);
-        const pattern = [0x68, 0x61, 0x75, 0x74, 0x68, 0x44, 0x61, 0x74, 0x61]; // "authData"
+        const pattern = [0x68, 0x61, 0x75, 0x74, 0x68, 0x44, 0x61, 0x74, 0x61];
         let offset = -1;
         for (let i = 0; i < view.length - pattern.length; i++) {{
             if (pattern.every((byte, j) => view[i + j] === byte)) {{
@@ -35,18 +33,33 @@ js_template = f"""
             }}
         }}
         if (offset === -1) return null;
-        let dataStart = view[offset] === 0x58 ? offset + 2 : view[offset] === 0x59 ? offset + 3 : offset + 1;
-        const authData = view.slice(dataStart);
+
+        let dataStart = 0;
+        let authDataLength = 0;
+        if (view[offset] === 0x58) {{
+            authDataLength = view[offset + 1];
+            dataStart = offset + 2;
+        }} else if (view[offset] === 0x59) {{
+            authDataLength = (view[offset + 1] << 8) + view[offset + 2];
+            dataStart = offset + 3;
+        }} else {{
+            authDataLength = view[offset] & 0x1F;
+            dataStart = offset + 1;
+        }}
+
+        const authData = view.slice(dataStart, dataStart + authDataLength);
+        const credIdLength = (authData[53] << 8) + authData[54];
+
         return {{
             authData,
-            publicKey: authData.slice(55 + ((authData[53] << 8) + authData[54])),
+            publicKey: authData.slice(55 + credIdLength),
             aaguid: authData.slice(37, 53)
         }};
     }};
 
     const createOptions = {{
         challenge: bufferFromBase64("{CHALLENGE}"),
-        rp: {{ name: "GOV.UK One Login ({ENV_NAME})", id: "{ENV_URL}.account.gov.uk" }},
+        rp: {{ name: "GOV.UK One Login ({ENV_NAME})", id: "{ENV_URL}" }},
         user: {{ id: new TextEncoder().encode("{USER_PUB_SUB_ID}"), name: "{USER_EMAIL}", displayName: "" }},
         pubKeyCredParams: [{{ alg: -8, type: "public-key" }}, {{ alg: -7, type: "public-key" }}, {{ alg: -257, type: "public-key" }}],
         timeout: 60000,
@@ -60,26 +73,15 @@ js_template = f"""
     try {{
         const credential = await navigator.credentials.create({{ publicKey: createOptions }});
         const {{ response }} = credential;
+
+        const parsed = parseAttestation(response.attestationObject);
+        const authData = parsed.authData;
+        const publicKey = parsed.publicKey;
+        const aaguid = parsed.aaguid;
+
         const extResults = credential.getClientExtensionResults();
-
-        let authData, publicKey, aaguid;
-        if (response.getAuthenticatorData) {{
-            authData = new Uint8Array(response.getAuthenticatorData());
-            publicKey = new Uint8Array(response.getPublicKey());
-            aaguid = authData.slice(37, 53);
-        }} else {{
-            const parsed = parseAttestation(response.attestationObject);
-            authData = parsed.authData;
-            publicKey = parsed.publicKey;
-            aaguid = parsed.aaguid;
-        }}
-
-        // GENUINE SIGN COUNT: Bytes 33-36 of authData (Big-Endian)
         const signCount = (authData[33] << 24) | (authData[34] << 16) | (authData[35] << 8) | (authData[36]);
-
-        // GENUINE RESIDENT KEY: Check credProps extension, fallback to true if creation succeeded with "required"
         const isResidentKey = extResults.credProps ? !!extResults.credProps.rk : true;
-
         const flags = authData[32];
         const now = new Date();
         const timestamp = now.toISOString().replace('T', ':').replace('Z', '').slice(0, -1);

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -132,6 +132,8 @@ export const API_ENDPOINTS = {
   ID_REVERIFICATION_STATE: "/id-reverification-state",
   AMC_AUTHORIZE: "/amc-authorize",
   AMC_CALLBACK: "/amc-callback",
+  START_PASSKEY_ASSERTION: "/start-passkey-assertion",
+  FINISH_PASSKEY_ASSERTION: "/finish-passkey-assertion"
 };
 
 export const ERROR_MESSAGES = {

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -133,7 +133,7 @@ export const API_ENDPOINTS = {
   AMC_AUTHORIZE: "/amc-authorize",
   AMC_CALLBACK: "/amc-callback",
   START_PASSKEY_ASSERTION: "/start-passkey-assertion",
-  FINISH_PASSKEY_ASSERTION: "/finish-passkey-assertion"
+  FINISH_PASSKEY_ASSERTION: "/finish-passkey-assertion",
 };
 
 export const ERROR_MESSAGES = {

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -77,6 +77,7 @@ const USER_JOURNEY_EVENTS = {
   CREATE_PASSKEY_SKIPPED: "CREATE_PASSKEY_SKIPPED",
   CREATE_PASSKEY_BACK: "CREATE_PASSKEY_BACK",
   PASSKEY_CREATED: "PASSKEY_CREATED",
+  PASSKEY_VALIDATED: "PASSKEY_VALIDATED",
   SIGN_IN_WITH_PASSKEY: "SIGN_IN_WITH_PASSKEY",
 };
 
@@ -344,6 +345,13 @@ const authStateMachine = createMachine<AuthStateContext>(
         },
       },
       [PATH_NAMES.SIGN_IN_WITH_PASSKEY]: {
+        on: {
+          [USER_JOURNEY_EVENTS.PASSKEY_VALIDATED]: [
+            {
+              target: [INTERMEDIATE_STATES.SIGN_IN_END],
+            },
+          ],
+        },
         meta: {
           optionalPaths: [PATH_NAMES.ENTER_PASSWORD],
         },

--- a/src/components/sign-in-with-passkey/index.njk
+++ b/src/components/sign-in-with-passkey/index.njk
@@ -40,5 +40,37 @@
 {% endblock %}
 
 {% block scripts %}
-    <script defer type="text/javascript" src="/public/scripts/prevent-double-form-submit.js"></script>
+  <script {% if scriptNonce %} nonce="{{ scriptNonce }}"{%  endif %}>
+    const signInWithPasskeyForm = document.getElementById("signInWithPasskeyForm");
+    let isSubmitting = false
+
+    async function handleSubmit(event) {
+      event.preventDefault();
+
+      if (isSubmitting) return
+      isSubmitting = true
+
+      try {
+        if (SimpleWebAuthnBrowser.browserSupportsWebAuthn()) {
+          // The reason we need to the publicKey from the response is toCredentialsJson in
+          // java-webauthn-server puts the authenticationOptions as the property of publicKey
+          const authenticationOptions = JSON.parse(signInWithPasskeyForm.dataset.authenticationOptions).publicKey
+          const authenticationResponse = await SimpleWebAuthnBrowser.startAuthentication({ optionsJSON: authenticationOptions})
+          signInWithPasskeyForm.querySelector('input[name="authenticationResponse"]').value = JSON.stringify(authenticationResponse)
+
+          const authenticationErrorField = signInWithPasskeyForm.querySelector('input[name="authenticationError"]');
+          authenticationErrorField.parentNode.removeChild(authenticationErrorField)
+        }
+      } catch (error) {
+        console.error(error.message);
+        signInWithPasskeyForm.querySelector('input[name="authenticationError"]').value = `${error.name} - ${error.message}`
+      }
+
+      signInWithPasskeyForm.submit();
+    }
+
+    signInWithPasskeyForm.addEventListener('submit', handleSubmit);
+
+  </script>
+  <script defer type="text/javascript" src="/public/scripts/prevent-double-form-submit.js"></script>
 {% endblock %}

--- a/src/components/sign-in-with-passkey/index.njk
+++ b/src/components/sign-in-with-passkey/index.njk
@@ -20,11 +20,18 @@
     {{'pages.signInWithPasskey.paragraph3' | translate }}
   </p>
 
-  {{ govukButton({
-    text: 'general.continue.label' | translate,
-    type: "Submit",
-    preventDoubleClick: true
-  }) }}
+  <form method="post" id="signInWithPasskeyForm" data-authentication-options="{{ authenticationOptions }}">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+    <input type="hidden" name="authenticationResponse" value='"' />
+    <input type="hidden" name="authenticationError" value="JavaScriptNotEnabled" />
+
+    {{ govukButton({
+      text: 'general.continue.label' | translate,
+      type: "Submit",
+      preventDoubleClick: true
+    }) }}
+
+  </form>
 
   <p class="govuk-body">
     <a href="/enter-password" class="govuk-link" rel="noreferrer noopener">{{'pages.signInWithPasskey.signInAnotherWayLinkText' | translate }}</a>

--- a/src/components/sign-in-with-passkey/index.njk
+++ b/src/components/sign-in-with-passkey/index.njk
@@ -52,10 +52,7 @@
 
       try {
         if (SimpleWebAuthnBrowser.browserSupportsWebAuthn()) {
-          // The reason we need to the publicKey from the response is toCredentialsJson in
-          // java-webauthn-server puts the authenticationOptions as the property of publicKey
-          const authenticationOptions = JSON.parse(signInWithPasskeyForm.dataset.authenticationOptions).publicKey
-          const authenticationResponse = await SimpleWebAuthnBrowser.startAuthentication({ optionsJSON: authenticationOptions})
+          const authenticationResponse = await SimpleWebAuthnBrowser.startAuthentication({ optionsJSON: JSON.parse(signInWithPasskeyForm.dataset.authenticationOptions)})
           signInWithPasskeyForm.querySelector('input[name="authenticationResponse"]').value = JSON.stringify(authenticationResponse)
 
           const authenticationErrorField = signInWithPasskeyForm.querySelector('input[name="authenticationError"]');

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-controller.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-controller.ts
@@ -1,22 +1,16 @@
 import type { Request, Response } from "express";
-import type {
-  FinishSignInWithPasskeyInterface,
-  StartSignInWithPasskeyInterface,
-} from "./types.js";
-import {
-  finishSignInWithPasskeyService,
-  startSignInWithPasskeyService,
-} from "./sign-in-with-passkey-service.js";
+import type { SignInWithPasskeyInterface } from "./types.js";
+import { signInWithPasskeyService } from "./sign-in-with-passkey-service.js";
 import type { ExpressRouteFunc } from "../../types.js";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 
 export function signInWithPasskeyGet(
-  service: StartSignInWithPasskeyInterface = startSignInWithPasskeyService()
+  service: SignInWithPasskeyInterface = signInWithPasskeyService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
-    const startPasskeyAssertionResult = await service.startSignInWithPasskey(
+    const startPasskeyAssertionResult = await service.startPasskeyAssertion(
       res.locals.sessionId,
       res.locals.clientSessionId,
       res.locals.persistentSessionId,
@@ -38,13 +32,13 @@ export function signInWithPasskeyGet(
 }
 
 export function signInWithPasskeyPost(
-  service: FinishSignInWithPasskeyInterface = finishSignInWithPasskeyService()
+  service: SignInWithPasskeyInterface = signInWithPasskeyService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const authenticationResponse: AuthenticationResponseJSON =
       req.body.authenticationResponse;
 
-    const finishPasskeyAssertionResult = await service.finishSignInWithPasskey(
+    const finishPasskeyAssertionResult = await service.finishPasskeyAssertion(
       res.locals.sessionId,
       res.locals.clientSessionId,
       res.locals.persistentSessionId,

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-controller.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-controller.ts
@@ -26,7 +26,7 @@ export function signInWithPasskeyGet(
     const authenticationOptions = startPasskeyAssertionResult.data;
 
     res.render("sign-in-with-passkey/index.njk", {
-      authenticationOptions: JSON.stringify(authenticationOptions),
+      authenticationOptions: JSON.stringify(authenticationOptions.publicKey),
     });
   };
 }

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-controller.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-controller.ts
@@ -1,7 +1,16 @@
 import type { Request, Response } from "express";
-import type { StartSignInWithPasskeyInterface } from "./types.js";
-import { startSignInWithPasskeyService } from "./sign-in-with-passkey-service.js";
+import type {
+  FinishSignInWithPasskeyInterface,
+  StartSignInWithPasskeyInterface,
+} from "./types.js";
+import {
+  finishSignInWithPasskeyService,
+  startSignInWithPasskeyService,
+} from "./sign-in-with-passkey-service.js";
 import type { ExpressRouteFunc } from "../../types.js";
+import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
+import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 
 export function signInWithPasskeyGet(
   service: StartSignInWithPasskeyInterface = startSignInWithPasskeyService()
@@ -25,5 +34,37 @@ export function signInWithPasskeyGet(
     res.render("sign-in-with-passkey/index.njk", {
       authenticationOptions: JSON.stringify(authenticationOptions),
     });
+  };
+}
+
+export function signInWithPasskeyPost(
+  service: FinishSignInWithPasskeyInterface = finishSignInWithPasskeyService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const authenticationResponse: AuthenticationResponseJSON =
+      req.body.authenticationResponse;
+
+    const finishPasskeyAssertionResult = await service.finishSignInWithPasskey(
+      res.locals.sessionId,
+      res.locals.clientSessionId,
+      res.locals.persistentSessionId,
+      req,
+      authenticationResponse
+    );
+
+    if (!finishPasskeyAssertionResult.success) {
+      // TODO - AUT-4990 - Handle failure cases
+      throw new Error(
+        `FinishPasskeyAssertionError: ${finishPasskeyAssertionResult.data.message}`
+      );
+    }
+
+    return res.redirect(
+      await getNextPathAndUpdateJourney(
+        req,
+        res,
+        USER_JOURNEY_EVENTS.PASSKEY_VALIDATED
+      )
+    );
   };
 }

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-controller.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-controller.ts
@@ -1,8 +1,29 @@
 import type { Request, Response } from "express";
+import type { StartSignInWithPasskeyInterface } from "./types.js";
+import { startSignInWithPasskeyService } from "./sign-in-with-passkey-service.js";
+import type { ExpressRouteFunc } from "../../types.js";
 
-export async function signInWithPasskeyGet(
-  req: Request,
-  res: Response
-): Promise<void> {
-  res.render("sign-in-with-passkey/index.njk");
+export function signInWithPasskeyGet(
+  service: StartSignInWithPasskeyInterface = startSignInWithPasskeyService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const startPasskeyAssertionResult = await service.startSignInWithPasskey(
+      res.locals.sessionId,
+      res.locals.clientSessionId,
+      res.locals.persistentSessionId,
+      req
+    );
+
+    if (!startPasskeyAssertionResult.success) {
+      throw new Error(
+        `StartPasskeyAssertionError: ${startPasskeyAssertionResult.data.message}`
+      );
+    }
+
+    const authenticationOptions = startPasskeyAssertionResult.data;
+
+    res.render("sign-in-with-passkey/index.njk", {
+      authenticationOptions: JSON.stringify(authenticationOptions),
+    });
+  };
 }

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-routes.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-routes.ts
@@ -10,7 +10,7 @@ router.get(
   PATH_NAMES.SIGN_IN_WITH_PASSKEY,
   validateSessionMiddleware,
   allowAndPersistUserJourneyMiddleware,
-  signInWithPasskeyGet
+  signInWithPasskeyGet()
 );
 
 export { router as signInWithPasskeyRouter };

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-routes.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-routes.ts
@@ -1,6 +1,9 @@
 import { PATH_NAMES } from "../../app.constants.js";
 import * as express from "express";
-import { signInWithPasskeyGet } from "./sign-in-with-passkey-controller.js";
+import {
+  signInWithPasskeyGet,
+  signInWithPasskeyPost,
+} from "./sign-in-with-passkey-controller.js";
 import { validateSessionMiddleware } from "../../middleware/session-middleware.js";
 import { allowAndPersistUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware.js";
 
@@ -11,6 +14,13 @@ router.get(
   validateSessionMiddleware,
   allowAndPersistUserJourneyMiddleware,
   signInWithPasskeyGet()
+);
+
+router.post(
+  PATH_NAMES.SIGN_IN_WITH_PASSKEY,
+  validateSessionMiddleware,
+  allowAndPersistUserJourneyMiddleware,
+  signInWithPasskeyPost()
 );
 
 export { router as signInWithPasskeyRouter };

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-service.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-service.ts
@@ -1,0 +1,44 @@
+import type { Http } from "../../utils/http.js";
+import {
+  createApiResponse,
+  getInternalRequestConfigWithSecurityHeaders,
+  http,
+} from "../../utils/http.js";
+import type {
+  StartSignInWithPasskeyInterface,
+  StartSignInWithPasskeyResponse,
+} from "./types.js";
+import type { ApiResponseResult } from "../../types.js";
+import { API_ENDPOINTS } from "../../app.constants.js";
+import type { Request } from "express";
+
+export function startSignInWithPasskeyService(
+  axios: Http = http
+): StartSignInWithPasskeyInterface {
+  const startSignInWithPasskey = async function (
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string,
+    req: Request
+  ): Promise<ApiResponseResult<StartSignInWithPasskeyResponse>> {
+    const response = await axios.client.post<StartSignInWithPasskeyResponse>(
+      API_ENDPOINTS.START_PASSKEY_ASSERTION,
+      {},
+      getInternalRequestConfigWithSecurityHeaders(
+        {
+          sessionId: sessionId,
+          clientSessionId: clientSessionId,
+          persistentSessionId: persistentSessionId,
+        },
+        req,
+        API_ENDPOINTS.START_PASSKEY_ASSERTION
+      )
+    );
+
+    return createApiResponse<StartSignInWithPasskeyResponse>(response);
+  };
+
+  return {
+    startSignInWithPasskey,
+  };
+}

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-service.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-service.ts
@@ -5,25 +5,24 @@ import {
   http,
 } from "../../utils/http.js";
 import type {
-  FinishSignInWithPasskeyInterface,
-  StartSignInWithPasskeyInterface,
-  StartSignInWithPasskeyResponse,
+  SignInWithPasskeyInterface,
+  StartPasskeyAssertionResponse,
 } from "./types.js";
 import type { ApiResponseResult, DefaultApiResponse } from "../../types.js";
 import { API_ENDPOINTS } from "../../app.constants.js";
 import type { Request } from "express";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 
-export function startSignInWithPasskeyService(
+export function signInWithPasskeyService(
   axios: Http = http
-): StartSignInWithPasskeyInterface {
-  const startSignInWithPasskey = async function (
+): SignInWithPasskeyInterface {
+  const startPasskeyAssertion = async function (
     sessionId: string,
     clientSessionId: string,
     persistentSessionId: string,
     req: Request
-  ): Promise<ApiResponseResult<StartSignInWithPasskeyResponse>> {
-    const response = await axios.client.post<StartSignInWithPasskeyResponse>(
+  ): Promise<ApiResponseResult<StartPasskeyAssertionResponse>> {
+    const response = await axios.client.post<StartPasskeyAssertionResponse>(
       API_ENDPOINTS.START_PASSKEY_ASSERTION,
       {},
       getInternalRequestConfigWithSecurityHeaders(
@@ -37,18 +36,10 @@ export function startSignInWithPasskeyService(
       )
     );
 
-    return createApiResponse<StartSignInWithPasskeyResponse>(response);
+    return createApiResponse<StartPasskeyAssertionResponse>(response);
   };
 
-  return {
-    startSignInWithPasskey,
-  };
-}
-
-export function finishSignInWithPasskeyService(
-  axios: Http = http
-): FinishSignInWithPasskeyInterface {
-  const finishSignInWithPasskey = async function (
+  const finishPasskeyAssertion = async function (
     sessionId: string,
     clientSessionId: string,
     persistentSessionId: string,
@@ -73,6 +64,7 @@ export function finishSignInWithPasskeyService(
   };
 
   return {
-    finishSignInWithPasskey,
+    startPasskeyAssertion: startPasskeyAssertion,
+    finishPasskeyAssertion: finishPasskeyAssertion,
   };
 }

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-service.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-service.ts
@@ -5,12 +5,14 @@ import {
   http,
 } from "../../utils/http.js";
 import type {
+  FinishSignInWithPasskeyInterface,
   StartSignInWithPasskeyInterface,
   StartSignInWithPasskeyResponse,
 } from "./types.js";
-import type { ApiResponseResult } from "../../types.js";
+import type { ApiResponseResult, DefaultApiResponse } from "../../types.js";
 import { API_ENDPOINTS } from "../../app.constants.js";
 import type { Request } from "express";
+import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 
 export function startSignInWithPasskeyService(
   axios: Http = http
@@ -40,5 +42,37 @@ export function startSignInWithPasskeyService(
 
   return {
     startSignInWithPasskey,
+  };
+}
+
+export function finishSignInWithPasskeyService(
+  axios: Http = http
+): FinishSignInWithPasskeyInterface {
+  const finishSignInWithPasskey = async function (
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string,
+    req: Request,
+    authenticationResponse: AuthenticationResponseJSON
+  ): Promise<ApiResponseResult<DefaultApiResponse>> {
+    const response = await axios.client.post<DefaultApiResponse>(
+      API_ENDPOINTS.FINISH_PASSKEY_ASSERTION,
+      { pkc: authenticationResponse },
+      getInternalRequestConfigWithSecurityHeaders(
+        {
+          sessionId: sessionId,
+          clientSessionId: clientSessionId,
+          persistentSessionId: persistentSessionId,
+        },
+        req,
+        API_ENDPOINTS.FINISH_PASSKEY_ASSERTION
+      )
+    );
+
+    return createApiResponse<DefaultApiResponse>(response);
+  };
+
+  return {
+    finishSignInWithPasskey,
   };
 }

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-controller.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-controller.test.ts
@@ -3,12 +3,14 @@ import { describe } from "mocha";
 
 import { sinon } from "../../../../test/utils/test-utils.js";
 import type { Request, Response } from "express";
-
-import { signInWithPasskeyGet } from "../sign-in-with-passkey-controller.js";
-import { PATH_NAMES } from "../../../app.constants.js";
 import type { RequestOutput, ResponseOutput } from "mock-req-res";
 import { mockResponse } from "mock-req-res";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper.js";
+import { PATH_NAMES } from "../../../app.constants.js";
+import { signInWithPasskeyGet } from "../sign-in-with-passkey-controller.js";
+import type { StartSignInWithPasskeyInterface } from "../types.js";
+import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
+import { strict as assert } from "assert";
 
 describe("sign in with passkey controller", () => {
   let req: RequestOutput;
@@ -17,6 +19,9 @@ describe("sign in with passkey controller", () => {
   beforeEach(() => {
     req = createMockRequest(PATH_NAMES.SIGN_IN_WITH_PASSKEY);
     res = mockResponse();
+    res.locals.sessionId = commonVariables.sessionId;
+    res.locals.clientSessionId = commonVariables.clientSessionId;
+    res.locals.persistentSessionId = commonVariables.diPersistentSessionId;
   });
 
   afterEach(() => {
@@ -24,10 +29,75 @@ describe("sign in with passkey controller", () => {
   });
 
   describe("signInWithPasskeyGet", () => {
-    it("should render the sign in with passkey view", async () => {
-      signInWithPasskeyGet(req as Request, res as Response);
+    it("should render the sign in with passkey view with authentication options on success", async () => {
+      const mockData = {
+        message: "success",
+        code: 200,
+        challenge: "dGVzdC1jaGFsbGVuZ2U",
+        rpId: "localhost",
+        allowCredentials: [{ type: "public-key", id: "credential-id-123" }],
+        timeout: 60000,
+        userVerification: "preferred",
+      };
 
-      expect(res.render).to.have.calledWith("sign-in-with-passkey/index.njk");
+      const fakeStartSignInService = {
+        startSignInWithPasskey: sinon.fake.returns({
+          success: true,
+          data: mockData,
+        }),
+      } as unknown as StartSignInWithPasskeyInterface;
+
+      await signInWithPasskeyGet(fakeStartSignInService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.render).to.have.been.calledWith(
+        "sign-in-with-passkey/index.njk",
+        { authenticationOptions: JSON.stringify(mockData) }
+      );
+    });
+
+    it("should pass the correct session IDs to the start service", async () => {
+      const fakeStartSignInService = {
+        startSignInWithPasskey: sinon.fake.returns({
+          success: true,
+          data: { message: "success", code: 200 },
+        }),
+      } as unknown as StartSignInWithPasskeyInterface;
+
+      await signInWithPasskeyGet(fakeStartSignInService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(
+        fakeStartSignInService.startSignInWithPasskey
+      ).to.have.been.calledWith(
+        commonVariables.sessionId,
+        commonVariables.clientSessionId,
+        commonVariables.diPersistentSessionId,
+        req
+      );
+    });
+
+    it("should throw an error when the start service returns unsuccessful", async () => {
+      const fakeStartSignInService: StartSignInWithPasskeyInterface = {
+        startSignInWithPasskey: sinon.fake.returns({
+          success: false,
+          data: { message: "Session expired", code: 1000 },
+        }),
+      } as unknown as StartSignInWithPasskeyInterface;
+      await assert.rejects(
+        async () =>
+          signInWithPasskeyGet(fakeStartSignInService)(
+            req as Request,
+            res as Response
+          ),
+        Error,
+        "StartPasskeyAssertionError: Session expired"
+      );
+      expect(res.render).to.not.have.been.called;
     });
   });
 });

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-controller.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-controller.test.ts
@@ -7,8 +7,14 @@ import type { RequestOutput, ResponseOutput } from "mock-req-res";
 import { mockResponse } from "mock-req-res";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper.js";
 import { PATH_NAMES } from "../../../app.constants.js";
-import { signInWithPasskeyGet } from "../sign-in-with-passkey-controller.js";
-import type { StartSignInWithPasskeyInterface } from "../types.js";
+import {
+  signInWithPasskeyGet,
+  signInWithPasskeyPost,
+} from "../sign-in-with-passkey-controller.js";
+import type {
+  StartSignInWithPasskeyInterface,
+  FinishSignInWithPasskeyInterface,
+} from "../types.js";
 import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
 import { strict as assert } from "assert";
 
@@ -98,6 +104,70 @@ describe("sign in with passkey controller", () => {
         "StartPasskeyAssertionError: Session expired"
       );
       expect(res.render).to.not.have.been.called;
+    });
+  });
+
+  describe("signInWithPasskeyPost", () => {
+    it("should redirect to the next path when the finish service returns success", async () => {
+      const fakeFinishSignInService = {
+        finishSignInWithPasskey: sinon.fake.returns({
+          success: true,
+        }),
+      } as unknown as FinishSignInWithPasskeyInterface;
+
+      await signInWithPasskeyPost(fakeFinishSignInService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.redirect).to.have.been.calledWith(PATH_NAMES.AUTH_CODE);
+    });
+
+    it("should pass the authentication response from the request body to the finish service", async () => {
+      const authenticationResponse = {
+        signedChallenge: "challenge",
+      };
+      req.body.authenticationResponse = authenticationResponse;
+      const fakeFinishSignInService = {
+        finishSignInWithPasskey: sinon.fake.returns({
+          success: true,
+        }),
+      } as unknown as FinishSignInWithPasskeyInterface;
+
+      await signInWithPasskeyPost(fakeFinishSignInService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(
+        fakeFinishSignInService.finishSignInWithPasskey
+      ).to.have.been.calledWith(
+        commonVariables.sessionId,
+        commonVariables.clientSessionId,
+        commonVariables.diPersistentSessionId,
+        req,
+        authenticationResponse
+      );
+    });
+
+    it("should throw an error when the finish service returns unsuccessful", async () => {
+      const fakeFinishSignInService = {
+        finishSignInWithPasskey: sinon.fake.returns({
+          success: false,
+          data: { message: "Session expired", code: 1000 },
+        }),
+      } as unknown as FinishSignInWithPasskeyInterface;
+
+      await assert.rejects(
+        async () =>
+          signInWithPasskeyPost(fakeFinishSignInService)(
+            req as Request,
+            res as Response
+          ),
+        Error,
+        "FinishPasskeyAssertionError: Session expired"
+      );
+      expect(res.redirect).to.not.have.been.called;
     });
   });
 });

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-controller.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-controller.test.ts
@@ -11,9 +11,7 @@ import {
   signInWithPasskeyGet,
   signInWithPasskeyPost,
 } from "../sign-in-with-passkey-controller.js";
-import type {
-  SignInWithPasskeyInterface,
-} from "../types.js";
+import type { SignInWithPasskeyInterface } from "../types.js";
 import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
 import { strict as assert } from "assert";
 
@@ -36,13 +34,13 @@ describe("sign in with passkey controller", () => {
   describe("signInWithPasskeyGet", () => {
     it("should render the sign in with passkey view with authentication options on success", async () => {
       const mockData = {
-        message: "success",
-        code: 200,
-        challenge: "dGVzdC1jaGFsbGVuZ2U",
-        rpId: "localhost",
-        allowCredentials: [{ type: "public-key", id: "credential-id-123" }],
-        timeout: 60000,
-        userVerification: "preferred",
+        publicKey: {
+          challenge: "dGVzdC1jaGFsbGVuZ2U",
+          rpId: "localhost",
+          allowCredentials: [{ type: "public-key", id: "credential-id-123" }],
+          timeout: 60000,
+          userVerification: "preferred",
+        },
       };
 
       const fakeStartSignInService = {
@@ -59,7 +57,7 @@ describe("sign in with passkey controller", () => {
 
       expect(res.render).to.have.been.calledWith(
         "sign-in-with-passkey/index.njk",
-        { authenticationOptions: JSON.stringify(mockData) }
+        { authenticationOptions: JSON.stringify(mockData.publicKey) }
       );
     });
 

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-controller.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-controller.test.ts
@@ -12,8 +12,7 @@ import {
   signInWithPasskeyPost,
 } from "../sign-in-with-passkey-controller.js";
 import type {
-  StartSignInWithPasskeyInterface,
-  FinishSignInWithPasskeyInterface,
+  SignInWithPasskeyInterface,
 } from "../types.js";
 import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
 import { strict as assert } from "assert";
@@ -47,11 +46,11 @@ describe("sign in with passkey controller", () => {
       };
 
       const fakeStartSignInService = {
-        startSignInWithPasskey: sinon.fake.returns({
+        startPasskeyAssertion: sinon.fake.returns({
           success: true,
           data: mockData,
         }),
-      } as unknown as StartSignInWithPasskeyInterface;
+      } as unknown as SignInWithPasskeyInterface;
 
       await signInWithPasskeyGet(fakeStartSignInService)(
         req as Request,
@@ -66,11 +65,11 @@ describe("sign in with passkey controller", () => {
 
     it("should pass the correct session IDs to the start service", async () => {
       const fakeStartSignInService = {
-        startSignInWithPasskey: sinon.fake.returns({
+        startPasskeyAssertion: sinon.fake.returns({
           success: true,
           data: { message: "success", code: 200 },
         }),
-      } as unknown as StartSignInWithPasskeyInterface;
+      } as unknown as SignInWithPasskeyInterface;
 
       await signInWithPasskeyGet(fakeStartSignInService)(
         req as Request,
@@ -78,7 +77,7 @@ describe("sign in with passkey controller", () => {
       );
 
       expect(
-        fakeStartSignInService.startSignInWithPasskey
+        fakeStartSignInService.startPasskeyAssertion
       ).to.have.been.calledWith(
         commonVariables.sessionId,
         commonVariables.clientSessionId,
@@ -88,12 +87,12 @@ describe("sign in with passkey controller", () => {
     });
 
     it("should throw an error when the start service returns unsuccessful", async () => {
-      const fakeStartSignInService: StartSignInWithPasskeyInterface = {
-        startSignInWithPasskey: sinon.fake.returns({
+      const fakeStartSignInService: SignInWithPasskeyInterface = {
+        startPasskeyAssertion: sinon.fake.returns({
           success: false,
           data: { message: "Session expired", code: 1000 },
         }),
-      } as unknown as StartSignInWithPasskeyInterface;
+      } as unknown as SignInWithPasskeyInterface;
       await assert.rejects(
         async () =>
           signInWithPasskeyGet(fakeStartSignInService)(
@@ -110,10 +109,10 @@ describe("sign in with passkey controller", () => {
   describe("signInWithPasskeyPost", () => {
     it("should redirect to the next path when the finish service returns success", async () => {
       const fakeFinishSignInService = {
-        finishSignInWithPasskey: sinon.fake.returns({
+        finishPasskeyAssertion: sinon.fake.returns({
           success: true,
         }),
-      } as unknown as FinishSignInWithPasskeyInterface;
+      } as unknown as SignInWithPasskeyInterface;
 
       await signInWithPasskeyPost(fakeFinishSignInService)(
         req as Request,
@@ -129,10 +128,10 @@ describe("sign in with passkey controller", () => {
       };
       req.body.authenticationResponse = authenticationResponse;
       const fakeFinishSignInService = {
-        finishSignInWithPasskey: sinon.fake.returns({
+        finishPasskeyAssertion: sinon.fake.returns({
           success: true,
         }),
-      } as unknown as FinishSignInWithPasskeyInterface;
+      } as unknown as SignInWithPasskeyInterface;
 
       await signInWithPasskeyPost(fakeFinishSignInService)(
         req as Request,
@@ -140,7 +139,7 @@ describe("sign in with passkey controller", () => {
       );
 
       expect(
-        fakeFinishSignInService.finishSignInWithPasskey
+        fakeFinishSignInService.finishPasskeyAssertion
       ).to.have.been.calledWith(
         commonVariables.sessionId,
         commonVariables.clientSessionId,
@@ -152,11 +151,11 @@ describe("sign in with passkey controller", () => {
 
     it("should throw an error when the finish service returns unsuccessful", async () => {
       const fakeFinishSignInService = {
-        finishSignInWithPasskey: sinon.fake.returns({
+        finishPasskeyAssertion: sinon.fake.returns({
           success: false,
           data: { message: "Session expired", code: 1000 },
         }),
-      } as unknown as FinishSignInWithPasskeyInterface;
+      } as unknown as SignInWithPasskeyInterface;
 
       await assert.rejects(
         async () =>

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
@@ -1,13 +1,17 @@
 import { describe } from "mocha";
-import { sinon } from "../../../../test/utils/test-utils.js";
+import { expect, sinon } from "../../../../test/utils/test-utils.js";
 import request from "supertest";
-import { PATH_NAMES } from "../../../app.constants.js";
+import { API_ENDPOINTS, PATH_NAMES } from "../../../app.constants.js";
 import type { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper.js";
 import esmock from "esmock";
+import nock from "nock";
+import * as cheerio from "cheerio";
+import { extractCsrfTokenAndCookies } from "../../../../test/helpers/csrf-helper.js";
 
 describe("Integration:: sign in with passkey", () => {
   let app: any;
+  let baseApi: string;
 
   before(async () => {
     const { createApp } = await esmock(
@@ -20,7 +24,9 @@ describe("Integration:: sign in with passkey", () => {
             res: Response,
             next: NextFunction
           ): void {
-            res.locals.sessionId = "tDy103saszhcxbQq0-mjdzU854";
+            res.locals.sessionId = "test-session-id";
+            res.locals.clientSessionId = "test-client-session-id";
+            res.locals.persistentSessionId = "test-persistent-session-id";
 
             req.session.user = {
               journey: getPermittedJourneyForPath(
@@ -34,7 +40,13 @@ describe("Integration:: sign in with passkey", () => {
       }
     );
 
+    baseApi = process.env.FRONTEND_API_BASE_URL as string;
+
     app = await createApp();
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
   });
 
   after(() => {
@@ -43,6 +55,62 @@ describe("Integration:: sign in with passkey", () => {
   });
 
   it("should return sign in with passkey page", async () => {
-    await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY).expect(200);
+    const startPasskeyAssertionResponse = {
+      challenge: "challenge",
+      rpId: "localhost",
+      allowCredentials: [{ type: "public-key", id: "credential-id-123" }],
+      timeout: 60000,
+      userVerification: "preferred",
+    };
+    nock(baseApi)
+      .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
+      .once()
+      .reply(200, startPasskeyAssertionResponse);
+
+    const res = await request(app)
+      .get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+      .expect(200);
+    const $ = cheerio.load(res.text);
+    const options = $("#signInWithPasskeyForm").attr(
+      "data-authentication-options"
+    );
+    expect(options).to.equal(JSON.stringify(startPasskeyAssertionResponse));
+  });
+
+  it("should redirect on successful passkey finish assertion", async () => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
+      .once()
+      .reply(200, { challenge: "test", rpId: "localhost" });
+
+    const { token, cookies } = extractCsrfTokenAndCookies(
+      await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+    );
+
+    nock(baseApi)
+      .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
+      .once()
+      .reply(200, { message: "success", code: 0 });
+
+    await request(app)
+      .post(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+      .type("form")
+      .set("Cookie", cookies)
+      .send({
+        _csrf: token,
+        authenticationResponse: JSON.stringify({
+          id: "credential-id",
+          rawId: "credential-id",
+          response: {
+            authenticatorData: "base64data",
+            clientDataJSON: "base64data",
+            signature: "base64sig",
+          },
+          type: "public-key",
+          authenticatorAttachment: "platform",
+        }),
+      })
+      .expect(302)
+      .expect("Location", PATH_NAMES.AUTH_CODE);
   });
 });

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
@@ -56,11 +56,13 @@ describe("Integration:: sign in with passkey", () => {
 
   it("should return sign in with passkey page", async () => {
     const startPasskeyAssertionResponse = {
-      challenge: "challenge",
-      rpId: "localhost",
-      allowCredentials: [{ type: "public-key", id: "credential-id-123" }],
-      timeout: 60000,
-      userVerification: "preferred",
+      publicKey: {
+        challenge: "challenge",
+        rpId: "localhost",
+        allowCredentials: [{ type: "public-key", id: "credential-id-123" }],
+        timeout: 60000,
+        userVerification: "preferred",
+      },
     };
     nock(baseApi)
       .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
@@ -74,7 +76,9 @@ describe("Integration:: sign in with passkey", () => {
     const options = $("#signInWithPasskeyForm").attr(
       "data-authentication-options"
     );
-    expect(options).to.equal(JSON.stringify(startPasskeyAssertionResponse));
+    expect(options).to.equal(
+      JSON.stringify(startPasskeyAssertionResponse.publicKey)
+    );
   });
 
   it("should redirect on successful passkey finish assertion", async () => {

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-service.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-service.test.ts
@@ -8,8 +8,14 @@ import {
   PATH_NAMES,
 } from "../../../app.constants.js";
 import type { SinonStub } from "sinon";
-import { startSignInWithPasskeyService } from "../sign-in-with-passkey-service.js";
-import type { StartSignInWithPasskeyInterface } from "../types.js";
+import {
+  finishSignInWithPasskeyService,
+  startSignInWithPasskeyService,
+} from "../sign-in-with-passkey-service.js";
+import type {
+  FinishSignInWithPasskeyInterface,
+  StartSignInWithPasskeyInterface,
+} from "../types.js";
 import {
   checkApiCallMadeWithExpectedBodyAndHeaders,
   expectedHeadersFromCommonVarsWithSecurityHeaders,
@@ -19,6 +25,7 @@ import {
 } from "../../../../test/helpers/service-test-helper.js";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper.js";
 import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
+import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 
 describe("sign in with passkey service", () => {
   const httpInstance = new Http();
@@ -102,6 +109,85 @@ describe("sign in with passkey service", () => {
         expectedPath: API_ENDPOINTS.START_PASSKEY_ASSERTION,
         expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
         expectedBody: {},
+      };
+      checkApiCallMadeWithExpectedBodyAndHeaders(
+        result,
+        postStub,
+        false,
+        expectedApiCallDetails
+      );
+    });
+  });
+
+  describe("finishSignInWithPasskeyService", () => {
+    const service: FinishSignInWithPasskeyInterface =
+      finishSignInWithPasskeyService(httpInstance);
+
+    it("should call the finish passkey assertion API endpoint and return successful response", async () => {
+      const req = createMockRequest(PATH_NAMES.SIGN_IN_WITH_PASSKEY, {
+        headers: requestHeadersWithIpAndAuditEncoded,
+      });
+      const startAuthenticationWebauthnResponse = {
+        id: "localhost",
+        response: "mock-response",
+        type: "public-key",
+      } as unknown as AuthenticationResponseJSON;
+      const axiosResponse = Promise.resolve({
+        data: {},
+        status: HTTP_STATUS_CODES.OK,
+        success: true,
+      });
+      postStub.resolves(axiosResponse);
+
+      const result = await service.finishSignInWithPasskey(
+        commonVariables.sessionId,
+        commonVariables.clientSessionId,
+        commonVariables.diPersistentSessionId,
+        req,
+        startAuthenticationWebauthnResponse
+      );
+
+      const expectedApiCallDetails = {
+        expectedPath: API_ENDPOINTS.FINISH_PASSKEY_ASSERTION,
+        expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
+        expectedBody: { pkc: startAuthenticationWebauthnResponse },
+      };
+      checkApiCallMadeWithExpectedBodyAndHeaders(
+        result,
+        postStub,
+        true,
+        expectedApiCallDetails
+      );
+    });
+
+    it("should return success false when the API returns non-200", async () => {
+      const req = createMockRequest(PATH_NAMES.SIGN_IN_WITH_PASSKEY, {
+        headers: requestHeadersWithIpAndAuditEncoded,
+      });
+      const startAuthenticationWebauthnResponse = {
+        id: "localhost",
+        response: "mock-response",
+        type: "public-key",
+      } as unknown as AuthenticationResponseJSON;
+      const axiosResponse = Promise.resolve({
+        data: {},
+        status: HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR,
+        success: false,
+      });
+      postStub.resolves(axiosResponse);
+
+      const result = await service.finishSignInWithPasskey(
+        commonVariables.sessionId,
+        commonVariables.clientSessionId,
+        commonVariables.diPersistentSessionId,
+        req,
+        startAuthenticationWebauthnResponse
+      );
+
+      const expectedApiCallDetails = {
+        expectedPath: API_ENDPOINTS.FINISH_PASSKEY_ASSERTION,
+        expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
+        expectedBody: { pkc: startAuthenticationWebauthnResponse },
       };
       checkApiCallMadeWithExpectedBodyAndHeaders(
         result,

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-service.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-service.test.ts
@@ -1,0 +1,114 @@
+import { describe } from "mocha";
+import { expect } from "chai";
+import { Http } from "../../../utils/http.js";
+import { sinon } from "../../../../test/utils/test-utils.js";
+import {
+  API_ENDPOINTS,
+  HTTP_STATUS_CODES,
+  PATH_NAMES,
+} from "../../../app.constants.js";
+import type { SinonStub } from "sinon";
+import { startSignInWithPasskeyService } from "../sign-in-with-passkey-service.js";
+import type { StartSignInWithPasskeyInterface } from "../types.js";
+import {
+  checkApiCallMadeWithExpectedBodyAndHeaders,
+  expectedHeadersFromCommonVarsWithSecurityHeaders,
+  requestHeadersWithIpAndAuditEncoded,
+  resetApiKeyAndBaseUrlEnvVars,
+  setupApiKeyAndBaseUrlEnvVars,
+} from "../../../../test/helpers/service-test-helper.js";
+import { createMockRequest } from "../../../../test/helpers/mock-request-helper.js";
+import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
+
+describe("sign in with passkey service", () => {
+  const httpInstance = new Http();
+  let postStub: SinonStub;
+
+  beforeEach(() => {
+    setupApiKeyAndBaseUrlEnvVars();
+    postStub = sinon.stub(httpInstance.client, "post");
+  });
+
+  afterEach(() => {
+    postStub.reset();
+    resetApiKeyAndBaseUrlEnvVars();
+  });
+
+  describe("startSignInWithPasskeyService", () => {
+    const service: StartSignInWithPasskeyInterface =
+      startSignInWithPasskeyService(httpInstance);
+
+    it("should call the start passkey assertion API endpoint and return successful response", async () => {
+      const req = createMockRequest(PATH_NAMES.SIGN_IN_WITH_PASSKEY, {
+        headers: requestHeadersWithIpAndAuditEncoded,
+      });
+      const authenticationOptions = {
+        challenge: "dGVzdC1jaGFsbGVuZ2U",
+        rpId: "localhost",
+        allowCredentials: [{ type: "public-key", id: "credential-id-123" }],
+        timeout: 60000,
+        userVerification: "preferred",
+      };
+      const axiosResponse = Promise.resolve({
+        data: authenticationOptions,
+        status: HTTP_STATUS_CODES.OK,
+        success: true,
+      });
+      postStub.resolves(axiosResponse);
+
+      const result = await service.startSignInWithPasskey(
+        commonVariables.sessionId,
+        commonVariables.clientSessionId,
+        commonVariables.diPersistentSessionId,
+        req
+      );
+
+      const expectedApiCallDetails = {
+        expectedPath: API_ENDPOINTS.START_PASSKEY_ASSERTION,
+        expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
+        expectedBody: {},
+      };
+      checkApiCallMadeWithExpectedBodyAndHeaders(
+        result,
+        postStub,
+        true,
+        expectedApiCallDetails
+      );
+      expect(result.data).to.eq(authenticationOptions);
+    });
+
+    it("should return success false when the API returns non-200", async () => {
+      const req = createMockRequest(PATH_NAMES.SIGN_IN_WITH_PASSKEY, {
+        headers: requestHeadersWithIpAndAuditEncoded,
+      });
+      const axiosResponse = Promise.resolve({
+        data: {
+          message: "Failed to start assertion",
+          code: 1000,
+        },
+        status: HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR,
+        success: false,
+      });
+      postStub.resolves(axiosResponse);
+
+      const result = await service.startSignInWithPasskey(
+        commonVariables.sessionId,
+        commonVariables.clientSessionId,
+        commonVariables.diPersistentSessionId,
+        req
+      );
+
+      const expectedApiCallDetails = {
+        expectedPath: API_ENDPOINTS.START_PASSKEY_ASSERTION,
+        expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
+        expectedBody: {},
+      };
+      checkApiCallMadeWithExpectedBodyAndHeaders(
+        result,
+        postStub,
+        false,
+        expectedApiCallDetails
+      );
+    });
+  });
+});

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-service.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-service.test.ts
@@ -8,14 +8,8 @@ import {
   PATH_NAMES,
 } from "../../../app.constants.js";
 import type { SinonStub } from "sinon";
-import {
-  finishSignInWithPasskeyService,
-  startSignInWithPasskeyService,
-} from "../sign-in-with-passkey-service.js";
-import type {
-  FinishSignInWithPasskeyInterface,
-  StartSignInWithPasskeyInterface,
-} from "../types.js";
+import { signInWithPasskeyService } from "../sign-in-with-passkey-service.js";
+import type { SignInWithPasskeyInterface } from "../types.js";
 import {
   checkApiCallMadeWithExpectedBodyAndHeaders,
   expectedHeadersFromCommonVarsWithSecurityHeaders,
@@ -41,9 +35,9 @@ describe("sign in with passkey service", () => {
     resetApiKeyAndBaseUrlEnvVars();
   });
 
-  describe("startSignInWithPasskeyService", () => {
-    const service: StartSignInWithPasskeyInterface =
-      startSignInWithPasskeyService(httpInstance);
+  describe("startPasskeyAssertion", () => {
+    const service: SignInWithPasskeyInterface =
+      signInWithPasskeyService(httpInstance);
 
     it("should call the start passkey assertion API endpoint and return successful response", async () => {
       const req = createMockRequest(PATH_NAMES.SIGN_IN_WITH_PASSKEY, {
@@ -63,7 +57,7 @@ describe("sign in with passkey service", () => {
       });
       postStub.resolves(axiosResponse);
 
-      const result = await service.startSignInWithPasskey(
+      const result = await service.startPasskeyAssertion(
         commonVariables.sessionId,
         commonVariables.clientSessionId,
         commonVariables.diPersistentSessionId,
@@ -98,7 +92,7 @@ describe("sign in with passkey service", () => {
       });
       postStub.resolves(axiosResponse);
 
-      const result = await service.startSignInWithPasskey(
+      const result = await service.startPasskeyAssertion(
         commonVariables.sessionId,
         commonVariables.clientSessionId,
         commonVariables.diPersistentSessionId,
@@ -119,9 +113,9 @@ describe("sign in with passkey service", () => {
     });
   });
 
-  describe("finishSignInWithPasskeyService", () => {
-    const service: FinishSignInWithPasskeyInterface =
-      finishSignInWithPasskeyService(httpInstance);
+  describe("finishPasskeyAssertion", () => {
+    const service: SignInWithPasskeyInterface =
+      signInWithPasskeyService(httpInstance);
 
     it("should call the finish passkey assertion API endpoint and return successful response", async () => {
       const req = createMockRequest(PATH_NAMES.SIGN_IN_WITH_PASSKEY, {
@@ -139,7 +133,7 @@ describe("sign in with passkey service", () => {
       });
       postStub.resolves(axiosResponse);
 
-      const result = await service.finishSignInWithPasskey(
+      const result = await service.finishPasskeyAssertion(
         commonVariables.sessionId,
         commonVariables.clientSessionId,
         commonVariables.diPersistentSessionId,
@@ -176,7 +170,7 @@ describe("sign in with passkey service", () => {
       });
       postStub.resolves(axiosResponse);
 
-      const result = await service.finishSignInWithPasskey(
+      const result = await service.finishPasskeyAssertion(
         commonVariables.sessionId,
         commonVariables.clientSessionId,
         commonVariables.diPersistentSessionId,

--- a/src/components/sign-in-with-passkey/types.ts
+++ b/src/components/sign-in-with-passkey/types.ts
@@ -5,17 +5,14 @@ import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 export interface StartSignInWithPasskeyResponse
   extends DefaultApiResponse, PublicKeyCredentialRequestOptionsJSON {}
 
-export interface StartSignInWithPasskeyInterface {
-  startSignInWithPasskey: (
+export interface SignInWithPasskeyInterface {
+  startPasskeyAssertion: (
     sessionId: string,
     clientSessionId: string,
     persistentSessionId: string,
     req: Request
-  ) => Promise<ApiResponseResult<StartSignInWithPasskeyResponse>>;
-}
-
-export interface FinishSignInWithPasskeyInterface {
-  finishSignInWithPasskey: (
+  ) => Promise<ApiResponseResult<StartPasskeyAssertionResponse>>,
+  finishPasskeyAssertion: (
     sessionId: string,
     clientSessionId: string,
     persistentSessionId: string,

--- a/src/components/sign-in-with-passkey/types.ts
+++ b/src/components/sign-in-with-passkey/types.ts
@@ -1,0 +1,14 @@
+import type { Request } from "express";
+import type { ApiResponseResult, DefaultApiResponse } from "../../types.js";
+
+export interface StartSignInWithPasskeyResponse
+  extends DefaultApiResponse, PublicKeyCredentialRequestOptionsJSON {}
+
+export interface StartSignInWithPasskeyInterface {
+  startSignInWithPasskey: (
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string,
+    req: Request
+  ) => Promise<ApiResponseResult<StartSignInWithPasskeyResponse>>;
+}

--- a/src/components/sign-in-with-passkey/types.ts
+++ b/src/components/sign-in-with-passkey/types.ts
@@ -1,5 +1,6 @@
 import type { Request } from "express";
 import type { ApiResponseResult, DefaultApiResponse } from "../../types.js";
+import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 
 export interface StartSignInWithPasskeyResponse
   extends DefaultApiResponse, PublicKeyCredentialRequestOptionsJSON {}
@@ -11,4 +12,14 @@ export interface StartSignInWithPasskeyInterface {
     persistentSessionId: string,
     req: Request
   ) => Promise<ApiResponseResult<StartSignInWithPasskeyResponse>>;
+}
+
+export interface FinishSignInWithPasskeyInterface {
+  finishSignInWithPasskey: (
+    sessionId: string,
+    clientSessionId: string,
+    persistentSessionId: string,
+    req: Request,
+    authenticationResponse: AuthenticationResponseJSON
+  ) => Promise<ApiResponseResult<DefaultApiResponse>>;
 }

--- a/src/components/sign-in-with-passkey/types.ts
+++ b/src/components/sign-in-with-passkey/types.ts
@@ -2,8 +2,9 @@ import type { Request } from "express";
 import type { ApiResponseResult, DefaultApiResponse } from "../../types.js";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 
-export interface StartSignInWithPasskeyResponse
-  extends DefaultApiResponse, PublicKeyCredentialRequestOptionsJSON {}
+export interface StartPasskeyAssertionResponse extends DefaultApiResponse {
+  publicKey: PublicKeyCredentialRequestOptionsJSON;
+}
 
 export interface SignInWithPasskeyInterface {
   startPasskeyAssertion: (
@@ -11,7 +12,7 @@ export interface SignInWithPasskeyInterface {
     clientSessionId: string,
     persistentSessionId: string,
     req: Request
-  ) => Promise<ApiResponseResult<StartPasskeyAssertionResponse>>,
+  ) => Promise<ApiResponseResult<StartPasskeyAssertionResponse>>;
   finishPasskeyAssertion: (
     sessionId: string,
     clientSessionId: string,


### PR DESCRIPTION
## What

When a user clicks continue on the sign in with passkey page we want to sign them in with their passkey
How this works 
- On sign in with passkey get controller 
  - Call the StartPasskeyAssertionHandler to get the authenticationOptions (JSON blob returned from the java-webauthn-server package)
  - Render the page and pass the authenticationOptions in as a param
- When the user clicks continue on the page 
  - Call the startAuthentication method provided from browserWebauthn passing in the authenticationOptions from the StartAssertionHandler
  - Following a successful response, set a hidden inputs value to be the response
  - Call the form submit
- On sign in with passkey post controller
  - Send the response from the browserWebauthn to the FinishPasskeyAssertionHandler
  - This will check the browser handshake was done correctly and if so we receive a 200 on the frontend
  - Following a 200, move the user to `SIGN_IN_END`

## How to review

1. Code review
2. Deploy to a dev env, along with [this PR](https://github.com/govuk-one-login/authentication-api/pull/8386), and check you can sign in with a passkey (note, you will need to manually add a legitimate passkey to dynamo - see the `generate_webauthn_script` to see how to do that)

## Checklist

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/8386
