### PR TITLE
Aut 5503/remove route users to new ipv journey

### DIFF
--- a/cloudformation/deploy/readme.md
+++ b/cloudformation/deploy/readme.md
@@ -83,13 +83,13 @@ Authentication Frontend uses the [sub-environment feature](https://govukverify.a
 
 EnvironmentConfiguration maintains a **flat** mapping, authdev environments configuration are treated at the same level as environments, and **not nested**.
 
-**Example**: Now to enable MFA reset
+**Example**:
 
 Setting a condition
 
 ```Yaml
 Conditions:
-  UseMfaResetWithIpv:
+  UseMyFeatureFlag:
     Fn::Or:
       - Fn::And:
           - !Condition UseSubEnvironment
@@ -97,7 +97,7 @@ Conditions:
               - !FindInMap [
                   EnvironmentConfiguration,
                   !Ref SubEnvironment,
-                  UseMfaResetWithIpv,
+                  UseMyFeatureFlag,
                   DefaultValue: "No",
                 ]
               - "Yes"
@@ -107,7 +107,7 @@ Conditions:
               - !FindInMap [
                   EnvironmentConfiguration,
                   !Ref Environment,
-                  UseMfaResetWithIpv,
+                  UseMyFeatureFlag,
                   DefaultValue: "No",
                 ]
               - "Yes"
@@ -119,13 +119,13 @@ Configure at environment and sub-environment level
 Mappings:
   EnvironmentConfiguration:
     authdev1:
-      UseMfaResetWithIpv: "Yes"
+      UseMyFeatureFlag: "Yes"
     authdev2:
-      UseMfaResetWithIpv: "No"
+      UseMyFeatureFlag: "No"
     dev:
-      UseMfaResetWithIpv: "No"
+      UseMyFeatureFlag: "No"
     build:
-      UseMfaResetWithIpv: "No"
+      UseMyFeatureFlag: "No"
     staging:
-      UseMfaResetWithIpv: "Yes"
+      UseMyFeatureFlag: "Yes"
 ```

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -125,29 +125,6 @@ Conditions:
                     ]
                   - "Yes"
 
-  UseMfaResetWithIpv:
-    Fn::Or:
-      - Fn::And:
-          - !Condition UseSubEnvironment
-          - Fn::Equals:
-              - !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref SubEnvironment,
-                  UseMfaResetWithIpv,
-                  DefaultValue: "No",
-                ]
-              - "Yes"
-      - Fn::And:
-          - !Condition NotSubEnvironment
-          - Fn::Equals:
-              - !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  UseMfaResetWithIpv,
-                  DefaultValue: "No",
-                ]
-              - "Yes"
-
   UseSubEnvironment:
     Fn::And:
       - Fn::Equals:
@@ -432,7 +409,6 @@ Mappings:
         XK7CAYMcVvy1pP5yV4O2mnDjYmvjZpvio2ctgOPxDuBb38QP1HD9WAOR2w==
         -----END PUBLIC KEY-----
       migratedDomain: signin.authdev1.dev.account.gov.uk
-      UseMfaResetWithIpv: "Yes"
       Enableipvspinner: "No"
       PrivacyNoticeRedirectEnabled: "Yes"
       OrchApiBaseUrl: "https://oidc.authdev1.dev.account.gov.uk"
@@ -452,7 +428,6 @@ Mappings:
         tJwzOYNWUmK/+GxooRp+j9i9KWQ0WlV4gVI0iQkHY3ZKq+RWk94tSDHbyQ==
         -----END PUBLIC KEY-----
       migratedDomain: signin.authdev2.dev.account.gov.uk
-      UseMfaResetWithIpv: "Yes"
       Enableipvspinner: "No"
       PrivacyNoticeRedirectEnabled: "Yes"
       OrchApiBaseUrl: "https://oidc.authdev2.dev.account.gov.uk"
@@ -467,7 +442,6 @@ Mappings:
       cloudfrontDistributionStackName: "authdev3-cloudfront"
       frontendApiBaseUrl: https://y3s69ubaz5-vpce-0b907325ae3bfe3ce.execute-api.eu-west-2.amazonaws.com/authdev3/
       migratedDomain: signin.authdev3.dev.account.gov.uk
-      UseMfaResetWithIpv: "Yes"
       Enableipvspinner: "No"
       DeviceIntelligenceEnabled: "Yes"
       OrchApiBaseUrl: "https://oidc.authdev3.dev.account.gov.uk"
@@ -495,7 +469,6 @@ Mappings:
       IsSplunkEnabled: "No"
       SupportHTTPKeepAlive: "No"
       migratedDomain: signin.dev.account.gov.uk
-      UseMfaResetWithIpv: "Yes"
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       PrivacyNoticeRedirectEnabled: "Yes"
@@ -525,7 +498,6 @@ Mappings:
       IsSplunkEnabled: "Yes"
       SupportHTTPKeepAlive: "No"
       migratedDomain: signin.build.account.gov.uk
-      UseMfaResetWithIpv: "Yes"
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       PrivacyNoticeRedirectEnabled: "Yes"
@@ -561,7 +533,6 @@ Mappings:
       IsSplunkEnabled: "Yes"
       SupportHTTPKeepAlive: "Yes"
       migratedDomain: signin.staging.account.gov.uk
