### PR TITLE
BAU: Constrain form-data to >=4.0.6 to fix CVE-2026-12143

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,8 @@
   },
   "overrides": {
     "serialize-javascript": ">=7.0.5",
-    "fast-xml-parser": ">=5.5.6"
+    "fast-xml-parser": ">=5.5.6",
+    "form-data": ">=4.0.6"
   },
   "resolutions": {
     "minimist": "1.2.6",


### PR DESCRIPTION
## What

- CVE-2026-12143: CRLF injection in form-data via unescaped multipart field names and filenames. Adds an explicit override to ensure form-data cannot resolve below 4.0.6 where the fix was released. The lockfile already resolved to 4.0.6 but the override makes the floor explicit to prevent regression.

## How to review

1. Code Review