### PR TITLE
AUT-5000: Retry and fallback options from we could not sign you in page

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -38,6 +38,7 @@ ANALYTICS_COOKIE_DOMAIN=localhost
 VITAL_SIGNS_INTERVAL_SECONDS=360
 
 # Dependency config
+API_BASE_URL=http://localhost:4402
 FRONTEND_API_BASE_URL=http://localhost:4402/
 # This key is only for use in insecure local environments
 # It matches the public key in the local orchestrator stub

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -677,7 +677,7 @@ Mappings:
     dev:
       tags: >-
         @UI and not (@AccountInterventions or @Reauth or @old-mfa-without-ipv or
-        @AccountRecovery or @InternationalSmsSendingDisabled or @PasskeyUsageEnabled)
+        @AccountRecovery or @InternationalSmsSendingDisabled)
         and not (@InternationalNumbersIndefiniteLockout and @under-development)
     build:
       tags: >-

--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
@@ -5,6 +5,7 @@ import { passkeyService } from "../common/passkey/passkey-service.js";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
+import { PATH_NAMES } from "../../app.constants.js";
 
 export function cannotSignInPasskeyGet(
   service: PasskeyServiceInterface = passkeyService()
@@ -47,10 +48,10 @@ export function cannotSignInPasskeyPost(
     );
 
     if (!finishPasskeyAssertionResult.success) {
-      // TODO - AUT-5000 - Handle error case
-      throw new Error(
-        `FinishPasskeyAssertionError: ${finishPasskeyAssertionResult.data.message}`
+      req.log.info(
+        `Failed to retry sign in with passkey due to FinishPasskeyAssertionError: ${finishPasskeyAssertionResult.data.message}`
       );
+      return res.redirect(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);
     }
 
     return res.redirect(

--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
@@ -3,6 +3,7 @@ import type { ExpressRouteFunc } from "../../types.js";
 import type { PasskeyServiceInterface } from "../common/passkey/types.js";
 import { passkeyService } from "../common/passkey/passkey-service.js";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
+import { CANNOT_SIGN_IN_PASSKEY_ACTION } from "./types.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 import { USER_JOURNEY_EVENTS } from "../common/state-machine/state-machine.js";
 import { PATH_NAMES } from "../../app.constants.js";
@@ -38,6 +39,21 @@ export function cannotSignInPasskeyPost(
   return async function (req: Request, res: Response) {
     const authenticationResponse: AuthenticationResponseJSON =
       req.body.authenticationResponse;
+    const cannotSignInPasskeyAction: CANNOT_SIGN_IN_PASSKEY_ACTION =
+      req.body["cannot-sign-in-passkey-action"];
+
+    if (
+      cannotSignInPasskeyAction ===
+      CANNOT_SIGN_IN_PASSKEY_ACTION.SIGN_IN_WITHOUT_PASSKEY
+    ) {
+      return res.redirect(
+        await getNextPathAndUpdateJourney(
+          req,
+          res,
+          USER_JOURNEY_EVENTS.SIGN_IN_WITHOUT_PASSKEY
+        )
+      );
+    }
 
     const finishPasskeyAssertionResult = await service.finishPasskeyAssertion(
       res.locals.sessionId,

--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-routes.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-routes.ts
@@ -7,6 +7,7 @@ import {
   cannotSignInPasskeyPost,
 } from "./cannot-sign-in-passkey-controller.js";
 import { validateCannotSignInPasskeyRequest } from "./cannot-sign-in-passkey-validation.js";
+import { goBackMiddleware } from "../../middleware/go-back-middleware.js";
 
 const router = express.Router();
 
@@ -14,6 +15,7 @@ router.get(
   PATH_NAMES.CANNOT_SIGN_IN_PASSKEY,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
+  goBackMiddleware,
   cannotSignInPasskeyGet()
 );
 

--- a/src/components/cannot-sign-in-passkey/index.njk
+++ b/src/components/cannot-sign-in-passkey/index.njk
@@ -35,9 +35,9 @@
           id: "retry-passkey"
         },
         {
-          value: "sign-in-with-password",
+          value: "sign-in-without-passkey",
           text: ( 'pages.cannotSignInPasskey.radios.signInWithPasswordMfaOption' if is2FAJourney else 'pages.cannotSignInPasskey.radios.signInWithPasswordOption' ) | translate,
-          id: "sign-in-with-password"
+          id: "sign-in-without-passkey"
         }
       ],
       errorMessage: {

--- a/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-controller.test.ts
+++ b/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-controller.test.ts
@@ -13,6 +13,7 @@ import {
 import { sinon } from "../../../../test/utils/test-utils.js";
 import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
 import type { PasskeyServiceInterface } from "../../common/passkey/types.js";
+import { CANNOT_SIGN_IN_PASSKEY_ACTION } from "../types.js";
 
 describe("cannot sign in passkey controller", () => {
   let req: RequestOutput;
@@ -118,6 +119,26 @@ describe("cannot sign in passkey controller", () => {
         expect(res.redirect).to.have.been.calledWith(PATH_NAMES.AUTH_CODE);
       });
 
+      it("should redirect to enter-password when user selects sign in without passkey option", async () => {
+        req.body["cannot-sign-in-passkey-action"] =
+          CANNOT_SIGN_IN_PASSKEY_ACTION.SIGN_IN_WITHOUT_PASSKEY;
+
+        const fakePasskeyService = {
+          finishPasskeyAssertion: sinon.fake.returns({
+            success: true,
+          }),
+        } as unknown as PasskeyServiceInterface;
+
+        await cannotSignInPasskeyPost(fakePasskeyService)(
+          req as Request,
+          res as Response
+        );
+
+        expect(fakePasskeyService.finishPasskeyAssertion).to.not.have.been
+          .called;
+        expect(res.redirect).to.have.been.calledWith(PATH_NAMES.ENTER_PASSWORD);
+      });
+
       it("should pass the authenticationResponse from the request body to finishPasskeyAssertion", async () => {
         const authenticationResponse = {
           signedChallenge: "challenge",
@@ -158,7 +179,9 @@ describe("cannot sign in passkey controller", () => {
           res as Response
         );
 
-        expect(res.redirect).to.have.been.calledWith(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
+        expect(res.redirect).to.have.been.calledWith(
+          PATH_NAMES.CANNOT_SIGN_IN_PASSKEY
+        );
       });
     });
   });

--- a/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-controller.test.ts
+++ b/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-controller.test.ts
@@ -145,7 +145,7 @@ describe("cannot sign in passkey controller", () => {
         );
       });
 
-      it("should throw an error when finishPasskeyAssertion returns unsuccessful", async () => {
+      it("should redirect back to cannot-sign-in-passkey when finishPasskeyAssertion returns unsuccessful", async () => {
         const fakePasskeyService = {
           finishPasskeyAssertion: sinon.fake.returns({
             success: false,
@@ -153,16 +153,12 @@ describe("cannot sign in passkey controller", () => {
           }),
         } as unknown as PasskeyServiceInterface;
 
-        await assert.rejects(
-          async () =>
-            cannotSignInPasskeyPost(fakePasskeyService)(
-              req as Request,
-              res as Response
-            ),
-          Error,
-          "FinishPasskeyAssertionError: Session expired"
+        await cannotSignInPasskeyPost(fakePasskeyService)(
+          req as Request,
+          res as Response
         );
-        expect(res.redirect).to.not.have.been.called;
+
+        expect(res.redirect).to.have.been.calledWith(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
       });
     });
   });

--- a/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
+++ b/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
@@ -7,6 +7,7 @@ import { getPermittedJourneyForPath } from "../../../../test/helpers/session-hel
 import { extractCsrfTokenAndCookies } from "../../../../test/helpers/csrf-helper.js";
 import esmock from "esmock";
 import * as cheerio from "cheerio";
+import type { UserSession } from "../../../types.js";
 import nock from "nock";
 import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
 import { CANNOT_SIGN_IN_PASSKEY_ACTION } from "../types.js";
@@ -14,10 +15,11 @@ import { CANNOT_SIGN_IN_PASSKEY_ACTION } from "../types.js";
 describe("Integration:: cannot sign in passkey", () => {
   let app: any;
   let baseApi: string;
+  let capturedSession: UserSession;
 
   before(async () => {
     process.env.SUPPORT_PASSKEY_USAGE = "1";
-    process.env.SUPPORT_PASSKEY_REGISTRATION = "1"
+    process.env.SUPPORT_PASSKEY_REGISTRATION = "1";
 
     const { createApp } = await esmock(
       "../../../app.js",
@@ -39,6 +41,8 @@ describe("Integration:: cannot sign in passkey", () => {
                 PATH_NAMES.CANNOT_SIGN_IN_PASSKEY
               ),
             };
+
+            capturedSession = req.session.user;
 
             next();
           }),
@@ -117,10 +121,30 @@ describe("Integration:: cannot sign in passkey", () => {
           .send({
             _csrf: token,
             authenticationResponse: commonVariables.passkeyAssertionResponse,
-            "cannot-sign-in-passkey-action": "retry-passkey",
+            "cannot-sign-in-passkey-action":
+              CANNOT_SIGN_IN_PASSKEY_ACTION.RETRY_PASSKEY,
           })
           .expect(302)
           .expect("Location", PATH_NAMES.AUTH_CODE);
+      });
+
+      it("should redirect to enter-password and save cannot-sign-in-passkey in goBackHistory when user selects sign in without passkey option", async () => {
+        await request(app)
+          .post(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            _csrf: token,
+            authenticationResponse: commonVariables.passkeyAssertionResponse,
+            "cannot-sign-in-passkey-action":
+              CANNOT_SIGN_IN_PASSKEY_ACTION.SIGN_IN_WITHOUT_PASSKEY,
+          })
+          .expect(302)
+          .expect("Location", PATH_NAMES.ENTER_PASSWORD);
+
+        expect(capturedSession.journey.goBackHistory).to.deep.equal([
+          PATH_NAMES.CANNOT_SIGN_IN_PASSKEY,
+        ]);
       });
     });
 
@@ -137,7 +161,8 @@ describe("Integration:: cannot sign in passkey", () => {
           .set("Cookie", cookies)
           .send({
             authenticationResponse: commonVariables.passkeyAssertionResponse,
-            "cannot-sign-in-passkey-action": "retry-passkey",
+            "cannot-sign-in-passkey-action":
+              CANNOT_SIGN_IN_PASSKEY_ACTION.RETRY_PASSKEY,
           })
           .expect(403);
       });
@@ -155,7 +180,8 @@ describe("Integration:: cannot sign in passkey", () => {
           .send({
             _csrf: token,
             authenticationResponse: commonVariables.passkeyAssertionResponse,
-            "cannot-sign-in-passkey-action": CANNOT_SIGN_IN_PASSKEY_ACTION.RETRY_PASSKEY,
+            "cannot-sign-in-passkey-action":
+              CANNOT_SIGN_IN_PASSKEY_ACTION.RETRY_PASSKEY,
           })
           .expect(302)
           .expect("Location", PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);

--- a/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
+++ b/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
@@ -9,6 +9,7 @@ import esmock from "esmock";
 import * as cheerio from "cheerio";
 import nock from "nock";
 import { commonVariables } from "../../../../test/helpers/common-test-variables.js";
+import { CANNOT_SIGN_IN_PASSKEY_ACTION } from "../types.js";
 
 describe("Integration:: cannot sign in passkey", () => {
   let app: any;
@@ -16,6 +17,7 @@ describe("Integration:: cannot sign in passkey", () => {
 
   before(async () => {
     process.env.SUPPORT_PASSKEY_USAGE = "1";
+    process.env.SUPPORT_PASSKEY_REGISTRATION = "1"
 
     const { createApp } = await esmock(
       "../../../app.js",
@@ -138,6 +140,25 @@ describe("Integration:: cannot sign in passkey", () => {
             "cannot-sign-in-passkey-action": "retry-passkey",
           })
           .expect(403);
+      });
+
+      it("should redirect to cannot-sign-in-passkey when finishPasskeyAssertion fails", async () => {
+        nock(baseApi)
+          .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
+          .once()
+          .reply(400, { success: false, code: 0 });
+
+        await request(app)
+          .post(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            _csrf: token,
+            authenticationResponse: commonVariables.passkeyAssertionResponse,
+            "cannot-sign-in-passkey-action": CANNOT_SIGN_IN_PASSKEY_ACTION.RETRY_PASSKEY,
+          })
+          .expect(302)
+          .expect("Location", PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);
       });
 
       it("should return a validation error when no option is selected", async () => {

--- a/src/components/cannot-sign-in-passkey/types.ts
+++ b/src/components/cannot-sign-in-passkey/types.ts
@@ -1,0 +1,4 @@
+export enum CANNOT_SIGN_IN_PASSKEY_ACTION {
+  SIGN_IN_WITHOUT_PASSKEY = "sign-in-without-passkey",
+  RETRY_PASSKEY = "retry-passkey",
+}

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -81,6 +81,7 @@ const USER_JOURNEY_EVENTS = {
   PASSKEY_VERIFICATION_SUCCESSFUL: "PASSKEY_VERIFICATION_SUCCESSFUL",
   PASSKEY_VERIFICATION_FAILED: "PASSKEY_VERIFICATION_FAILED",
   SIGN_IN_WITH_PASSKEY: "SIGN_IN_WITH_PASSKEY",
+  SIGN_IN_WITHOUT_PASSKEY: "SIGN_IN_WITHOUT_PASSKEY",
 };
 
 export interface AuthStateContext {
@@ -373,6 +374,12 @@ const authStateMachine = createMachine<AuthStateContext>(
           [USER_JOURNEY_EVENTS.PASSKEY_VERIFICATION_SUCCESSFUL]: [
             {
               target: [INTERMEDIATE_STATES.SIGN_IN_END],
+            },
+          ],
+          [USER_JOURNEY_EVENTS.SIGN_IN_WITHOUT_PASSKEY]: [
+            {
+              target: [PATH_NAMES.ENTER_PASSWORD],
+              meta: { reversible: true },
             },
           ],
         },


### PR DESCRIPTION
## What

- If retrying to sign in with a passkey fails, redirect them back to `cannot-sign-in-passkey` so they can retry signing in
- If the user wants to sign in with their password/mfa, when they click the radio to do so, they should are redirect to `enter-password`
- When they click back from `enter-password`, they are taken back to `cannot-sign-in-passkey`

## How to review

1. Code review
2. Test this in a dev env - focusing on the back functionality

## Checklist

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [ ] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [ ] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->
