### PR TITLE
AUT-5522: Pass mfaRequired into the cannot-sign-in-passkey template to render the different content

### DIFF
--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
@@ -27,6 +27,7 @@ export function cannotSignInPasskeyGet(
 
     res.render("cannot-sign-in-passkey/index.njk", {
       authenticationOptions: JSON.stringify(authenticationOptions.publicKey),
+      is2FAJourney: req.session.user.isMfaRequired,
     });
   };
 }

--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-validation.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-validation.ts
@@ -1,6 +1,7 @@
 import type { ValidationChainFunc } from "../../types.js";
 import { body } from "express-validator";
 import { validateBodyMiddleware } from "../../middleware/form-validation-middleware.js";
+import type { Request } from "express";
 
 export function validateCannotSignInPasskeyRequest(): ValidationChainFunc {
   return [
@@ -11,6 +12,17 @@ export function validateCannotSignInPasskeyRequest(): ValidationChainFunc {
           value,
         });
       }),
-    validateBodyMiddleware("cannot-sign-in-passkey/index.njk"),
+    validateBodyMiddleware(
+      "cannot-sign-in-passkey/index.njk",
+      postValidationLocals
+    ),
   ];
 }
+
+const postValidationLocals = function locals(
+  req: Request
+): Record<string, unknown> {
+  return {
+    is2FAJourney: req.session.user.isMfaRequired,
+  };
+};

--- a/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-controller.test.ts
+++ b/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-controller.test.ts
@@ -56,8 +56,36 @@ describe("cannot sign in passkey controller", () => {
 
       expect(res.render).to.have.been.calledWith(
         "cannot-sign-in-passkey/index.njk",
-        { authenticationOptions: JSON.stringify(mockData.publicKey) }
+        {
+          authenticationOptions: JSON.stringify(mockData.publicKey),
+          is2FAJourney: undefined,
+        }
       );
+    });
+
+    [true, false].forEach((isMfaRequired) => {
+      it(`should pass is2FAJourney as ${isMfaRequired} when session isMfaRequired is ${isMfaRequired}`, async () => {
+        req.session.user.isMfaRequired = isMfaRequired;
+
+        const fakePasskeyService = {
+          startPasskeyAssertion: sinon.fake.returns({
+            success: true,
+            data: {
+              publicKey: { challenge: "dGVzdA" },
+            },
+          }),
+        } as unknown as PasskeyServiceInterface;
+
+        await cannotSignInPasskeyGet(fakePasskeyService)(
+          req as Request,
+          res as Response
+        );
+
+        expect(res.render).to.have.been.calledWith(
+          "cannot-sign-in-passkey/index.njk",
+          sinon.match({ is2FAJourney: isMfaRequired })
+        );
+      });
     });
 
     it("should pass the correct session IDs to the passkey service", async () => {


### PR DESCRIPTION
## What

Now that we are setting `isMfaRequired` in the `/authorize` we can pass this value into the cannot-sign-in-passkey template in order to render the dynamic content for whether to sign in with password or password and security code.

## How to review

1. Code review
2. Deploy to a dev env and go down a passkey sign in journey on both a 1fa and 2fa journey. When it comes to the sign in prompt, cancel and check that the content you see matches the authentication factor journey
  - Either "Sign in with your password"
  - "Sign in with your password and a security code"

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [x] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->



<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
