### PR TITLE
AUT-5522: Set mfaRequired in authorize

### DIFF
--- a/src/components/authorize/authorize-controller.ts
+++ b/src/components/authorize/authorize-controller.ts
@@ -260,6 +260,7 @@ function setSessionDataFromAuthResponse(
   if (startAuthResponse.data.featureFlags) {
     req.session.user.featureFlags = startAuthResponse.data.featureFlags;
   }
+  req.session.user.isMfaRequired = startAuthResponse.data.user.mfaRequired;
 }
 
 function validateQueryParams(clientId: string, responseType: string) {

--- a/src/components/authorize/tests/authorize-controller.test.ts
+++ b/src/components/authorize/tests/authorize-controller.test.ts
@@ -599,6 +599,25 @@ describe("authorize controller", () => {
     )(req as Request, res as Response);
     expect(req.session.user.channel).to.eq("web");
   });
+
+  [true, false].forEach((mfaRequired) => {
+    it(`should set isMfaRequired to ${mfaRequired} in session`, async () => {
+      authServiceResponseData.data.user = {
+        mfaRequired,
+      };
+      fakeAuthorizeService = mockAuthService(authServiceResponseData);
+
+      await authorizeGet(
+        fakeAuthorizeService,
+        fakeCookieConsentService,
+        fakeKmsDecryptionService,
+        fakeJwtService
+      )(req as Request, res as Response);
+
+      expect(req.session.user.isMfaRequired).to.eq(mfaRequired);
+    });
+  });
+
   function mockAuthService(authResponseData: any): AuthorizeServiceInterface {
     return {
       start: sinon.fake.returns({

--- a/src/components/authorize/types.ts
+++ b/src/components/authorize/types.ts
@@ -40,6 +40,7 @@ export interface UserSessionInfo {
   gaCrossDomainTrackingId?: string;
   mfaMethodType?: MFA_METHOD_TYPE;
   isBlockedForReauth: boolean;
+  mfaRequired?: boolean;
 }
 
 export interface AuthorizeServiceInterface {

--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -173,6 +173,12 @@ export function enterPasswordPost(
 
     const isPasswordChangeRequired = userLogin.data.passwordChangeRequired;
 
+    if (req.session.user.isMfaRequired !== userLogin.data.mfaRequired) {
+      req.log.info(
+        `isMfaRequired is ${req.session.user.isMfaRequired} but mfaRequired from /login is ${userLogin.data.mfaRequired}`
+      );
+    }
+
     req.session.user.mfaMethods = userLogin.data.mfaMethods;
     req.session.user.activeMfaMethodId = userLogin.data.mfaMethods.find(
       (method: MfaMethod) => method.priority === MfaMethodPriority.DEFAULT


### PR DESCRIPTION
## What

For passkeys, we need to know the `mfaRequired` flag earlier in the journey. This is so that we can display dynamic content on the cannot-sign-in-with-passkey page. However, we currently make this call in the `enter-password-controller` to the `/login` endpoint. 

This PR covers requesting the new `mfaRequired` flag in the authorize-controller and setting it in the frontend session. However, this PR doesn't remove any of the existing functionality in the enter-password-controller as that could affect existing sessions. Therefore, the plan is to first roll the changes out on this PR, then follow up with a subsequent PR to stop requesting the `mfaRequired` in the `enter-password-controller` and instead use the value directly from the session.

## How to review

1. Code review
2. Deploy to dev env and check that you don't see the added log and that journeys work as normal

