### PR TITLE
BAU: Add automatic Docker Desktop startup to local `startup.sh`

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -62,6 +62,30 @@ if [ "${ACTION_CLEAN:-0}" == "1" ]; then
   rm -rf logs
 fi
 
+# Check Docker daemon is running, attempt to start if not
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker daemon is not running. Attempting to start Docker Desktop..."
+  open -a Docker
+
+  DOCKER_STARTUP_TIMEOUT=60
+  DOCKER_POLL_INTERVAL=3
+  echo "Waiting for Docker to start..."
+  elapsed=0
+
+  while ! docker info >/dev/null 2>&1; do
+    # Poll every ${DOCKER_POLL_INTERVAL}s to avoid hammering the CPU while waiting for daemon
+    sleep $DOCKER_POLL_INTERVAL
+    elapsed=$((elapsed + DOCKER_POLL_INTERVAL))
+
+    if [ $elapsed -ge $DOCKER_STARTUP_TIMEOUT ]; then
+      echo "Error: Docker failed to start within ${DOCKER_STARTUP_TIMEOUT}s" >&2
+      exit 1
+    fi
+  done
+
+  echo "Docker is now running."
+fi
+
 "${DIR}"/shutdown.sh
 
 if [ "${ACTION_FULL_LOCAL:-0}" == "1" ]; then


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Dev quality of life improvement to auto start Docker if not already running. Affects local running only.

Prior to this change, if Docker wasn't running the following error would've occurred:
```
Cannot connect to the Docker daemon at unix:///Users/USERNAME/.docker/run/docker.sock. Is the docker daemon running?
```

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-frontend/actions/workflows/build-deploy-frontend-dev.yml)
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Testing

The following are all working as expected:
1. Running `startup.sh -L` with Docker not running - Docker starts automatically, script continues
1. Running `startup.sh -L` with Docker running - script continues as normal

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

- [ ] Performance analyst has been notified of the change. **- N/A**

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [ ] A UCD review has been performed. **- N/A**

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made. **- N/A**

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [ ] Documentation has been updated to reflect these changes. **- N/A**

- [x] Local running `./startup -L` still works. **- Tested locally (see above)**
