### PR TITLE
AUT 5540: Dockerfile hardening

### DIFF
--- a/.github/workflows/playwright-acceptance-tests.yml
+++ b/.github/workflows/playwright-acceptance-tests.yml
@@ -42,6 +42,11 @@ jobs:
         working-directory: playwright-acceptance-tests
         run: docker compose logs > docker-compose-logs.txt 2>&1 || true
 
+      - name: Copy reports from container
+        if: always()
+        working-directory: playwright-acceptance-tests
+        run: docker compose cp test-runner:/app/reports ./reports || true
+
       - name: Tear down
         if: always()
         working-directory: playwright-acceptance-tests

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -66,6 +66,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run snapshot tests
         run: docker compose -f docker-compose.snapshots.yml up --exit-code-from playwright
+      - name: Copy test results from container
+        if: ${{ failure() }}
+        run: docker compose -f docker-compose.snapshots.yml cp playwright:/app/test-results ./test-results || true
       - name: Upload test artifacts
         if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docker-compose.snapshots.yml
+++ b/docker-compose.snapshots.yml
@@ -27,6 +27,5 @@ services:
     volumes:
       - ./src:/app/src
       - ./test:/app/test
-      - ./test-results:/app/test-results
     command: npx playwright test ${COMMAND:-}
     network_mode: "host"

--- a/playwright-acceptance-tests/.dockerignore
+++ b/playwright-acceptance-tests/.dockerignore
@@ -5,3 +5,5 @@ playwright-report
 .git
 .gitignore
 .DS_Store
+.env
+.env.*

--- a/playwright-acceptance-tests/Dockerfile
+++ b/playwright-acceptance-tests/Dockerfile
@@ -1,10 +1,13 @@
-FROM mcr.microsoft.com/playwright:v1.59.1-noble
+FROM mcr.microsoft.com/playwright:v1.59.1-noble@sha256:eac9b0a5312cdab40ee8c2429df5bf19bffdccf8f3bf3c42268e173f97541645
 
 WORKDIR /app
+RUN chown -R pwuser:pwuser /app
+
+USER pwuser
 
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --ignore-scripts
 
-COPY . .
+COPY --chown=pwuser:pwuser . .
 
 CMD ["npm", "test"]

--- a/playwright-acceptance-tests/docker-compose.yml
+++ b/playwright-acceptance-tests/docker-compose.yml
@@ -83,8 +83,6 @@ services:
       A11Y_CHECK: "false"
       SECURITY_CHECK: "false"
       CUCUMBER_FILTER_TAGS: "@Frontend"
-    volumes:
-      - ./reports:/app/reports
     networks:
       - test-net
     depends_on:

--- a/service-down-page-config/Dockerfile
+++ b/service-down-page-config/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginxinc/nginx-unprivileged:1.27.4-alpine@sha256:2211200bb46431bb70f044f83cd989901205ce3232e1c431822876f1fd166689
 
 COPY ./service-down/ /usr/share/nginx/html/
 COPY ./nginx-fargate.conf /etc/nginx/conf.d/default.conf

--- a/snapshots-playwright.Dockerfile
+++ b/snapshots-playwright.Dockerfile
@@ -8,9 +8,12 @@ RUN npm config get ignore-scripts | grep -q "true" || exit 1
 RUN npm ci --ignore-scripts
 
 
-FROM mcr.microsoft.com/playwright:v1.59.1-noble AS playwright
+FROM mcr.microsoft.com/playwright:v1.59.1-noble@sha256:eac9b0a5312cdab40ee8c2429df5bf19bffdccf8f3bf3c42268e173f97541645 AS playwright
 
 WORKDIR /app
+RUN chown -R pwuser:pwuser /app
+
+USER pwuser
 
 COPY /playwright.config.ts ./
 COPY --from=builder /app/node_modules ./node_modules


### PR DESCRIPTION
## What

Dockerfile hardening for snapshot tests, playwright acceptance tests and the service down page

See commits for details

## How to review

1. Code Review
1. Check that the playwright acceptance tests continue to run in GHA
1. Check that the snapshot tests continue to run in GHA
1. Check that the Service Down Page continues to run locally and in a dev environment

## Checklist

- [x] Local running `./startup -L` still works.

## Related PRs

Testing for Service Down Page enabled by #3453