### PR TITLE
AUT-5001: Retry sign in with passkey (happy path)

### DIFF
--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
@@ -1,5 +1,29 @@
 import type { Request, Response } from "express";
+import { ExpressRouteFunc } from "../../types.js";
+import { PasskeyServiceInterface } from "../common/passkey/types.js";
+import { passkeyService } from "../common/passkey/passkey-service.js";
 
-export function cannotSignInPasskeyGet(req: Request, res: Response): void {
-  return res.render("cannot-sign-in-passkey/index.njk");
+export function cannotSignInPasskeyGet(
+  service: PasskeyServiceInterface = passkeyService(),
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const startPasskeyAssertionResult = await service.startPasskeyAssertion(
+      res.locals.sessionId,
+      res.locals.clientSessionId,
+      res.locals.persistentSessionId,
+      req
+    )
+
+    if (!startPasskeyAssertionResult.success) {
+      throw new Error(
+        `StartPasskeyAssertionError: ${startPasskeyAssertionResult.data.message}`
+      )
+    }
+
+    const authenticationOptions = startPasskeyAssertionResult.data;
+
+    res.render("cannot-sign-in-passkey/index.njk", {
+      authenticationOptions: JSON.stringify(authenticationOptions.publicKey),
+    });
+  }
 }

--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
@@ -1,10 +1,13 @@
 import type { Request, Response } from "express";
-import { ExpressRouteFunc } from "../../types.js";
-import { PasskeyServiceInterface } from "../common/passkey/types.js";
+import type { ExpressRouteFunc } from "../../types.js";
+import type { PasskeyServiceInterface } from "../common/passkey/types.js";
 import { passkeyService } from "../common/passkey/passkey-service.js";
+import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
+import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 
 export function cannotSignInPasskeyGet(
-  service: PasskeyServiceInterface = passkeyService(),
+  service: PasskeyServiceInterface = passkeyService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const startPasskeyAssertionResult = await service.startPasskeyAssertion(
@@ -12,12 +15,12 @@ export function cannotSignInPasskeyGet(
       res.locals.clientSessionId,
       res.locals.persistentSessionId,
       req
-    )
+    );
 
     if (!startPasskeyAssertionResult.success) {
       throw new Error(
         `StartPasskeyAssertionError: ${startPasskeyAssertionResult.data.message}`
-      )
+      );
     }
 
     const authenticationOptions = startPasskeyAssertionResult.data;
@@ -25,5 +28,37 @@ export function cannotSignInPasskeyGet(
     res.render("cannot-sign-in-passkey/index.njk", {
       authenticationOptions: JSON.stringify(authenticationOptions.publicKey),
     });
-  }
+  };
+}
+
+export function cannotSignInPasskeyPost(
+  service: PasskeyServiceInterface = passkeyService()
+): ExpressRouteFunc {
+  return async function (req: Request, res: Response) {
+    const authenticationResponse: AuthenticationResponseJSON =
+      req.body.authenticationResponse;
+
+    const finishPasskeyAssertionResult = await service.finishPasskeyAssertion(
+      res.locals.sessionId,
+      res.locals.clientSessionId,
+      res.locals.persistentSessionId,
+      req,
+      authenticationResponse
+    );
+
+    if (!finishPasskeyAssertionResult.success) {
+      // TODO - AUT-5000 - Handle error case
+      throw new Error(
+        `FinishPasskeyAssertionError: ${finishPasskeyAssertionResult.data.message}`
+      );
+    }
+
+    return res.redirect(
+      await getNextPathAndUpdateJourney(
+        req,
+        res,
+        USER_JOURNEY_EVENTS.PASSKEY_VERIFICATION_SUCCESSFUL
+      )
+    );
+  };
 }

--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-routes.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-routes.ts
@@ -11,7 +11,7 @@ router.get(
   PATH_NAMES.CANNOT_SIGN_IN_PASSKEY,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  cannotSignInPasskeyGet
+  cannotSignInPasskeyGet()
 );
 
 router.post(

--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-routes.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-routes.ts
@@ -2,7 +2,10 @@ import express from "express";
 import { PATH_NAMES } from "../../app.constants.js";
 import { validateSessionMiddleware } from "../../middleware/session-middleware.js";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware.js";
-import { cannotSignInPasskeyGet } from "./cannot-sign-in-passkey-controller.js";
+import {
+  cannotSignInPasskeyGet,
+  cannotSignInPasskeyPost,
+} from "./cannot-sign-in-passkey-controller.js";
 import { validateCannotSignInPasskeyRequest } from "./cannot-sign-in-passkey-validation.js";
 
 const router = express.Router();
@@ -18,7 +21,8 @@ router.post(
   PATH_NAMES.CANNOT_SIGN_IN_PASSKEY,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
-  validateCannotSignInPasskeyRequest()
+  validateCannotSignInPasskeyRequest(),
+  cannotSignInPasskeyPost()
 );
 
 export { router as cannotSignInPasskeyRouter };

--- a/src/components/cannot-sign-in-passkey/index.njk
+++ b/src/components/cannot-sign-in-passkey/index.njk
@@ -52,3 +52,44 @@
     }) }}
   </form>
 {% endblock %}
+
+{% block scripts %}
+  <script {% if scriptNonce %} nonce="{{ scriptNonce }}"{%  endif %}>
+    const cannotSignInPasskeyForm = document.getElementById("cannotSignInPasskeyForm");
+    let isSubmitting = false
+
+    async function triggerWebAuthnFlow() {
+      try {
+        if (SimpleWebAuthnBrowser.browserSupportsWebAuthn()) {
+          const authenticationResponse = await SimpleWebAuthnBrowser.startAuthentication({ optionsJSON: JSON.parse(cannotSignInPasskeyForm.dataset.authenticationOptions) });
+          cannotSignInPasskeyForm.querySelector("input[name=\"authenticationResponse\"]").value = JSON.stringify(authenticationResponse);
+
+          const authenticationErrorField = cannotSignInPasskeyForm.querySelector("input[name=\"authenticationError\"]");
+          authenticationErrorField.parentNode.removeChild(authenticationErrorField);
+        }
+      } catch (error) {
+        console.error(error.message);
+        cannotSignInPasskeyForm.querySelector("input[name=\"authenticationError\"]").value = `${error.name} - ${error.message}`;
+      }
+    }
+
+    async function handleSubmit(event) {
+      event.preventDefault();
+
+      if (isSubmitting) return
+      isSubmitting = true
+
+      const selectedOption = document.querySelector('input[name="cannot-sign-in-passkey-action"]:checked')?.value;
+
+      if (selectedOption === "retry-passkey") {
+        await triggerWebAuthnFlow();
+      }
+
+      cannotSignInPasskeyForm.submit();
+    }
+
+    cannotSignInPasskeyForm.addEventListener('submit', handleSubmit);
+
+  </script>
+  <script defer type="text/javascript" src="/public/scripts/prevent-double-form-submit.js"></script>
+{% endblock %}

