### PR TITLE
BAU: Add js-yaml override to fix CVE-2026-53550

### DIFF
--- a/playwright-acceptance-tests/package-lock.json
+++ b/playwright-acceptance-tests/package-lock.json
@@ -2047,16 +2047,26 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.0.0.tgz",
+      "integrity": "sha512-GSvaPUbk1U+FMZ7rJzF+F8e5YVtu7KnD40et/5rBXXRBv2jCO9L3qCewvIDDdudC0QycTFlf6EAA+h3kxBsuUw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/json-buffer": {

--- a/playwright-acceptance-tests/package.json
+++ b/playwright-acceptance-tests/package.json
@@ -31,6 +31,7 @@
     "typescript": "5.9.3"
   },
   "overrides": {
-    "uuid": ">=11.1.1"
+    "uuid": ">=11.1.1",
+    "js-yaml": ">=4.2.0"
   }
 }


### PR DESCRIPTION
## What

- CVE-2026-53550: Quadratic-complexity DoS in merge key handling via repeated aliases
- Adds js-yaml >=4.2.0 override in playwright-acceptance-tests/package.json to force from vulnerable 4.1.1

## How to review

1. Code Review