### PR TITLE
BAU: Turn off passkey usage in build

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -627,7 +627,7 @@ Mappings:
       PrivacyNoticeRedirectEnabled: "Yes"
       OrchApiBaseUrl: "https://oidc.build.account.gov.uk"
       UseRebrand: "Yes"
-      SupportPasskeyUsage: "Yes"
+      SupportPasskeyUsage: "No"
       SupportPasskeyRegistration: "No"
       SupportNewInternationalSms: "No"
       EnableDwpKbvContactFormChanges: "Yes"


### PR DESCRIPTION
The build environment is supposed to resemble prod / integration as best as possible, so we should not turn this flag on yet as we're not ready to enable passkeys in prod / integration

