### PR TITLE
BAU: Switch all passkeys routes to use non-persisting user journey middleware

### DIFF
--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-routes.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-routes.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import { PATH_NAMES } from "../../app.constants.js";
 import { validateSessionMiddleware } from "../../middleware/session-middleware.js";
-import { allowAndPersistUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware.js";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware.js";
 import { cannotSignInPasskeyGet } from "./cannot-sign-in-passkey-controller.js";
 import { validateCannotSignInPasskeyRequest } from "./cannot-sign-in-passkey-validation.js";
 
@@ -10,14 +10,14 @@ const router = express.Router();
 router.get(
   PATH_NAMES.CANNOT_SIGN_IN_PASSKEY,
   validateSessionMiddleware,
-  allowAndPersistUserJourneyMiddleware,
+  allowUserJourneyMiddleware,
   cannotSignInPasskeyGet
 );
 
 router.post(
   PATH_NAMES.CANNOT_SIGN_IN_PASSKEY,
   validateSessionMiddleware,
-  allowAndPersistUserJourneyMiddleware,
+  allowUserJourneyMiddleware,
   validateCannotSignInPasskeyRequest()
 );
 

--- a/src/components/create-passkey/create-passkey-routes.ts
+++ b/src/components/create-passkey/create-passkey-routes.ts
@@ -5,20 +5,20 @@ import {
 } from "./create-passkey-controller.js";
 import { PATH_NAMES } from "../../app.constants.js";
 import { validateSessionMiddleware } from "../../middleware/session-middleware.js";
-import { allowAndPersistUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware.js";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware.js";
 const router = express.Router();
 
 router.get(
   PATH_NAMES.CREATE_PASSKEY,
   validateSessionMiddleware,
-  allowAndPersistUserJourneyMiddleware,
+  allowUserJourneyMiddleware,
   createPasskeyGet
 );
 
 router.post(
   PATH_NAMES.CREATE_PASSKEY,
   validateSessionMiddleware,
-  allowAndPersistUserJourneyMiddleware,
+  allowUserJourneyMiddleware,
   createPasskeyPost()
 );
 

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-routes.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-routes.ts
@@ -5,21 +5,21 @@ import {
   signInWithPasskeyPost,
 } from "./sign-in-with-passkey-controller.js";
 import { validateSessionMiddleware } from "../../middleware/session-middleware.js";
-import { allowAndPersistUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware.js";
+import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware.js";
 
 const router = express.Router();
 
 router.get(
   PATH_NAMES.SIGN_IN_WITH_PASSKEY,
   validateSessionMiddleware,
-  allowAndPersistUserJourneyMiddleware,
+  allowUserJourneyMiddleware,
   signInWithPasskeyGet()
 );
 
 router.post(
   PATH_NAMES.SIGN_IN_WITH_PASSKEY,
   validateSessionMiddleware,
-  allowAndPersistUserJourneyMiddleware,
+  allowUserJourneyMiddleware,
   signInWithPasskeyPost()
 );
 


### PR DESCRIPTION
The allow and persist user journey middleware was introduced to fix certain issues users had when using back buttons. It's not required here and we should use it sparingly before a full back solution (via history) is implemented.

