### PR TITLE
BAU: Bump dompurify to 3.4.11 to fix multiple CVEs

### DIFF
--- a/journey-map/package-lock.json
+++ b/journey-map/package-lock.json
@@ -49,7 +49,7 @@
         "connect-dynamodb": "3.0.5",
         "cookie-parser": "1.4.7",
         "csrf-sync": "4.2.1",
-        "dompurify": "3.4.8",
+        "dompurify": "3.4.11",
         "express": "5.2.1",
         "express-session": "1.19.0",
         "express-validator": "7.3.2",
@@ -82,7 +82,7 @@
         "@types/express": "5.0.6",
         "@types/express-session": "1.19.0",
         "@types/i18next-fs-backend": "1.2.0",
-        "@types/jsdom": "21.1.7",
+        "@types/jsdom": "28.0.3",
         "@types/mocha": "10.0.10",
         "@types/mock-req-res": "1.1.6",
         "@types/node": "24.12.3",
@@ -2384,9 +2384,9 @@
       "link": true
     },
     "node_modules/dompurify": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/journey-map/package.json
+++ b/journey-map/package.json
@@ -38,7 +38,7 @@
   },
   "overrides": {
     "lodash-es": "4.18.1",
-    "dompurify": ">=3.4.0",
+    "dompurify": ">=3.4.11",
     "uuid": ">=11.1.1"
   }
 }


### PR DESCRIPTION
## What

- Bumps the dompurify override in journey-map from >=3.4.0 to >=3.4.11 to fix:
  - CVE-2026-49978: IN_PLACE Sanitization Bypass via Attached Shadow Root
  - CVE-2026-49458: Cross-realm IN_PLACE sanitization bypass
  - CVE-2026-49459: IN_PLACE mode preserves attributes of clobbered root element
  - GHSA (no CVE): Hook mutation pollutes DEFAULT_ALLOWED_TAGS
  - GHSA (no CVE): SAFE_FOR_TEMPLATES bypass inside \<template\> content
  - GHSA (no CVE): Trusted Types policy survives clearConfig()
  - GHSA (no CVE): Permanent ALLOWED_ATTR pollution via setConfig()
- Note: Alert 250 (IN_PLACE mode trusts attacker-controlled nodeName) has no patched version yet

## How to review

1. Code Review