### PR TITLE
BAU: Bump serialize-javascript override to 7.0.5 to fix CVE-2026-34043

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8101,9 +8101,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
   "overrides": {
     "js-yaml": "4.1.1",
     "validator": "13.15.23",
-    "serialize-javascript": ">=7.0.3",
+    "serialize-javascript": ">=7.0.5",
     "fast-xml-parser": ">=5.5.6"
   },
   "resolutions": {


### PR DESCRIPTION
## What

- CVE-2026-34043: cross-site scripting via crafted object serialization in serialize-javascript. Bumping existing override from >=7.0.3 to >=7.0.5 where the fix was released.

## How to review

1. Code Review