### PR TITLE
Bau/tidy up overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "uglify-js": "3.19.3"
   },
   "overrides": {
-    "validator": "13.15.23",
     "serialize-javascript": ">=7.0.5",
     "fast-xml-parser": ">=5.5.6"
   },

--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
     "uglify-js": "3.19.3"
   },
   "overrides": {
-    "js-yaml": "4.1.1",
     "validator": "13.15.23",
     "serialize-javascript": ">=7.0.5",
     "fast-xml-parser": ">=5.5.6"


### PR DESCRIPTION
Remove two overrides for transitive dependencies we no longer need. Makes maintaining this project and reasoning about dependencies easier.