-      UseMfaResetWithIpv: "Yes"
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       UseAlarmActions: "Yes"
@@ -592,7 +563,6 @@ Mappings:
       IsSplunkEnabled: "Yes"
       SupportHTTPKeepAlive: "No"
       migratedDomain: signin.integration.account.gov.uk
-      UseMfaResetWithIpv: "Yes"
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       orchStubToAuth: ""
@@ -625,7 +595,6 @@ Mappings:
       IsSplunkEnabled: "Yes"
       SupportHTTPKeepAlive: "No"
       migratedDomain: signin.account.gov.uk
-      UseMfaResetWithIpv: "Yes"
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       orchStubToAuth: ""
@@ -1166,8 +1135,6 @@ Resources:
               Value: !If [Enableipvspinner, "1", "0"]
             - Name: SUPPORT_HTTP_KEEP_ALIVE
               Value: !If [SupportHTTPKeepAlive, "1", "0"]
-            - Name: SUPPORT_MFA_RESET_WITH_IPV
-              Value: !If [UseMfaResetWithIpv, "1", "0"]
             - Name: PRIVACY_NOTICE_REDIRECT_ENABLED
               Value: !If [PrivacyNoticeRedirectEnabled, "1", "0"]
             - Name: USE_REBRAND

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -148,29 +148,6 @@ Conditions:
                 ]
               - "Yes"
 
-  UseRouteUsersToNewIpvJourney:
-    Fn::Or:
-      - Fn::And:
-          - !Condition UseSubEnvironment
-          - Fn::Equals:
-              - !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref SubEnvironment,
-                  UseRouteUsersToNewIpvJourney,
-                  DefaultValue: "No",
-                ]
-              - "Yes"
-      - Fn::And:
-          - !Condition NotSubEnvironment
-          - Fn::Equals:
-              - !FindInMap [
-                  EnvironmentConfiguration,
-                  !Ref Environment,
-                  UseRouteUsersToNewIpvJourney,
-                  DefaultValue: "No",
-                ]
-              - "Yes"
-
   UseSubEnvironment:
     Fn::And:
       - Fn::Equals:
@@ -456,7 +433,6 @@ Mappings:
         -----END PUBLIC KEY-----
       migratedDomain: signin.authdev1.dev.account.gov.uk
       UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
       PrivacyNoticeRedirectEnabled: "Yes"
       OrchApiBaseUrl: "https://oidc.authdev1.dev.account.gov.uk"
@@ -477,7 +453,6 @@ Mappings:
         -----END PUBLIC KEY-----
       migratedDomain: signin.authdev2.dev.account.gov.uk
       UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
       PrivacyNoticeRedirectEnabled: "Yes"
       OrchApiBaseUrl: "https://oidc.authdev2.dev.account.gov.uk"
@@ -493,7 +468,6 @@ Mappings:
       frontendApiBaseUrl: https://y3s69ubaz5-vpce-0b907325ae3bfe3ce.execute-api.eu-west-2.amazonaws.com/authdev3/
       migratedDomain: signin.authdev3.dev.account.gov.uk
       UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "Yes"
       Enableipvspinner: "No"
       DeviceIntelligenceEnabled: "Yes"
       OrchApiBaseUrl: "https://oidc.authdev3.dev.account.gov.uk"
@@ -522,7 +496,6 @@ Mappings:
       SupportHTTPKeepAlive: "No"
       migratedDomain: signin.dev.account.gov.uk
       UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "Yes"
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       PrivacyNoticeRedirectEnabled: "Yes"
@@ -553,7 +526,6 @@ Mappings:
       SupportHTTPKeepAlive: "No"
       migratedDomain: signin.build.account.gov.uk
       UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "Yes"
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       PrivacyNoticeRedirectEnabled: "Yes"
@@ -590,7 +562,6 @@ Mappings:
       SupportHTTPKeepAlive: "Yes"
       migratedDomain: signin.staging.account.gov.uk
       UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "Yes"
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       UseAlarmActions: "Yes"
@@ -622,7 +593,6 @@ Mappings:
       SupportHTTPKeepAlive: "No"
       migratedDomain: signin.integration.account.gov.uk
       UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "Yes"
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       orchStubToAuth: ""
@@ -656,7 +626,6 @@ Mappings:
       SupportHTTPKeepAlive: "No"
       migratedDomain: signin.account.gov.uk
       UseMfaResetWithIpv: "Yes"
-      UseRouteUsersToNewIpvJourney: "Yes"
       ECSServiceCanaryPhasedDeploy: "Yes"
       Enableipvspinner: "No"
       orchStubToAuth: ""
@@ -1199,8 +1168,6 @@ Resources:
               Value: !If [SupportHTTPKeepAlive, "1", "0"]
             - Name: SUPPORT_MFA_RESET_WITH_IPV
               Value: !If [UseMfaResetWithIpv, "1", "0"]
-            - Name: ROUTE_USERS_TO_NEW_IPV_JOURNEY
-              Value: !If [UseRouteUsersToNewIpvJourney, "1", "0"]
             - Name: PRIVACY_NOTICE_REDIRECT_ENABLED
               Value: !If [PrivacyNoticeRedirectEnabled, "1", "0"]
             - Name: USE_REBRAND


### PR DESCRIPTION
Removes two redundant variables from infrastructure. 

They are no longer used as of [this PR](https://github.com/govuk-one-login/authentication-frontend/pull/2749) but we missed removing them from the template at that time.

## How to review

Sense check my logic - are these variables used anywhere?