### PR TITLE
AUT-5295: Update cookies page with amc cookies

### DIFF
--- a/src/components/common/cookies/index.njk
+++ b/src/components/common/cookies/index.njk
@@ -222,7 +222,27 @@
                     text: 'pages.cookiePolicy.essential.info.table.rows.row15.col2' | translate,
                     classes: 'govuk-body-s'
                 }
-            ]
+            ],
+           [
+               {
+                   text: "amc_sess",
+                   classes: 'govuk-body-s'
+               },
+               {
+                   text: 'pages.cookiePolicy.essential.info.table.rows.row16.col2' | translate,
+                   classes: 'govuk-body-s'
+               }
+           ],
+           [
+               {
+                   text: "amc",
+                   classes: 'govuk-body-s'
+               },
+               {
+                   text: 'pages.cookiePolicy.essential.info.table.rows.row17.col2' | translate,
+                   classes: 'govuk-body-s'
+               }
+           ]
         ]
     }) }}
 

--- a/src/locales/cy/translation.json
+++ b/src/locales/cy/translation.json
@@ -901,6 +901,12 @@
               },
               "row15": {
                 "col2": "Pan fyddwch yn cau eich porwr gwe"
+              },
+              "row16": {
+                "col2": "Pan fyddwch yn cau eich porwr gwe"
+              },
+              "row17": {
+                "col2": "Pan fyddwch yn cau eich porwr gwe"
               }
             }
           }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -901,6 +901,12 @@
               },
               "row15": {
                 "col2": "When you close your web browser"
+              },
+              "row16": {
+                "col2": "When you close your web browser"
+              },
+              "row17": {
+                "col2": "When you close your web browser"
               }
             }
           }


### PR DESCRIPTION
Passkeys work introduces calls to account management components (amc) which requires some amc specific cookies. Update the cookies policy with details of these.

Screenshots of page

| English | Welsh |
|-----|-----|
|<img width="636" height="794" alt="Screenshot 2026-06-23 at 10 02 09" src="https://github.com/user-attachments/assets/7a35a4c5-836d-45f4-baaf-3f339e7d1475" />|<img width="604" height="790" alt="Screenshot 2026-06-23 at 10 02 19" src="https://github.com/user-attachments/assets/243e65b7-9a9a-4870-9276-ad77012e262e" />|


