### PR TITLE
AUT-5522: Stop setting isMfaRequired in enter password

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -173,17 +173,10 @@ export function enterPasswordPost(
 
     const isPasswordChangeRequired = userLogin.data.passwordChangeRequired;
 
-    if (req.session.user.isMfaRequired !== userLogin.data.mfaRequired) {
-      req.log.info(
-        `isMfaRequired is ${req.session.user.isMfaRequired} but mfaRequired from /login is ${userLogin.data.mfaRequired}`
-      );
-    }
-
     req.session.user.mfaMethods = userLogin.data.mfaMethods;
     req.session.user.activeMfaMethodId = userLogin.data.mfaMethods.find(
       (method: MfaMethod) => method.priority === MfaMethodPriority.DEFAULT
     )?.id;
-    req.session.user.isMfaRequired = userLogin.data.mfaRequired;
     req.session.user.isAccountPartCreated = !userLogin.data.mfaMethodVerified;
     req.session.user.isLatestTermsAndConditionsAccepted =
       userLogin.data.latestTermsAndConditionsAccepted;
@@ -207,7 +200,7 @@ export function enterPasswordPost(
     req.session.user.isSignInJourney = true;
 
     if (
-      userLogin.data.mfaRequired &&
+      req.session.user.isMfaRequired &&
       userLogin.data.mfaMethodVerified &&
       userLogin.data.mfaMethodType === MFA_METHOD_TYPE.SMS &&
       !isPasswordChangeRequired

--- a/src/components/enter-password/tests/enter-password-controller.test.ts
+++ b/src/components/enter-password/tests/enter-password-controller.test.ts
@@ -39,7 +39,7 @@ describe("enter password controller", () => {
   beforeEach(() => {
     req = createMockRequest(PATH_NAMES.ENTER_PASSWORD);
     res = mockResponse();
-    req.session.user = { email };
+    req.session.user = { email, isMfaRequired: true };
     process.env.SUPPORT_ACCOUNT_INTERVENTIONS = "1";
   });
 
@@ -67,7 +67,6 @@ describe("enter password controller", () => {
           loginUser: sinon.fake.returns({
             data: {
               redactedPhoneNumber: "3456",
-              mfaRequired: true,
               latestTermsAndConditionsAccepted: true,
               mfaMethodVerified: true,
               mfaMethodType: "SMS",
@@ -101,7 +100,6 @@ describe("enter password controller", () => {
           loginUser: sinon.fake.returns({
             data: {
               redactedPhoneNumber: "3456",
-              mfaRequired: true,
               latestTermsAndConditionsAccepted: true,
               mfaMethodVerified: true,
               mfaMethodType: "SMS",
@@ -125,7 +123,7 @@ describe("enter password controller", () => {
           journey.getJourneyTypeFromUserSession
         );
 
-        req.session.user = { email, reauthenticate: "test_data" };
+        req.session.user = { ...req.session.user, reauthenticate: "test_data" };
 
         const { enterPasswordPost: mockEnterPasswordPost } = await esmock(
           "../enter-password-controller.js",
@@ -252,7 +250,6 @@ describe("enter password controller", () => {
         loginUser: sinon.fake.returns({
           data: {
             redactedPhoneNumber: "3456",
-            mfaRequired: true,
             latestTermsAndConditionsAccepted: true,
             mfaMethodVerified: true,
             mfaMethodType: "SMS",
@@ -325,7 +322,6 @@ describe("enter password controller", () => {
         loginUser: sinon.fake.returns({
           data: {
             redactedPhoneNumber: "3456",
-            mfaRequired: true,
             latestTermsAndConditionsAccepted: true,
             mfaMethodVerified: true,
             mfaMethodType: "SMS",
@@ -366,7 +362,6 @@ describe("enter password controller", () => {
           loginUser: sinon.fake.returns({
             data: {
               redactedPhoneNumber: "3456",
-              mfaRequired: true,
               latestTermsAndConditionsAccepted: true,
               mfaMethodVerified: true,
               mfaMethodType: "SMS",
@@ -421,7 +416,6 @@ describe("enter password controller", () => {
           loginUser: sinon.fake.returns({
             data: {
               redactedPhoneNumber: "3456",
-              mfaRequired: true,
               latestTermsAndConditionsAccepted: true,
               mfaMethodVerified: true,
               mfaMethodType: "SMS",
@@ -485,12 +479,12 @@ describe("enter password controller", () => {
     });
 
     it("should redirect to auth code when mfa is not required", async () => {
+      req.session.user.isMfaRequired = false;
       const fakeService: EnterPasswordServiceInterface = {
         loginUser: sinon.fake.returns({
           success: true,
           data: {
             redactedPhoneNumber: "3456",
-            mfaRequired: false,
             mfaMethodVerified: true,
             mfaMethodType: "SMS",
             mfaMethods: buildMfaMethods({
@@ -536,6 +530,7 @@ describe("enter password controller", () => {
     });
 
     it("should redirect to updated terms when terms and conditions not accepted", async () => {
+      req.session.user.isMfaRequired = false;
       const fakeService: EnterPasswordServiceInterface = {
         loginUser: sinon.fake.returns({
           data: {
@@ -591,7 +586,6 @@ describe("enter password controller", () => {
         loginUser: sinon.fake.returns({
           data: {
             redactedPhoneNumber: "3456",
-            mfaRequired: true,
             latestTermsAndConditionsAccepted: true,
             mfaMethodVerified: true,
             mfaMethodType: "SMS",

--- a/src/components/enter-password/tests/enter-password-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-integration.test.ts
@@ -52,6 +52,10 @@ describe("Integration::enter password", () => {
               req.session.user.journey.nextPath = PATH_NAMES.ENTER_PASSWORD;
             }
 
+            if (process.env.TEST_MFA_JOURNEY === "1") {
+              req.session.user.isMfaRequired = true;
+            }
+
             capturedSession = req.session;
 
             next();
@@ -75,6 +79,7 @@ describe("Integration::enter password", () => {
   });
 
   beforeEach(() => {
+    process.env.TEST_MFA_JOURNEY = "0";
     nock.cleanAll();
   });
 
@@ -133,7 +138,6 @@ describe("Integration::enter password", () => {
       .post(API_ENDPOINTS.LOG_IN_USER)
       .once()
       .reply(200, {
-        mfaRequired: false,
         mfaMethodType: "SMS",
         mfaMethods: buildMfaMethods({
           id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
@@ -157,11 +161,11 @@ describe("Integration::enter password", () => {
   });
 
   it("should redirect to /enter-code when password is correct (VTR Cl.Cm)", async () => {
+    process.env.TEST_MFA_JOURNEY = "1";
     nock(baseApi)
       .post(API_ENDPOINTS.LOG_IN_USER)
       .once()
       .reply(200, {
-        mfaRequired: true,
         mfaMethodType: "SMS",
         mfaMethods: buildMfaMethods({
           id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
@@ -190,7 +194,6 @@ describe("Integration::enter password", () => {
       .post(API_ENDPOINTS.LOG_IN_USER)
       .once()
       .reply(200, {
-        mfaRequired: false,
         mfaMethodType: "SMS",
         mfaMethods: buildMfaMethods({
           id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
@@ -216,11 +219,11 @@ describe("Integration::enter password", () => {
   });
 
   it("should redirect to /reset-password-2fa-sms when password is correct and user's MFA is set to SMS when 2FA is required", async () => {
+    process.env.TEST_MFA_JOURNEY = "1";
     nock(baseApi)
       .post(API_ENDPOINTS.LOG_IN_USER)
       .once()
       .reply(200, {
-        mfaRequired: true,
         mfaMethodType: "SMS",
         mfaMethods: buildMfaMethods({
           id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
@@ -263,12 +266,12 @@ describe("Integration::enter password", () => {
   });
 
   it("should redirect to cannot-use-security-code page when mfa returns indefinite international SMS block error", async () => {
+    process.env.TEST_MFA_JOURNEY = "1";
     nock(baseApi)
       .post(API_ENDPOINTS.LOG_IN_USER)
       .once()
       .reply(200, {
         success: true,
-        mfaRequired: true,
         mfaMethodVerified: true,
         mfaMethodType: "SMS",
         mfaMethods: buildMfaMethods({ redactedPhoneNumber: "1234" }),

--- a/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
+++ b/src/components/enter-password/tests/enter-password-reauth-integration.test.ts
@@ -47,6 +47,10 @@ describe("Integration::enter password", () => {
               redirectUri: REDIRECT_URI,
             };
 
+            if (process.env.TEST_MFA_JOURNEY === "1") {
+              req.session.user.isMfaRequired = true;
+            }
+
             next();
           }),
         },
@@ -69,6 +73,7 @@ describe("Integration::enter password", () => {
   });
 
   beforeEach(() => {
+    process.env.TEST_MFA_JOURNEY = "0";
     nock.cleanAll();
   });
 
@@ -127,7 +132,6 @@ describe("Integration::enter password", () => {
       .post(API_ENDPOINTS.LOG_IN_USER)
       .once()
       .reply(200, {
-        mfaRequired: false,
         mfaMethodType: "SMS",
         mfaMethods: buildMfaMethods({
           id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",
@@ -151,11 +155,11 @@ describe("Integration::enter password", () => {
   });
 
   it("should redirect to /enter-code when password is correct (VTR Cl.Cm)", async () => {
+    process.env.TEST_MFA_JOURNEY = "1";
     nock(baseApi)
       .post(API_ENDPOINTS.LOG_IN_USER)
       .once()
       .reply(200, {
-        mfaRequired: true,
         mfaMethodType: "SMS",
         mfaMethods: buildMfaMethods({
           id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",

--- a/src/components/enter-password/types.ts
+++ b/src/components/enter-password/types.ts
@@ -8,7 +8,6 @@ import type { Request } from "express";
 
 export interface UserLoginResponse extends DefaultApiResponse {
   redactedPhoneNumber?: string;
-  mfaRequired?: boolean;
   latestTermsAndConditionsAccepted?: boolean;
   mfaMethodType?: MFA_METHOD_TYPE;
   mfaMethodVerified?: boolean;

--- a/src/components/reset-password/tests/reset-password-controller.test.ts
+++ b/src/components/reset-password/tests/reset-password-controller.test.ts
@@ -86,7 +86,6 @@ describe("reset password controller (in 6 digit code flow)", () => {
         redactedPhoneNumber: "1234",
         latestTermsAndConditionsAccepted: true,
         mfaMethodVerified: verified,
-        mfaRequired: true,
         passwordChangeRequired: passwordChangeRequired,
       };
       const data = mfaMethodType ? { ...baseData, mfaMethodType } : baseData;

--- a/src/components/reset-password/tests/reset-password-integration.test.ts
+++ b/src/components/reset-password/tests/reset-password-integration.test.ts
@@ -268,7 +268,6 @@ describe("Integration::reset password (in 6 digit code flow)", () => {
       .post("/login")
       .once()
       .reply(200, {
-        mfaRequired: true,
         mfaMethodType: "SMS",
         mfaMethods: buildMfaMethods({
           id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7a3a03d7",


### PR DESCRIPTION
## What

Following [this PR](https://github.com/govuk-one-login/authentication-frontend/pull/3459) to start setting the `isMfaRequired` session property in the /authorize, I have monitored logs and this seems to be getting set correctly. 

Now, we can stop getting this property from the response from `/login` and setting `isMfaRequired` in `/enter-password` and instead use the existing variable from the session

## How to review

1. Code review
2. Deploy to a dev env and check that enter-password still takes you to either enter-code or enter-authenticator-app-code (depending on the type of authenticator)

## Checklist

