### PR TITLE
AUT-5569  Ithc ec2 lacking ebs encryption and httptoken metadata

### DIFF
--- a/cloudformation/bastion/bastion-host.yaml
+++ b/cloudformation/bastion/bastion-host.yaml
@@ -121,13 +121,19 @@ Resources:
   BastionInstanceAuthdev1:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: ami-0a3a2f225ee59368f # Amazon Linux 2023 ARM64
+      ImageId: ami-0ab33fafe62fa3f9a # Amazon Linux 2023 ARM64
       InstanceType: !Ref InstanceType
       SubnetId:
         Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
       SecurityGroupIds:
         - !Ref BastionSecurityGroup
       IamInstanceProfile: !Ref SSMInstanceProfileAuthdev1
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            Encrypted: true
+      Monitoring: true
+      EbsOptimized: true
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
@@ -218,13 +224,19 @@ Resources:
   BastionInstanceAuthdev2:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: ami-0a3a2f225ee59368f # Amazon Linux 2023 ARM64
+      ImageId: ami-0ab33fafe62fa3f9a # Amazon Linux 2023 ARM64
       InstanceType: !Ref InstanceType
       SubnetId:
         Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
       SecurityGroupIds:
         - !Ref BastionSecurityGroup
       IamInstanceProfile: !Ref SSMInstanceProfileAuthdev2
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            Encrypted: true
+      Monitoring: true
+      EbsOptimized: true
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
@@ -315,13 +327,19 @@ Resources:
   BastionInstanceDev:
     Type: AWS::EC2::Instance
     Properties:
-      ImageId: ami-0a3a2f225ee59368f # Amazon Linux 2023 ARM64
+      ImageId: ami-0ab33fafe62fa3f9a # Amazon Linux 2023 ARM64
       InstanceType: !Ref InstanceType
       SubnetId:
         Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
       SecurityGroupIds:
         - !Ref BastionSecurityGroup
       IamInstanceProfile: !Ref SSMInstanceProfileDev
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            Encrypted: true
+      Monitoring: true
+      EbsOptimized: true
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash

--- a/cloudformation/bastion/bastion-host.yaml
+++ b/cloudformation/bastion/bastion-host.yaml
@@ -134,6 +134,8 @@ Resources:
             Encrypted: true
       Monitoring: true
       EbsOptimized: true
+      MetadataOptions:
+        HttpTokens: required
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
@@ -237,6 +239,8 @@ Resources:
             Encrypted: true
       Monitoring: true
       EbsOptimized: true
+      MetadataOptions:
+        HttpTokens: required
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash
@@ -340,6 +344,8 @@ Resources:
             Encrypted: true
       Monitoring: true
       EbsOptimized: true
+      MetadataOptions:
+        HttpTokens: required
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash


### PR DESCRIPTION
## What

AUT-5569 : Enable EBS encryption on bastion host and Also Enable httptoken ec2 metadata to fix Ithc finding 

## How to review
1. Code Review


## Local frontend tested after Ec2 changes  
<img width="1299" height="829" alt="image" src="https://github.com/user-attachments/assets/be8a5323-358a-43ea-90e2-4160cb4f0a44" />
