### PR TITLE
AUT-5540: Enable the Service Down Page in dev, build and staging

### DIFF
--- a/.github/workflows/build-deploy-frontend-dev.yml
+++ b/.github/workflows/build-deploy-frontend-dev.yml
@@ -10,31 +10,27 @@ on:
         required: true
 
 jobs:
-  # NOTE:
-  # IF you are testing service down page deployment in dev envs
-  # THEN while uncommenting this job, also enable feature flag DeployServiceDownPage: "Yes" in template.yaml
-  # AND override ServiceDownPageRegistry param to env specific settings
-  # deploy-service-down-page:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 60
-  #   environment: ${{ inputs.environment }}
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   steps:
-  #     - name: Build and push service down page image
-  #       uses: govuk-one-login/devplatform-upload-action-ecr@3931602236c176dd4ec2c11dceb38002110b5d87 # v1.3.0
-  #       with:
-  #         role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
-  #         container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_ARN }}
-  #         build-and-push-image-only: true
-  #         working-directory: service-down-page-config
-  #         artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
-  #         ecr-repo-name: ${{ secrets.SERVICE_DOWN_PAGE_ECR_REPOSITORY }}
+  deploy-service-down-page:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: ${{ inputs.environment }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Build and push service down page image
+        uses: govuk-one-login/devplatform-upload-action-ecr@3931602236c176dd4ec2c11dceb38002110b5d87 # v1.3.0
+        with:
+          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          container-sign-kms-key-arn: ${{ secrets.CONTAINER_SIGN_KMS_KEY_ARN }}
+          build-and-push-image-only: true
+          working-directory: service-down-page-config
+          artifact-bucket-name: ${{ secrets.ARTIFACT_SOURCE_BUCKET_NAME }}
+          ecr-repo-name: ${{ secrets.SERVICE_DOWN_PAGE_ECR_REPOSITORY }}
 
   deploy-frontend:
-    # needs:
-    #   - deploy-service-down-page
+    needs:
+      - deploy-service-down-page
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: ${{ inputs.environment }}

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -2185,7 +2185,7 @@ Resources:
       ServiceName: !Sub "${AWS::StackName}-ServiceDownECSService"
       Cluster: !Ref FrontendECSCluster
       LaunchType: FARGATE
-      DesiredCount: 2
+      DesiredCount: !If [IsNotProduction, 1, 2]
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 50

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -59,10 +59,6 @@ Parameters:
     Description: The ARN of the permissions boundary to apply when creating IAM roles
     Default: none
 
-  ServiceDownPageRegistry:
-    Type: String
-    Default: 058264536367.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository-containerrepository-5mf9vzblyt5l
-
 Conditions:
   DeployServiceDownPage:
     Fn::Equals:
@@ -493,7 +489,7 @@ Mappings:
       SupportSingleFactorAccountDeletion: "Yes"
       PasskeyPromptClientAllowList: ""
     dev:
-      DeployServiceDownPage: "No"
+      DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       frontendApiBaseUrl: https://tze402cnbk-vpce-0b907325ae3bfe3ce.execute-api.eu-west-2.amazonaws.com/dev/
       frontendAutoScalingMinCount: 1
@@ -522,9 +518,10 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       SupportSingleFactorAccountDeletion: "Yes"
       PasskeyPromptClientAllowList: "J3tedNRsfssnsf4STuc2NNIV1C1gdxBB"
+      serviceDownPageRegistry: "975050272416.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository-containerrepository-w62weogzsdkb"
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      DeployServiceDownPage: "No"
+      DeployServiceDownPage: "Yes"
       frontendApiBaseUrl: https://7ecg8e1o73-vpce-042c5d3d97d7438d9.execute-api.eu-west-2.amazonaws.com/build/
       frontendAutoScalingMinCount: 4
       frontendAutoScalingMaxCount: 6
@@ -552,9 +549,10 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       SupportSingleFactorAccountDeletion: "No"
       PasskeyPromptClientAllowList: "Ykg9fGyY76On4e8tPvFabK5BIl65EkGH"
+      serviceDownPageRegistry: "058264536367.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository-containerrepository-5mf9vzblyt5l"
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      DeployServiceDownPage: "No"
+      DeployServiceDownPage: "Yes"
       frontendApiBaseUrl: https://z02rnzbqw8-vpce-07078f5f005fe5efc.execute-api.eu-west-2.amazonaws.com/staging/
       frontendAutoScalingMinCount: 12
       frontendAutoScalingMaxCount: 240
@@ -589,6 +587,7 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       SupportSingleFactorAccountDeletion: "No"
       PasskeyPromptClientAllowList: "nsR2wZ7EebJ2VOzE1LUa9iAVadunWQP3,EMGmY82k-92QSakDl_9keKDFmZY" # perf-test client, home client
+      serviceDownPageRegistry: "058264536367.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository-containerrepository-5mf9vzblyt5l"
     integration:
       DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -620,6 +619,7 @@ Mappings:
       SupportNewInternationalSms: "No"
       EnableDwpKbvContactFormChanges: "Yes"
       PasskeyPromptClientAllowList: ""
+      serviceDownPageRegistry: "058264536367.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository-containerrepository-5mf9vzblyt5l"
     production:
       DeployServiceDownPage: "Yes"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -654,6 +654,7 @@ Mappings:
       EnableDwpKbvContactFormChanges: "Yes"
       SupportSingleFactorAccountDeletion: "No"
       PasskeyPromptClientAllowList: ""
+      serviceDownPageRegistry: "058264536367.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository-containerrepository-5mf9vzblyt5l"
 
 Globals:
   Function:
@@ -2255,7 +2256,9 @@ Resources:
       Family: !Sub "${Environment}-frontend-service-down-page-ecs-task-definition"
       ContainerDefinitions:
         - Name: "service-down-page"
-          Image: !Sub "${ServiceDownPageRegistry}:GIT-SHA-PLACEHOLDER"
+          Image: !Sub
+            - "${Registry}:GIT-SHA-PLACEHOLDER"
+            - Registry: !FindInMap [ EnvironmentConfiguration, !Ref Environment, serviceDownPageRegistry ]
           PortMappings:
             - ContainerPort: 8080
               HostPort: 8080


### PR DESCRIPTION

## What

Enable the Service Down Page in dev, build and staging

Makes it possible to test Service Down Page changes outside of integration and production

- Uncomment the dev deploy job
- Make the Service Down Page ECR configurable by environment
- Switch on the Service Down Page in dev, build and staging

## How to review

1. Code Review
1. Deploy to a dev and check that the service down page is deployed

Tested in dev by deploying the branch and following: https://team-manual.account.gov.uk/supporting-govuk-one-login/managing-incidents/temporarily-shutter-govuk-sign-in/#temporarily-shutter-gov-uk-one-login

## Related PRs

This PR will enable testing of the Service Down Page changes in #3447 