--- a/src/components/cannot-sign-in-passkey/index.njk
+++ b/src/components/cannot-sign-in-passkey/index.njk
@@ -12,8 +12,10 @@
     {{ 'pages.cannotSignInPasskey.title' | translate }}
   </h1>
 
-  <form method="post" id="cannotSignInPasskeyForm">
+  <form method="post" id="cannotSignInPasskeyForm" data-authentication-options="{{ authenticationOptions }}">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+    <input type="hidden" name="authenticationResponse" value='"' />
+    <input type="hidden" name="authenticationError" value="JavaScriptNotEnabled" />
 
     {{ govukRadios({
       name: "cannot-sign-in-passkey-action",

--- a/src/components/cannot-sign-in-passkey/index.njk
+++ b/src/components/cannot-sign-in-passkey/index.njk
@@ -14,7 +14,7 @@
 
   <form method="post" id="cannotSignInPasskeyForm" data-authentication-options="{{ authenticationOptions }}">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-    <input type="hidden" name="authenticationResponse" value='"' />
+    <input type="hidden" name="authenticationResponse" value="" />
     <input type="hidden" name="authenticationError" value="JavaScriptNotEnabled" />
 
     {{ govukRadios({

--- a/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-controller.test.ts
+++ b/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-controller.test.ts
@@ -1,12 +1,15 @@
 import { describe } from "mocha";
 import { expect } from "chai";
-import {strict as assert} from "assert";
+import { strict as assert } from "assert";
 import type { Request, Response } from "express";
 import type { RequestOutput, ResponseOutput } from "mock-req-res";
 import { mockResponse } from "mock-req-res";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper.js";
 import { PATH_NAMES } from "../../../app.constants.js";
-import { cannotSignInPasskeyGet } from "../cannot-sign-in-passkey-controller.js";
+import {
+  cannotSignInPasskeyGet,
+  cannotSignInPasskeyPost,
+} from "../cannot-sign-in-passkey-controller.js";
 import { sinon } from "../../../../test/utils/test-utils.js";
 import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
 import type { PasskeyServiceInterface } from "../../common/passkey/types.js";
@@ -70,9 +73,7 @@ describe("cannot sign in passkey controller", () => {
         res as Response
       );
 
-      expect(
-        fakePasskeyService.startPasskeyAssertion
-      ).to.have.been.calledWith(
+      expect(fakePasskeyService.startPasskeyAssertion).to.have.been.calledWith(
         commonVariables.sessionId,
         commonVariables.clientSessionId,
         commonVariables.diPersistentSessionId,
@@ -97,6 +98,72 @@ describe("cannot sign in passkey controller", () => {
         "StartPasskeyAssertionError: Session expired"
       );
       expect(res.render).to.not.have.been.called;
+    });
+  });
+
+  describe("cannotSignInPasskeyPost", () => {
+    describe("retry passkey", () => {
+      it("should redirect to the next path when finishPasskeyAssertion returns success", async () => {
+        const fakePasskeyService = {
+          finishPasskeyAssertion: sinon.fake.returns({
+            success: true,
+          }),
+        } as unknown as PasskeyServiceInterface;
+
+        await cannotSignInPasskeyPost(fakePasskeyService)(
+          req as Request,
+          res as Response
+        );
+
+        expect(res.redirect).to.have.been.calledWith(PATH_NAMES.AUTH_CODE);
+      });
+
+      it("should pass the authenticationResponse from the request body to finishPasskeyAssertion", async () => {
+        const authenticationResponse = {
+          signedChallenge: "challenge",
+        };
+        req.body.authenticationResponse = authenticationResponse;
+        const fakePasskeyService = {
+          finishPasskeyAssertion: sinon.fake.returns({
+            success: true,
+          }),
+        } as unknown as PasskeyServiceInterface;
+
+        await cannotSignInPasskeyPost(fakePasskeyService)(
+          req as Request,
+          res as Response
+        );
+
+        expect(
+          fakePasskeyService.finishPasskeyAssertion
+        ).to.have.been.calledWith(
+          commonVariables.sessionId,
+          commonVariables.clientSessionId,
+          commonVariables.diPersistentSessionId,
+          req,
+          authenticationResponse
+        );
+      });
+
+      it("should throw an error when finishPasskeyAssertion returns unsuccessful", async () => {
+        const fakePasskeyService = {
+          finishPasskeyAssertion: sinon.fake.returns({
+            success: false,
+            data: { message: "Session expired", code: 1000 },
+          }),
+        } as unknown as PasskeyServiceInterface;
+
+        await assert.rejects(
+          async () =>
+            cannotSignInPasskeyPost(fakePasskeyService)(
+              req as Request,
+              res as Response
+            ),
+          Error,
+          "FinishPasskeyAssertionError: Session expired"
+        );
+        expect(res.redirect).to.not.have.been.called;
+      });
     });
   });
 });

--- a/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-controller.test.ts
+++ b/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-controller.test.ts
@@ -1,5 +1,6 @@
 import { describe } from "mocha";
 import { expect } from "chai";
+import {strict as assert} from "assert";
 import type { Request, Response } from "express";
 import type { RequestOutput, ResponseOutput } from "mock-req-res";
 import { mockResponse } from "mock-req-res";
@@ -7,6 +8,8 @@ import { createMockRequest } from "../../../../test/helpers/mock-request-helper.
 import { PATH_NAMES } from "../../../app.constants.js";
 import { cannotSignInPasskeyGet } from "../cannot-sign-in-passkey-controller.js";
 import { sinon } from "../../../../test/utils/test-utils.js";
+import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
+import type { PasskeyServiceInterface } from "../../common/passkey/types.js";
 
 describe("cannot sign in passkey controller", () => {
   let req: RequestOutput;
@@ -15,6 +18,9 @@ describe("cannot sign in passkey controller", () => {
   beforeEach(() => {
     req = createMockRequest(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);
     res = mockResponse();
+    res.locals.sessionId = commonVariables.sessionId;
+    res.locals.clientSessionId = commonVariables.clientSessionId;
+    res.locals.persistentSessionId = commonVariables.diPersistentSessionId;
   });
 
   afterEach(() => {
@@ -22,9 +28,75 @@ describe("cannot sign in passkey controller", () => {
   });
 
   describe("cannotSignInPasskeyGet", () => {
-    it("should render the cannot sign in passkey page", () => {
-      cannotSignInPasskeyGet(req as Request, res as Response);
-      expect(res.render).to.have.calledWith("cannot-sign-in-passkey/index.njk");
+    it("should render the cannot sign in passkey view with authentication options on success", async () => {
+      const mockData = {
+        publicKey: {
+          challenge: "dGVzdC1jaGFsbGVuZ2U",
+          rpId: "localhost",
+          allowCredentials: [{ type: "public-key", id: "credential-id-123" }],
+          timeout: 60000,
+          userVerification: "preferred",
+        },
+      };
+
+      const fakePasskeyService = {
+        startPasskeyAssertion: sinon.fake.returns({
+          success: true,
+          data: mockData,
+        }),
+      } as unknown as PasskeyServiceInterface;
+
+      await cannotSignInPasskeyGet(fakePasskeyService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(res.render).to.have.been.calledWith(
+        "cannot-sign-in-passkey/index.njk",
+        { authenticationOptions: JSON.stringify(mockData.publicKey) }
+      );
+    });
+
+    it("should pass the correct session IDs to the passkey service", async () => {
+      const fakePasskeyService = {
+        startPasskeyAssertion: sinon.fake.returns({
+          success: true,
+          data: { message: "success", code: 200 },
+        }),
+      } as unknown as PasskeyServiceInterface;
+
+      await cannotSignInPasskeyGet(fakePasskeyService)(
+        req as Request,
+        res as Response
+      );
+
+      expect(
+        fakePasskeyService.startPasskeyAssertion
+      ).to.have.been.calledWith(
+        commonVariables.sessionId,
+        commonVariables.clientSessionId,
+        commonVariables.diPersistentSessionId,
+        req
+      );
+    });
+
+    it("should throw an error when the passkey service returns unsuccessful", async () => {
+      const fakePasskeyService: PasskeyServiceInterface = {
+        startPasskeyAssertion: sinon.fake.returns({
+          success: false,
+          data: { message: "Session expired", code: 1000 },
+        }),
+      } as unknown as PasskeyServiceInterface;
+      await assert.rejects(
+        async () =>
+          cannotSignInPasskeyGet(fakePasskeyService)(
+            req as Request,
+            res as Response
+          ),
+        Error,
+        "StartPasskeyAssertionError: Session expired"
+      );
+      expect(res.render).to.not.have.been.called;
     });
   });
 });

--- a/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
+++ b/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
@@ -1,15 +1,18 @@
 import { describe } from "mocha";
 import { expect, sinon } from "../../../../test/utils/test-utils.js";
 import request from "supertest";
-import { PATH_NAMES } from "../../../app.constants.js";
+import { API_ENDPOINTS, PATH_NAMES } from "../../../app.constants.js";
 import type { NextFunction, Request, Response } from "express";
 import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper.js";
 import { extractCsrfTokenAndCookies } from "../../../../test/helpers/csrf-helper.js";
 import esmock from "esmock";
 import * as cheerio from "cheerio";
+import nock from "nock";
+import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
 
 describe("Integration:: cannot sign in passkey", () => {
   let app: any;
+  let baseApi: string;
 
   before(async () => {
     process.env.SUPPORT_PASSKEY_USAGE = "1";
@@ -24,6 +27,11 @@ describe("Integration:: cannot sign in passkey", () => {
             res: Response,
             next: NextFunction
           ): void {
+            res.locals.sessionId = commonVariables.sessionId;
+            res.locals.clientSessionId = commonVariables.clientSessionId;
+            res.locals.persistentSessionId =
+              commonVariables.diPersistentSessionId;
+
             req.session.user = {
               journey: getPermittedJourneyForPath(
                 PATH_NAMES.CANNOT_SIGN_IN_PASSKEY
@@ -36,7 +44,13 @@ describe("Integration:: cannot sign in passkey", () => {
       }
     );
 
+    baseApi = process.env.FRONTEND_API_BASE_URL as string;
+
     app = await createApp();
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
   });
 
   after(() => {
@@ -46,40 +60,115 @@ describe("Integration:: cannot sign in passkey", () => {
 
   describe("GET /cannot-sign-in-passkey", () => {
     it("should return the cannot sign in passkey page", async () => {
-      await request(app).get(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY).expect(200);
+      const startPasskeyAssertionResponse = {
+        publicKey: {
+          challenge: "challenge",
+          rpId: "localhost",
+          allowCredentials: [{ type: "public-key", id: "credential-id-123" }],
+          timeout: 60000,
+          userVerification: "preferred",
+        },
+      };
+      nock(baseApi)
+        .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
+        .once()
+        .reply(200, startPasskeyAssertionResponse);
+
+      const res = await request(app)
+        .get(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
+        .expect(200);
+      const $ = cheerio.load(res.text);
+      const options = $("#cannotSignInPasskeyForm").attr(
+        "data-authentication-options"
+      );
+      expect(options).to.equal(
+        JSON.stringify(startPasskeyAssertionResponse.publicKey)
+      );
     });
   });
 
   describe("POST /cannot-sign-in-passkey", () => {
-    it("should return error when csrf not present", async () => {
-      await request(app)
-        .post(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
-        .type("form")
-        .send({
-          "cannot-sign-in-passkey-action": "retry-passkey",
-        })
-        .expect(403);
+    const SUCCESSFUL_ASSERTION_RESPONSE = JSON.stringify({
+      id: "credential-id",
+      rawId: "credential-id",
+      response: {
+        authenticatorData: "base64data",
+        clientDataJSON: "base64data",
+        signature: "base64sig",
+      },
+      type: "public-key",
+      authenticatorAttachment: "platform",
     });
 
-    it("should return a validation error when no option is selected", async () => {
-      const { token, cookies } = extractCsrfTokenAndCookies(
-        await request(app).get(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
-      );
+    let token: string;
+    let cookies: string;
+    before(async () => {
+      nock(baseApi)
+        .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
+        .once()
+        .reply(200, { challenge: "test", rpId: "localhost" });
 
-      await request(app)
-        .post(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
-        .type("form")
-        .set("Cookie", cookies)
-        .send({
-          _csrf: token,
-        })
-        .expect(function (res) {
-          const $ = cheerio.load(res.text);
-          expect($("#cannot-sign-in-passkey-action-error").text()).to.contains(
-            "Select what you would like to do"
-          );
-        })
-        .expect(400);
+      ({ token, cookies } = extractCsrfTokenAndCookies(
+        await request(app).get(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
+      ));
+    });
+
+    describe("success", () => {
+      it("should redirect to auth-code when passkey successfully retried", async () => {
+        nock(baseApi)
+          .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
+          .once()
+          .reply(200, { message: "success", code: 0 });
+
+        await request(app)
+          .post(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            _csrf: token,
+            authenticationResponse: SUCCESSFUL_ASSERTION_RESPONSE,
+            "cannot-sign-in-passkey-action": "retry-passkey",
+          })
+          .expect(302)
+          .expect("Location", PATH_NAMES.AUTH_CODE);
+      });
+    });
+
+    describe("failure", () => {
+      it("should return error when csrf not present", async () => {
+        nock(baseApi)
+          .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
+          .once()
+          .reply(200, { message: "success", code: 0 });
+
+        await request(app)
+          .post(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            authenticationResponse: SUCCESSFUL_ASSERTION_RESPONSE,
+            "cannot-sign-in-passkey-action": "retry-passkey",
+          })
+          .expect(403);
+      });
+
+      it("should return a validation error when no option is selected", async () => {
+        await request(app)
+          .post(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            _csrf: token,
+            authenticationResponse: SUCCESSFUL_ASSERTION_RESPONSE,
+          })
+          .expect(function (res) {
+            const $ = cheerio.load(res.text);
+            expect(
+              $("#cannot-sign-in-passkey-action-error").text()
+            ).to.contains("Select what you would like to do");
+          })
+          .expect(400);
+      });
     });
   });
 });

--- a/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
+++ b/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
@@ -88,18 +88,6 @@ describe("Integration:: cannot sign in passkey", () => {
   });
 
   describe("POST /cannot-sign-in-passkey", () => {
-    const SUCCESSFUL_ASSERTION_RESPONSE = JSON.stringify({
-      id: "credential-id",
-      rawId: "credential-id",
-      response: {
-        authenticatorData: "base64data",
-        clientDataJSON: "base64data",
-        signature: "base64sig",
-      },
-      type: "public-key",
-      authenticatorAttachment: "platform",
-    });
-
     let token: string;
     let cookies: string;
     before(async () => {
@@ -126,7 +114,7 @@ describe("Integration:: cannot sign in passkey", () => {
           .set("Cookie", cookies)
           .send({
             _csrf: token,
-            authenticationResponse: SUCCESSFUL_ASSERTION_RESPONSE,
+            authenticationResponse: commonVariables.passkeyAssertionResponse,
             "cannot-sign-in-passkey-action": "retry-passkey",
           })
           .expect(302)
@@ -146,7 +134,7 @@ describe("Integration:: cannot sign in passkey", () => {
           .type("form")
           .set("Cookie", cookies)
           .send({
-            authenticationResponse: SUCCESSFUL_ASSERTION_RESPONSE,
+            authenticationResponse: commonVariables.passkeyAssertionResponse,
             "cannot-sign-in-passkey-action": "retry-passkey",
           })
           .expect(403);
@@ -159,7 +147,7 @@ describe("Integration:: cannot sign in passkey", () => {
           .set("Cookie", cookies)
           .send({
             _csrf: token,
-            authenticationResponse: SUCCESSFUL_ASSERTION_RESPONSE,
+            authenticationResponse: commonVariables.passkeyAssertionResponse,
           })
           .expect(function (res) {
             const $ = cheerio.load(res.text);

--- a/src/components/common/passkey/passkey-service.ts
+++ b/src/components/common/passkey/passkey-service.ts
@@ -1,21 +1,19 @@
-import type { Http } from "../../utils/http.js";
+import type { Http } from "../../../utils/http.js";
 import {
   createApiResponse,
   getInternalRequestConfigWithSecurityHeaders,
   http,
-} from "../../utils/http.js";
+} from "../../../utils/http.js";
 import type {
-  SignInWithPasskeyInterface,
+  PasskeyServiceInterface,
   StartPasskeyAssertionResponse,
 } from "./types.js";
-import type { ApiResponseResult, DefaultApiResponse } from "../../types.js";
-import { API_ENDPOINTS } from "../../app.constants.js";
+import type { ApiResponseResult, DefaultApiResponse } from "../../../types.js";
+import { API_ENDPOINTS } from "../../../app.constants.js";
 import type { Request } from "express";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 
-export function signInWithPasskeyService(
-  axios: Http = http
-): SignInWithPasskeyInterface {
+export function passkeyService(axios: Http = http): PasskeyServiceInterface {
   const startPasskeyAssertion = async function (
     sessionId: string,
     clientSessionId: string,

--- a/src/components/common/passkey/tests/passkey-service.test.ts
+++ b/src/components/common/passkey/tests/passkey-service.test.ts
@@ -1,27 +1,23 @@
 import { describe } from "mocha";
 import { expect } from "chai";
-import { Http } from "../../../utils/http.js";
-import { sinon } from "../../../../test/utils/test-utils.js";
-import {
-  API_ENDPOINTS,
-  HTTP_STATUS_CODES,
-  PATH_NAMES,
-} from "../../../app.constants.js";
+import { Http } from "../../../../utils/http.js";
+import { sinon } from "../../../../../test/utils/test-utils.js";
+import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../../../app.constants.js";
 import type { SinonStub } from "sinon";
-import { signInWithPasskeyService } from "../sign-in-with-passkey-service.js";
-import type { SignInWithPasskeyInterface } from "../types.js";
+import { passkeyService } from "../passkey-service.js";
+import type { PasskeyServiceInterface } from "../types.js";
 import {
   checkApiCallMadeWithExpectedBodyAndHeaders,
   expectedHeadersFromCommonVarsWithSecurityHeaders,
   requestHeadersWithIpAndAuditEncoded,
   resetApiKeyAndBaseUrlEnvVars,
   setupApiKeyAndBaseUrlEnvVars,
-} from "../../../../test/helpers/service-test-helper.js";
-import { createMockRequest } from "../../../../test/helpers/mock-request-helper.js";
-import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
+} from "../../../../../test/helpers/service-test-helper.js";
+import { createMockRequest } from "../../../../../test/helpers/mock-request-helper.js";
+import { commonVariables } from "../../../../../test/helpers/common-test-variables.js";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 
-describe("sign in with passkey service", () => {
+describe("passkey service", () => {
   const httpInstance = new Http();
   let postStub: SinonStub;
 
@@ -36,11 +32,10 @@ describe("sign in with passkey service", () => {
   });
 
   describe("startPasskeyAssertion", () => {
-    const service: SignInWithPasskeyInterface =
-      signInWithPasskeyService(httpInstance);
+    const service: PasskeyServiceInterface = passkeyService(httpInstance);
 
     it("should call the start passkey assertion API endpoint and return successful response", async () => {
-      const req = createMockRequest(PATH_NAMES.SIGN_IN_WITH_PASSKEY, {
+      const req = createMockRequest("/test-path", {
         headers: requestHeadersWithIpAndAuditEncoded,
       });
       const authenticationOptions = {
@@ -79,7 +74,7 @@ describe("sign in with passkey service", () => {
     });
 
     it("should return success false when the API returns non-200", async () => {
-      const req = createMockRequest(PATH_NAMES.SIGN_IN_WITH_PASSKEY, {
+      const req = createMockRequest("/test-path", {
         headers: requestHeadersWithIpAndAuditEncoded,
       });
       const axiosResponse = Promise.resolve({
@@ -114,11 +109,10 @@ describe("sign in with passkey service", () => {
   });
 
   describe("finishPasskeyAssertion", () => {
-    const service: SignInWithPasskeyInterface =
-      signInWithPasskeyService(httpInstance);
+    const service: PasskeyServiceInterface = passkeyService(httpInstance);
 
     it("should call the finish passkey assertion API endpoint and return successful response", async () => {
-      const req = createMockRequest(PATH_NAMES.SIGN_IN_WITH_PASSKEY, {
+      const req = createMockRequest("/test-path", {
         headers: requestHeadersWithIpAndAuditEncoded,
       });
       const startAuthenticationWebauthnResponse = {
@@ -155,7 +149,7 @@ describe("sign in with passkey service", () => {
     });
 
     it("should return success false when the API returns non-200", async () => {
-      const req = createMockRequest(PATH_NAMES.SIGN_IN_WITH_PASSKEY, {
+      const req = createMockRequest("/test-path", {
         headers: requestHeadersWithIpAndAuditEncoded,
       });
       const startAuthenticationWebauthnResponse = {

--- a/src/components/common/passkey/types.ts
+++ b/src/components/common/passkey/types.ts
@@ -1,12 +1,12 @@
 import type { Request } from "express";
-import type { ApiResponseResult, DefaultApiResponse } from "../../types.js";
+import type { ApiResponseResult, DefaultApiResponse } from "../../../types.js";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 
 export interface StartPasskeyAssertionResponse extends DefaultApiResponse {
   publicKey: PublicKeyCredentialRequestOptionsJSON;
 }
 
-export interface SignInWithPasskeyInterface {
+export interface PasskeyServiceInterface {
   startPasskeyAssertion: (
     sessionId: string,
     clientSessionId: string,

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -369,7 +369,13 @@ const authStateMachine = createMachine<AuthStateContext>(
         },
       },
       [PATH_NAMES.CANNOT_SIGN_IN_PASSKEY]: {
-        type: "final",
+        on: {
+          [USER_JOURNEY_EVENTS.PASSKEY_VERIFICATION_SUCCESSFUL]: [
+            {
+              target: [INTERMEDIATE_STATES.SIGN_IN_END],
+            },
+          ],
+        },
       },
       [PATH_NAMES.ENTER_PASSWORD]: {
         on: {

--- a/src/components/sign-in-with-passkey/index.njk
+++ b/src/components/sign-in-with-passkey/index.njk
@@ -22,7 +22,7 @@
 
   <form method="post" id="signInWithPasskeyForm" data-authentication-options="{{ authenticationOptions }}">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
-    <input type="hidden" name="authenticationResponse" value='"' />
+    <input type="hidden" name="authenticationResponse" value="" />
     <input type="hidden" name="authenticationError" value="JavaScriptNotEnabled" />
 
     {{ govukButton({

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-controller.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-controller.ts
@@ -1,13 +1,13 @@
 import type { Request, Response } from "express";
-import type { SignInWithPasskeyInterface } from "./types.js";
-import { signInWithPasskeyService } from "./sign-in-with-passkey-service.js";
+import type { PasskeyServiceInterface } from "../common/passkey/types.js";
+import { passkeyService } from "../common/passkey/passkey-service.js";
 import type { ExpressRouteFunc } from "../../types.js";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 
 export function signInWithPasskeyGet(
-  service: SignInWithPasskeyInterface = signInWithPasskeyService()
+  service: PasskeyServiceInterface = passkeyService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const startPasskeyAssertionResult = await service.startPasskeyAssertion(
@@ -32,7 +32,7 @@ export function signInWithPasskeyGet(
 }
 
 export function signInWithPasskeyPost(
-  service: SignInWithPasskeyInterface = signInWithPasskeyService()
+  service: PasskeyServiceInterface = passkeyService()
 ): ExpressRouteFunc {
   return async function (req: Request, res: Response) {
     const authenticationError = req.body.authenticationError;

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-controller.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-controller.test.ts
@@ -11,7 +11,7 @@ import {
   signInWithPasskeyGet,
   signInWithPasskeyPost,
 } from "../sign-in-with-passkey-controller.js";
-import type { SignInWithPasskeyInterface } from "../types.js";
+import type { PasskeyServiceInterface } from "../../common/passkey/types.js";
 import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
 import { strict as assert } from "assert";
 
@@ -43,14 +43,14 @@ describe("sign in with passkey controller", () => {
         },
       };
 
-      const fakeStartSignInService = {
+      const fakePasskeyService = {
         startPasskeyAssertion: sinon.fake.returns({
           success: true,
           data: mockData,
         }),
-      } as unknown as SignInWithPasskeyInterface;
+      } as unknown as PasskeyServiceInterface;
 
-      await signInWithPasskeyGet(fakeStartSignInService)(
+      await signInWithPasskeyGet(fakePasskeyService)(
         req as Request,
         res as Response
       );
@@ -61,22 +61,20 @@ describe("sign in with passkey controller", () => {
       );
     });
 
-    it("should pass the correct session IDs to the start service", async () => {
-      const fakeStartSignInService = {
+    it("should pass the correct session IDs to the passkey service", async () => {
+      const fakePasskeyService = {
         startPasskeyAssertion: sinon.fake.returns({
           success: true,
           data: { message: "success", code: 200 },
         }),
-      } as unknown as SignInWithPasskeyInterface;
+      } as unknown as PasskeyServiceInterface;
 
-      await signInWithPasskeyGet(fakeStartSignInService)(
+      await signInWithPasskeyGet(fakePasskeyService)(
         req as Request,
         res as Response
       );
 
-      expect(
-        fakeStartSignInService.startPasskeyAssertion
-      ).to.have.been.calledWith(
+      expect(fakePasskeyService.startPasskeyAssertion).to.have.been.calledWith(
         commonVariables.sessionId,
         commonVariables.clientSessionId,
         commonVariables.diPersistentSessionId,
@@ -84,16 +82,16 @@ describe("sign in with passkey controller", () => {
       );
     });
 
-    it("should throw an error when the start service returns unsuccessful", async () => {
-      const fakeStartSignInService: SignInWithPasskeyInterface = {
+    it("should throw an error when the passkey service returns unsuccessful", async () => {
+      const fakePasskeyService: PasskeyServiceInterface = {
         startPasskeyAssertion: sinon.fake.returns({
           success: false,
           data: { message: "Session expired", code: 1000 },
         }),
-      } as unknown as SignInWithPasskeyInterface;
+      } as unknown as PasskeyServiceInterface;
       await assert.rejects(
         async () =>
-          signInWithPasskeyGet(fakeStartSignInService)(
+          signInWithPasskeyGet(fakePasskeyService)(
             req as Request,
             res as Response
           ),
@@ -105,14 +103,14 @@ describe("sign in with passkey controller", () => {
   });
 
   describe("signInWithPasskeyPost", () => {
-    it("should redirect to the next path when the finish service returns success", async () => {
-      const fakeFinishSignInService = {
+    it("should redirect to the next path when the passkey service returns success", async () => {
+      const fakePasskeyService = {
         finishPasskeyAssertion: sinon.fake.returns({
           success: true,
         }),
-      } as unknown as SignInWithPasskeyInterface;
+      } as unknown as PasskeyServiceInterface;
 
-      await signInWithPasskeyPost(fakeFinishSignInService)(
+      await signInWithPasskeyPost(fakePasskeyService)(
         req as Request,
         res as Response
       );
@@ -120,25 +118,23 @@ describe("sign in with passkey controller", () => {
       expect(res.redirect).to.have.been.calledWith(PATH_NAMES.AUTH_CODE);
     });
 
-    it("should pass the authentication response from the request body to the finish service", async () => {
+    it("should pass the authentication response from the request body to the passkey service", async () => {
       const authenticationResponse = {
         signedChallenge: "challenge",
       };
       req.body.authenticationResponse = authenticationResponse;
-      const fakeFinishSignInService = {
+      const fakePasskeyService = {
         finishPasskeyAssertion: sinon.fake.returns({
           success: true,
         }),
-      } as unknown as SignInWithPasskeyInterface;
+      } as unknown as PasskeyServiceInterface;
 
-      await signInWithPasskeyPost(fakeFinishSignInService)(
+      await signInWithPasskeyPost(fakePasskeyService)(
         req as Request,
         res as Response
       );
 
-      expect(
-        fakeFinishSignInService.finishPasskeyAssertion
-      ).to.have.been.calledWith(
+      expect(fakePasskeyService.finishPasskeyAssertion).to.have.been.calledWith(
         commonVariables.sessionId,
         commonVariables.clientSessionId,
         commonVariables.diPersistentSessionId,
@@ -147,15 +143,15 @@ describe("sign in with passkey controller", () => {
       );
     });
 
-    it("should redirect to cannot sign in passkey when the finish service returns unsuccessful", async () => {
-      const fakeFinishSignInService = {
+    it("should redirect to cannot sign in passkey when the passkey service returns unsuccessful", async () => {
+      const fakePasskeyService = {
         finishPasskeyAssertion: sinon.fake.returns({
           success: false,
           data: { message: "Session expired", code: 1000 },
         }),
-      } as unknown as SignInWithPasskeyInterface;
+      } as unknown as PasskeyServiceInterface;
 
-      await signInWithPasskeyPost(fakeFinishSignInService)(
+      await signInWithPasskeyPost(fakePasskeyService)(
         req as Request,
         res as Response
       );
@@ -168,11 +164,11 @@ describe("sign in with passkey controller", () => {
     it("should redirect to cannot sign in passkey when authenticationError is present", async () => {
       req.body.authenticationError = "NotAllowedError";
 
-      const fakeFinishSignInService = {
+      const fakePasskeyService = {
         finishPasskeyAssertion: sinon.fake(),
-      } as unknown as SignInWithPasskeyInterface;
+      } as unknown as PasskeyServiceInterface;
 
-      await signInWithPasskeyPost(fakeFinishSignInService)(
+      await signInWithPasskeyPost(fakePasskeyService)(
         req as Request,
         res as Response
       );
@@ -180,8 +176,7 @@ describe("sign in with passkey controller", () => {
       expect(res.redirect).to.have.been.calledWith(
         PATH_NAMES.CANNOT_SIGN_IN_PASSKEY
       );
-      expect(fakeFinishSignInService.finishPasskeyAssertion).to.not.have.been
-        .called;
+      expect(fakePasskeyService.finishPasskeyAssertion).to.not.have.been.called;
     });
   });
 });

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
@@ -8,12 +8,15 @@ import esmock from "esmock";
 import nock from "nock";
 import * as cheerio from "cheerio";
 import { extractCsrfTokenAndCookies } from "../../../../test/helpers/csrf-helper.js";
+import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
 
 describe("Integration:: sign in with passkey", () => {
   let app: any;
   let baseApi: string;
 
   before(async () => {
+    process.env.SUPPORT_PASSKEY_USAGE = "1";
+
     const { createApp } = await esmock(
       "../../../app.js",
       {},
@@ -24,9 +27,10 @@ describe("Integration:: sign in with passkey", () => {
             res: Response,
             next: NextFunction
           ): void {
-            res.locals.sessionId = "test-session-id";
-            res.locals.clientSessionId = "test-client-session-id";
-            res.locals.persistentSessionId = "test-persistent-session-id";
+            res.locals.sessionId = commonVariables.sessionId;
+            res.locals.clientSessionId = commonVariables.clientSessionId;
+            res.locals.persistentSessionId =
+              commonVariables.diPersistentSessionId;
 
             req.session.user = {
               journey: getPermittedJourneyForPath(
@@ -83,103 +87,105 @@ describe("Integration:: sign in with passkey", () => {
     });
   });
 
-  describe("POST /sign-in-passkey - success", () => {
-    it("should redirect on successful passkey finish assertion", async () => {
-      nock(baseApi)
-        .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
-        .once()
-        .reply(200, { challenge: "test", rpId: "localhost" });
+  describe("POST /sign-in-passkey", () => {
+    describe("success", () => {
+      it("should redirect on successful passkey finish assertion", async () => {
+        nock(baseApi)
+          .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
+          .once()
+          .reply(200, { challenge: "test", rpId: "localhost" });
 
-      const { token, cookies } = extractCsrfTokenAndCookies(
-        await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
-      );
+        const { token, cookies } = extractCsrfTokenAndCookies(
+          await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+        );
 
-      nock(baseApi)
-        .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
-        .once()
-        .reply(200, { message: "success", code: 0 });
+        nock(baseApi)
+          .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
+          .once()
+          .reply(200, { message: "success", code: 0 });
 
-      await request(app)
-        .post(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
-        .type("form")
-        .set("Cookie", cookies)
-        .send({
-          _csrf: token,
-          authenticationResponse: JSON.stringify({
-            id: "credential-id",
-            rawId: "credential-id",
-            response: {
-              authenticatorData: "base64data",
-              clientDataJSON: "base64data",
-              signature: "base64sig",
-            },
-            type: "public-key",
-            authenticatorAttachment: "platform",
-          }),
-        })
-        .expect(302)
-        .expect("Location", PATH_NAMES.AUTH_CODE);
-    });
-  });
-
-  describe("POST /sign-in-passkey - failure", () => {
-    it("should redirect to cannot sign in passkey when authenticationError is present", async () => {
-      nock(baseApi)
-        .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
-        .once()
-        .reply(200, { challenge: "test", rpId: "localhost" });
-
-      const { token, cookies } = extractCsrfTokenAndCookies(
-        await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
-      );
-
-      await request(app)
-        .post(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
-        .type("form")
-        .set("Cookie", cookies)
-        .send({
-          _csrf: token,
-          authenticationError: "NotAllowedError",
-        })
-        .expect(302)
-        .expect("Location", PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);
+        await request(app)
+          .post(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            _csrf: token,
+            authenticationResponse: JSON.stringify({
+              id: "credential-id",
+              rawId: "credential-id",
+              response: {
+                authenticatorData: "base64data",
+                clientDataJSON: "base64data",
+                signature: "base64sig",
+              },
+              type: "public-key",
+              authenticatorAttachment: "platform",
+            }),
+          })
+          .expect(302)
+          .expect("Location", PATH_NAMES.AUTH_CODE);
+      });
     });
 
-    it("should redirect to cannot sign in passkey when finish assertion fails", async () => {
-      nock(baseApi)
-        .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
-        .once()
-        .reply(200, { challenge: "test", rpId: "localhost" });
+    describe("failure", () => {
+      it("should redirect to cannot sign in passkey when authenticationError is present", async () => {
+        nock(baseApi)
+          .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
+          .once()
+          .reply(200, { challenge: "test", rpId: "localhost" });
 
-      const { token, cookies } = extractCsrfTokenAndCookies(
-        await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
-      );
+        const { token, cookies } = extractCsrfTokenAndCookies(
+          await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+        );
 
-      nock(baseApi)
-        .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
-        .once()
-        .reply(400, { message: "Assertion failed", code: 1000 });
+        await request(app)
+          .post(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            _csrf: token,
+            authenticationError: "NotAllowedError",
+          })
+          .expect(302)
+          .expect("Location", PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);
+      });
 
-      await request(app)
-        .post(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
-        .type("form")
-        .set("Cookie", cookies)
-        .send({
-          _csrf: token,
-          authenticationResponse: JSON.stringify({
-            id: "credential-id",
-            rawId: "credential-id",
-            response: {
-              authenticatorData: "base64data",
-              clientDataJSON: "base64data",
-              signature: "base64sig",
-            },
-            type: "public-key",
-            authenticatorAttachment: "platform",
-          }),
-        })
-        .expect(302)
-        .expect("Location", PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);
+      it("should redirect to cannot sign in passkey when finish assertion fails", async () => {
+        nock(baseApi)
+          .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
+          .once()
+          .reply(200, { challenge: "test", rpId: "localhost" });
+
+        const { token, cookies } = extractCsrfTokenAndCookies(
+          await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+        );
+
+        nock(baseApi)
+          .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
+          .once()
+          .reply(400, { message: "Assertion failed", code: 1000 });
+
+        await request(app)
+          .post(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            _csrf: token,
+            authenticationResponse: JSON.stringify({
+              id: "credential-id",
+              rawId: "credential-id",
+              response: {
+                authenticatorData: "base64data",
+                clientDataJSON: "base64data",
+                signature: "base64sig",
+              },
+              type: "public-key",
+              authenticatorAttachment: "platform",
+            }),
+          })
+          .expect(302)
+          .expect("Location", PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);
+      });
     });
   });
 });

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
@@ -88,17 +88,21 @@ describe("Integration:: sign in with passkey", () => {
   });
 
   describe("POST /sign-in-passkey", () => {
+    let token: string;
+    let cookies: string;
+    before(async () => {
+      nock(baseApi)
+        .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
+        .once()
+        .reply(200, { challenge: "test", rpId: "localhost" });
+
+      ({ token, cookies } = extractCsrfTokenAndCookies(
+        await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+      ));
+    });
+
     describe("success", () => {
       it("should redirect on successful passkey finish assertion", async () => {
-        nock(baseApi)
-          .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
-          .once()
-          .reply(200, { challenge: "test", rpId: "localhost" });
-
-        const { token, cookies } = extractCsrfTokenAndCookies(
-          await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
-        );
-
         nock(baseApi)
           .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
           .once()
@@ -110,17 +114,7 @@ describe("Integration:: sign in with passkey", () => {
           .set("Cookie", cookies)
           .send({
             _csrf: token,
-            authenticationResponse: JSON.stringify({
-              id: "credential-id",
-              rawId: "credential-id",
-              response: {
-                authenticatorData: "base64data",
-                clientDataJSON: "base64data",
-                signature: "base64sig",
-              },
-              type: "public-key",
-              authenticatorAttachment: "platform",
-            }),
+            authenticationResponse: commonVariables.passkeyAssertionResponse,
           })
           .expect(302)
           .expect("Location", PATH_NAMES.AUTH_CODE);
@@ -128,16 +122,23 @@ describe("Integration:: sign in with passkey", () => {
     });
 
     describe("failure", () => {
-      it("should redirect to cannot sign in passkey when authenticationError is present", async () => {
+      it("should return error when csrf not present", async () => {
         nock(baseApi)
-          .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
+          .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
           .once()
-          .reply(200, { challenge: "test", rpId: "localhost" });
+          .reply(200, { message: "success", code: 0 });
 
-        const { token, cookies } = extractCsrfTokenAndCookies(
-          await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
-        );
+        await request(app)
+          .post(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            authenticationResponse: commonVariables.passkeyAssertionResponse,
+          })
+          .expect(403);
+      });
 
+      it("should redirect to cannot sign in passkey when authenticationError is present", async () => {
         await request(app)
           .post(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
           .type("form")
@@ -152,15 +153,6 @@ describe("Integration:: sign in with passkey", () => {
 
       it("should redirect to cannot sign in passkey when finish assertion fails", async () => {
         nock(baseApi)
-          .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
-          .once()
-          .reply(200, { challenge: "test", rpId: "localhost" });
-
-        const { token, cookies } = extractCsrfTokenAndCookies(
-          await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
-        );
-
-        nock(baseApi)
           .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
           .once()
           .reply(400, { message: "Assertion failed", code: 1000 });
@@ -171,17 +163,7 @@ describe("Integration:: sign in with passkey", () => {
           .set("Cookie", cookies)
           .send({
             _csrf: token,
-            authenticationResponse: JSON.stringify({
-              id: "credential-id",
-              rawId: "credential-id",
-              response: {
-                authenticatorData: "base64data",
-                clientDataJSON: "base64data",
-                signature: "base64sig",
-              },
-              type: "public-key",
-              authenticatorAttachment: "platform",
-            }),
+            authenticationResponse: commonVariables.passkeyAssertionResponse,
           })
           .expect(302)
           .expect("Location", PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);

--- a/test/helpers/common-test-variables.ts
+++ b/test/helpers/common-test-variables.ts
@@ -10,4 +10,15 @@ export const commonVariables = {
     "R21vLmd3QilNKHJsaGkvTFxhZDZrKF44SStoLFsieG0oSUY3aEhWRVtOMFRNMVw1dyInKzB8OVV5N09hOi8kLmlLcWJjJGQiK1NPUEJPPHBrYWJHP358NDg2ZDVc",
   testPhoneNumber: "0123456789",
   testRedactedPhoneNumber: redactPhoneNumber("0123456789"),
+  passkeyAssertionResponse: JSON.stringify({
+    id: "credential-id",
+    rawId: "credential-id",
+    response: {
+      authenticatorData: "base64data",
+      clientDataJSON: "base64data",
+      signature: "base64sig",
+    },
+    type: "public-key",
+    authenticatorAttachment: "platform",
+  }),
 };


### PR DESCRIPTION
## What

Adds the ability to retry using your passkey on the `/cannot-sign-in-passkey` screen.

Basically copies what was implemented in https://github.com/govuk-one-login/authentication-frontend/pull/3414 (the main `/sign-in-passkey` page) but is slightly different:
* refactors out some of the common code between the two screens
* some conditional logic based on which radio option was selected

## How to review

1. Code Review
1. Test - deployed to authdev3
    * The un-happy paths (failing to retry or using password instead) aren't implemented, so will error out

## Checklist

- [x] A UCD review has been performed.