### PR TITLE
BAU: Migrate sign-in acceptance tests to Playwright

### DIFF
--- a/playwright-acceptance-tests/docker-compose.yml
+++ b/playwright-acceptance-tests/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - test-net
 
   api-stub:
-    image: outofcoffee/imposter:latest
+    image: outofcoffee/imposter:4.9.1
     volumes:
       - ./stubs/api-stub:/opt/imposter/config
     networks:
@@ -47,8 +47,10 @@ services:
 
   orch-stub-start:
     image: ${ORCH_STUB_IMAGE}
+    pull_policy: never
     environment:
       AUTHENTICATION_FRONTEND_URL: http://proxy/
+      AUTHENTICATION_BACKEND_URL: http://api-stub:8080/
       STUB_URL: http://orch-stub-start:4400/
       RP_CLIENT_ID: local-client-id
       RP_SECTOR_HOST: local-sector-host
@@ -78,11 +80,14 @@ services:
       dockerfile: Dockerfile
     environment:
       BASE_URL: http://proxy/
+      IMPOSTER_URL: http://api-stub:8080
       BROWSER: chromium
       HEADLESS: "true"
       A11Y_CHECK: "false"
       SECURITY_CHECK: "false"
       CUCUMBER_FILTER_TAGS: "@Frontend"
+    volumes:
+      - ./reports:/app/reports
     networks:
       - test-net
     depends_on:

--- a/playwright-acceptance-tests/docker-compose.yml
+++ b/playwright-acceptance-tests/docker-compose.yml
@@ -47,7 +47,6 @@ services:
 
   orch-stub-start:
     image: ${ORCH_STUB_IMAGE}
-    pull_policy: never
     environment:
       AUTHENTICATION_FRONTEND_URL: http://proxy/
       AUTHENTICATION_BACKEND_URL: http://api-stub:8080/

--- a/playwright-acceptance-tests/docker-compose.yml
+++ b/playwright-acceptance-tests/docker-compose.yml
@@ -86,8 +86,6 @@ services:
       A11Y_CHECK: "false"
       SECURITY_CHECK: "false"
       CUCUMBER_FILTER_TAGS: "@Frontend"
-    volumes:
-      - ./reports:/app/reports
     networks:
       - test-net
     depends_on:

--- a/playwright-acceptance-tests/features/sign-in-lockouts.feature
+++ b/playwright-acceptance-tests/features/sign-in-lockouts.feature
@@ -1,0 +1,97 @@
+@Frontend @SignIn
+Feature: Sign-in lockouts
+
+  Scenario: User is blocked after entering too many incorrect passwords
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    And I click on Sign in button
+    When I enter email "test@example.com"
+    And I enter an incorrect password 6 times
+    Then the "You entered the wrong password too many times" lockout screen is displayed
+    * the lockout duration is 2 hours
+    * the lockout reason is "you entered the wrong password"
+
+    Given the lockout has not yet expired
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    And I click on Sign in button
+    When I enter email "test@example.com"
+    Then the "You cannot sign in at the moment" lockout screen is displayed
+    * the lockout duration is 2 hours
+    * the lockout reason is "you entered the wrong password"
+
+  Scenario: User is blocked after entering too many incorrect SMS codes
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    And I click on Sign in button
+    When I enter email "test@example.com"
+    And I enter password "correct-password"
+    And I enter an incorrect phone security code 6 times
+    Then the "You entered the wrong security code too many times" lockout screen is displayed
+    * the lockout duration is 2 hours
+
+    Given the lockout has not yet expired
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    And I click on Sign in button
+    When I enter email "test@example.com"
+    And I enter password "correct-password"
+    Then the "You cannot sign in at the moment" lockout screen is displayed
+    * the lockout duration is 2 hours
+    * the lockout reason is "you entered the wrong security code too many times"
+
+  Scenario: User is blocked after requesting too many SMS codes
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    And I click on Sign in button
+    When I enter email "test@example.com"
+    And I enter password "correct-password"
+    And I request the phone security code a further 5 times
+    Then the "You asked to resend the security code too many times" lockout screen is displayed
+    * the lockout duration is 2 hours
+
+    Given the lockout has not yet expired
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    And I click on Sign in button
+    When I enter email "test@example.com"
+    And I enter password "correct-password"
+    Then the "You cannot sign in at the moment" lockout screen is displayed
+    * the lockout duration is 2 hours
+    * the lockout reason is "you asked to resend the security code too many times"
+
+  Scenario: User is blocked after entering too many incorrect auth app codes
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    And I click on Sign in button
+    When I enter email "authapp@example.com"
+    And I enter password "correct-password"
+    And I enter an incorrect auth app security code 6 times
+    Then the "You entered the wrong security code too many times" lockout screen is displayed
+    * the lockout duration is 2 hours
+
+    Given the lockout has not yet expired
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    And I click on Sign in button
+    When I enter email "authapp@example.com"
+    And I enter password "correct-password"
+    Then the "You cannot sign in at the moment" lockout screen is displayed
+    * the lockout duration is 2 hours
+    * the lockout reason is "you entered the wrong security code too many times"

--- a/playwright-acceptance-tests/features/sign-in.feature
+++ b/playwright-acceptance-tests/features/sign-in.feature
@@ -1,0 +1,62 @@
+@Frontend @SignIn
+Feature: Sign-in journeys
+
+  Scenario: Existing user signs in with SMS MFA
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    And I click on Sign in button
+    When I enter email "test@example.com"
+    And I enter password "correct-password"
+    And I enter the phone security code "123456"
+    Then I am returned to the service
+
+  Scenario: Existing user signs in with auth app MFA
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    And I click on Sign in button
+    When I enter email "authapp@example.com"
+    And I enter password "correct-password"
+    And I enter the auth app security code "123456"
+    Then I am returned to the service
+
+  Scenario: Existing user signs in without MFA
+    Given I open the orchestration stub start page
+    And I select the 2fa-off stub option
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    And I click on Sign in button
+    When I enter email "nomfa@example.com"
+    And I enter password "correct-password"
+    Then I am returned to the service
+
+  Scenario: Existing user tries to create account with same email
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    When I select create an account
+    Then I am taken to the enter your email address page
+    When I enter email "test@example.com"
+    Then I am taken to the you have a GOV.UK One Login page
+
+  Scenario: Existing user switches content to Welsh
+    Given I open the orchestration stub start page
+    And I select the default stub options
+    When I submit the stub form
+    Then I should see the Create your GOV.UK One Login or sign in page
+    When I switch to "Welsh" language
+    Then I am taken to the Welsh create or sign in page
+    When I click the sign in button
+    Then I am taken to the Welsh enter your email page
+    When I enter email "test@example.com" in Welsh
+    Then I am prompted for my password in Welsh
+    When I click link "Yn ôl"
+    Then I am taken to the Welsh enter your email page
+    When I click link "Yn ôl"
+    Then I am taken to the Welsh create or sign in page
+    When I switch to "English" language
+    Then I should see the Create your GOV.UK One Login or sign in page

--- a/playwright-acceptance-tests/package-lock.json
+++ b/playwright-acceptance-tests/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@axe-core/playwright": "4.11.0",
         "@cucumber/cucumber": "9.6.0",
+        "@playwright/test": "^1.59.1",
         "@types/node": "20.10.1",
         "@typescript-eslint/eslint-plugin": "8.47.0",
         "@typescript-eslint/parser": "8.47.0",
@@ -574,6 +575,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@teppeis/multimaps": {

--- a/playwright-acceptance-tests/package.json
+++ b/playwright-acceptance-tests/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@axe-core/playwright": "4.11.0",
     "@cucumber/cucumber": "9.6.0",
+    "@playwright/test": "^1.59.1",
     "@types/node": "20.10.1",
     "@typescript-eslint/eslint-plugin": "8.47.0",
     "@typescript-eslint/parser": "8.47.0",

--- a/playwright-acceptance-tests/src/pages/AccountLockedPage.ts
+++ b/playwright-acceptance-tests/src/pages/AccountLockedPage.ts
@@ -1,0 +1,20 @@
+import type { Page } from "playwright";
+import { expect } from "../support/expect";
+import { BasePage } from "./BasePage";
+
+export class AccountLockedPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async assertHeadingVisible(heading: string): Promise<void> {
+    await expect(
+      this.page.getByRole("heading", { name: new RegExp(heading, "i") })
+    ).toBeVisible();
+    await this.runAccessibilityCheck();
+  }
+
+  async assertContainsText(text: string): Promise<void> {
+    await expect(this.page.getByText(text).first()).toBeVisible();
+  }
+}

--- a/playwright-acceptance-tests/src/pages/BasePage.ts
+++ b/playwright-acceptance-tests/src/pages/BasePage.ts
@@ -22,7 +22,7 @@ export class BasePage {
   }
 
   async goto(url: string): Promise<void> {
-    await this.page.goto(url, { waitUntil: "networkidle" });
+    await this.page.goto(url, { waitUntil: "domcontentloaded" });
   }
 
   async assertBasicSecurity(): Promise<void> {

--- a/playwright-acceptance-tests/src/pages/CheckYourPhonePage.ts
+++ b/playwright-acceptance-tests/src/pages/CheckYourPhonePage.ts
@@ -1,0 +1,49 @@
+import type { Page } from "playwright";
+import { expect } from "../support/expect";
+import { BasePage } from "./BasePage";
+
+export class CheckYourPhonePage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async assertLoaded(): Promise<void> {
+    await expect(
+      this.page.getByRole("heading", { name: /check your phone/i })
+    ).toBeVisible();
+
+    await this.assertBasicSecurity();
+    await this.runAccessibilityCheck();
+  }
+
+  async enterCode(code: string): Promise<void> {
+    await this.page.locator("#code").fill(code);
+  }
+
+  async clickContinue(): Promise<void> {
+    await this.page.getByRole("button", { name: /continue/i }).click();
+  }
+
+  async enterCodeAndContinue(code: string): Promise<void> {
+    await this.enterCode(code);
+    await this.clickContinue();
+  }
+
+  async clickProblemsWithTheCodeLink(): Promise<void> {
+    await this.page
+      .getByRole("button", { name: /problems with the code/i })
+      .click();
+  }
+
+  async clickSendTheCodeAgainLink(): Promise<void> {
+    await this.page.getByRole("link", { name: /send the code again/i }).click();
+  }
+
+  async assertInlineError(): Promise<void> {
+    await expect(
+      this.page
+        .getByText(/the code you entered is not correct|enter the code/i)
+        .first()
+    ).toBeVisible();
+  }
+}

--- a/playwright-acceptance-tests/src/pages/CreateOrSignInPage.ts
+++ b/playwright-acceptance-tests/src/pages/CreateOrSignInPage.ts
@@ -1,4 +1,5 @@
 import type { Page } from "playwright";
+import { expect } from "../support/expect";
 import { BasePage } from "./BasePage";
 
 export class CreateOrSignInPage extends BasePage {
@@ -7,11 +8,11 @@ export class CreateOrSignInPage extends BasePage {
   }
 
   async assertLoaded(): Promise<void> {
-    await this.page
-      .getByRole("heading", {
+    await expect(
+      this.page.getByRole("heading", {
         name: /create your gov\.uk one login or sign in/i,
       })
-      .waitFor({ state: "visible" });
+    ).toBeVisible();
 
     await this.assertBasicSecurity();
     await this.runAccessibilityCheck();

--- a/playwright-acceptance-tests/src/pages/EnterAuthAppCodePage.ts
+++ b/playwright-acceptance-tests/src/pages/EnterAuthAppCodePage.ts
@@ -1,0 +1,38 @@
+import type { Page } from "playwright";
+import { expect } from "../support/expect";
+import { BasePage } from "./BasePage";
+
+export class EnterAuthAppCodePage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async assertLoaded(): Promise<void> {
+    await expect(
+      this.page.getByRole("heading", {
+        name: /enter the 6 digit security code/i,
+      })
+    ).toBeVisible();
+  }
+
+  async enterCode(code: string): Promise<void> {
+    await this.page.locator("#code").fill(code);
+  }
+
+  async clickContinue(): Promise<void> {
+    await this.page.getByRole("button", { name: /continue/i }).click();
+  }
+
+  async enterCodeAndContinue(code: string): Promise<void> {
+    await this.enterCode(code);
+    await this.clickContinue();
+  }
+
+  async assertInlineError(): Promise<void> {
+    await expect(
+      this.page
+        .getByText(/the code you entered is not correct|enter the code/i)
+        .first()
+    ).toBeVisible();
+  }
+}

--- a/playwright-acceptance-tests/src/pages/EnterEmailPage.ts
+++ b/playwright-acceptance-tests/src/pages/EnterEmailPage.ts
@@ -1,4 +1,5 @@
 import type { Page } from "playwright";
+import { expect } from "../support/expect";
 import { BasePage } from "./BasePage";
 
 export class EnterEmailPage extends BasePage {
@@ -7,13 +8,11 @@ export class EnterEmailPage extends BasePage {
   }
 
   async assertLoaded(): Promise<void> {
-    // Based on your screenshot:
-    // "Enter your email address to sign in to your GOV.UK One Login"
-    await this.page
-      .getByRole("heading", {
+    await expect(
+      this.page.getByRole("heading", {
         name: /enter your email address to sign in to your gov\.uk one login/i,
       })
-      .waitFor({ state: "visible" });
+    ).toBeVisible();
 
     await this.assertBasicSecurity();
     await this.runAccessibilityCheck();

--- a/playwright-acceptance-tests/src/pages/EnterPasswordPage.ts
+++ b/playwright-acceptance-tests/src/pages/EnterPasswordPage.ts
@@ -1,0 +1,43 @@
+import type { Page } from "playwright";
+import { expect } from "../support/expect";
+import { BasePage } from "./BasePage";
+
+export class EnterPasswordPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async assertLoaded(): Promise<void> {
+    await expect(
+      this.page.getByRole("heading", { name: /enter your password/i })
+    ).toBeVisible();
+
+    await this.assertBasicSecurity();
+    await this.runAccessibilityCheck();
+  }
+
+  async assertLoadedWelsh(): Promise<void> {
+    await expect(
+      this.page.getByRole("heading", { name: /Rhowch eich cyfrinair/i })
+    ).toBeVisible();
+  }
+
+  async enterPassword(password: string): Promise<void> {
+    await this.page.locator("#password").fill(password);
+  }
+
+  async clickContinue(): Promise<void> {
+    await this.page.getByRole("button", { name: /continue/i }).click();
+  }
+
+  async enterPasswordAndContinue(password: string): Promise<void> {
+    await this.enterPassword(password);
+    await this.clickContinue();
+  }
+
+  async assertInlineError(): Promise<void> {
+    await expect(
+      this.page.getByText(/enter your password|incorrect password/i).first()
+    ).toBeVisible();
+  }
+}

--- a/playwright-acceptance-tests/src/pages/GetSecurityCodePage.ts
+++ b/playwright-acceptance-tests/src/pages/GetSecurityCodePage.ts
@@ -1,0 +1,18 @@
+import type { Page } from "playwright";
+import { BasePage } from "./BasePage";
+
+export class GetSecurityCodePage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async assertLoaded(): Promise<void> {
+    await this.page
+      .getByRole("heading", { name: /get security code/i })
+      .waitFor({ state: "visible" });
+  }
+
+  async clickGetSecurityCode(): Promise<void> {
+    await this.page.getByRole("button", { name: /get security code/i }).click();
+  }
+}

--- a/playwright-acceptance-tests/src/pages/StubStartPage.ts
+++ b/playwright-acceptance-tests/src/pages/StubStartPage.ts
@@ -1,4 +1,5 @@
 import type { Page } from "playwright";
+import { expect } from "../support/expect";
 import { BasePage } from "./BasePage";
 
 export class StubStartPage extends BasePage {
@@ -14,19 +15,14 @@ export class StubStartPage extends BasePage {
 
     await this.goto(url);
 
-    // The Orchestration Stub main heading
-    await this.page
-      .getByRole("heading", { name: /orchestration stub/i })
-      .waitFor({ state: "visible" });
+    await expect(
+      this.page.getByRole("heading", { name: /orchestration stub/i })
+    ).toBeVisible();
 
     await this.assertBasicSecurity();
     await this.runAccessibilityCheck();
   }
 
-  /**
-   * Your stub page already loads with defaults selected.
-   * This method exists for BDD readability and future expansion.
-   */
   async selectDefaultOptions(): Promise<void> {
     return;
   }

--- a/playwright-acceptance-tests/src/pages/StubUserInfoPage.ts
+++ b/playwright-acceptance-tests/src/pages/StubUserInfoPage.ts
@@ -1,0 +1,19 @@
+import type { Page } from "playwright";
+import { BasePage } from "./BasePage";
+import assert from "node:assert";
+
+export class StubUserInfoPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async assertReturned(): Promise<void> {
+    await this.page.waitForFunction(
+      () => document.body.textContent?.includes("Session ID"),
+      null,
+      { timeout: 10000 }
+    );
+    const text = await this.page.locator("body").textContent();
+    assert(text?.includes("Session ID"), "Expected to be returned to service");
+  }
+}

--- a/playwright-acceptance-tests/src/pages/YouHaveAOneLoginPage.ts
+++ b/playwright-acceptance-tests/src/pages/YouHaveAOneLoginPage.ts
@@ -1,0 +1,19 @@
+import type { Page } from "playwright";
+import { expect } from "../support/expect";
+import { BasePage } from "./BasePage";
+
+export class YouHaveAOneLoginPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async assertLoaded(): Promise<void> {
+    await expect(
+      this.page.getByRole("heading", {
+        name: /you have a gov\.uk one login/i,
+      })
+    ).toBeVisible();
+    await this.assertBasicSecurity();
+    await this.runAccessibilityCheck();
+  }
+}

--- a/playwright-acceptance-tests/src/steps/sign-in-journey.steps.ts
+++ b/playwright-acceptance-tests/src/steps/sign-in-journey.steps.ts
@@ -3,7 +3,6 @@ import { expect } from "../support/expect";
 import type { PlaywrightWorld } from "../support/world";
 
 import { CreateOrSignInPage } from "../pages/CreateOrSignInPage";
-import { EnterEmailPage } from "../pages/EnterEmailPage";
 import { EnterPasswordPage } from "../pages/EnterPasswordPage";
 import { CheckYourPhonePage } from "../pages/CheckYourPhonePage";
 import { EnterAuthAppCodePage } from "../pages/EnterAuthAppCodePage";
@@ -35,10 +34,9 @@ When(
   "I enter email {string}",
   async function (this: PlaywrightWorld, email: string): Promise<void> {
     const page = getPage(this);
-    await page.getByRole("textbox").waitFor({ state: "visible" });
-    const emailPage = new EnterEmailPage(page);
-    await emailPage.enterEmail(email);
-    await emailPage.clickContinue();
+    await expect(page.getByRole("textbox")).toBeVisible();
+    await page.getByRole("textbox").fill(email);
+    await page.getByRole("button", { name: /continue/i }).click();
   }
 );
 

--- a/playwright-acceptance-tests/src/steps/sign-in-journey.steps.ts
+++ b/playwright-acceptance-tests/src/steps/sign-in-journey.steps.ts
@@ -1,0 +1,343 @@
+import { Given, When, Then } from "@cucumber/cucumber";
+import { expect } from "../support/expect";
+import type { PlaywrightWorld } from "../support/world";
+
+import { CreateOrSignInPage } from "../pages/CreateOrSignInPage";
+import { EnterEmailPage } from "../pages/EnterEmailPage";
+import { EnterPasswordPage } from "../pages/EnterPasswordPage";
+import { CheckYourPhonePage } from "../pages/CheckYourPhonePage";
+import { EnterAuthAppCodePage } from "../pages/EnterAuthAppCodePage";
+import { AccountLockedPage } from "../pages/AccountLockedPage";
+import { YouHaveAOneLoginPage } from "../pages/YouHaveAOneLoginPage";
+
+function getPage(world: PlaywrightWorld) {
+  if (!world.page) throw new Error("Playwright page is not initialised");
+  return world.page;
+}
+
+/* -----------------------------------------
+   Stub options
+------------------------------------------ */
+
+Given(
+  "I select the 2fa-off stub option",
+  async function (this: PlaywrightWorld): Promise<void> {
+    const page = getPage(this);
+    await page.locator("#level-2").click();
+  }
+);
+
+/* -----------------------------------------
+   Email entry
+------------------------------------------ */
+
+When(
+  "I enter email {string}",
+  async function (this: PlaywrightWorld, email: string): Promise<void> {
+    const page = getPage(this);
+    await page.getByRole("textbox").waitFor({ state: "visible" });
+    const emailPage = new EnterEmailPage(page);
+    await emailPage.enterEmail(email);
+    await emailPage.clickContinue();
+  }
+);
+
+When(
+  "I enter email {string} in Welsh",
+  async function (this: PlaywrightWorld, email: string): Promise<void> {
+    const page = getPage(this);
+    await page.getByRole("textbox").fill(email);
+    await page.getByRole("button", { name: "Parhau" }).click();
+  }
+);
+
+/* -----------------------------------------
+   Password entry
+------------------------------------------ */
+
+Then(
+  "I am taken to the enter your password page",
+  async function (this: PlaywrightWorld): Promise<void> {
+    const passwordPage = new EnterPasswordPage(getPage(this));
+    await passwordPage.assertLoaded();
+  }
+);
+
+When(
+  "I enter password {string}",
+  async function (this: PlaywrightWorld, password: string): Promise<void> {
+    const page = getPage(this);
+    const passwordPage = new EnterPasswordPage(page);
+    await passwordPage.assertLoaded();
+    await passwordPage.enterPasswordAndContinue(password);
+  }
+);
+
+/* -----------------------------------------
+   Check your phone (SMS MFA)
+------------------------------------------ */
+
+Then(
+  "I am taken to the check your phone page",
+  async function (this: PlaywrightWorld): Promise<void> {
+    const phonePage = new CheckYourPhonePage(getPage(this));
+    await phonePage.assertLoaded();
+  }
+);
+
+When(
+  "I enter the phone security code {string}",
+  async function (this: PlaywrightWorld, code: string): Promise<void> {
+    const phonePage = new CheckYourPhonePage(getPage(this));
+    await phonePage.enterCodeAndContinue(code);
+  }
+);
+
+/* -----------------------------------------
+   Auth app MFA
+------------------------------------------ */
+
+Then(
+  "I am taken to the enter authenticator app code page",
+  async function (this: PlaywrightWorld): Promise<void> {
+    const authAppPage = new EnterAuthAppCodePage(getPage(this));
+    await authAppPage.assertLoaded();
+  }
+);
+
+When(
+  "I enter the auth app security code {string}",
+  async function (this: PlaywrightWorld, code: string): Promise<void> {
+    const authAppPage = new EnterAuthAppCodePage(getPage(this));
+    await authAppPage.enterCodeAndContinue(code);
+  }
+);
+
+/* -----------------------------------------
+   Return to service
+------------------------------------------ */
+
+Then(
+  "I am returned to the service",
+  async function (this: PlaywrightWorld): Promise<void> {
+    const page = getPage(this);
+    await expect(page.getByText(/session id/i)).toBeVisible({
+      timeout: 15000,
+    });
+  }
+);
+
+/* -----------------------------------------
+   You have a GOV.UK One Login
+------------------------------------------ */
+
+Then(
+  "I am taken to the you have a GOV.UK One Login page",
+  async function (this: PlaywrightWorld): Promise<void> {
+    const page = new YouHaveAOneLoginPage(getPage(this));
+    await page.assertLoaded();
+  }
+);
+
+When(
+  "I select create an account",
+  async function (this: PlaywrightWorld): Promise<void> {
+    const createOrSignInPage = new CreateOrSignInPage(getPage(this));
+    await createOrSignInPage.clickCreateAccount();
+  }
+);
+
+Then(
+  "I am taken to the enter your email address page",
+  async function (this: PlaywrightWorld): Promise<void> {
+    await expect(
+      getPage(this).getByRole("heading", { name: /enter your email address$/i })
+    ).toBeVisible();
+  }
+);
+
+/* -----------------------------------------
+   Lockout: incorrect passwords
+------------------------------------------ */
+
+When(
+  "I enter an incorrect password {int} times",
+  async function (this: PlaywrightWorld, count: number): Promise<void> {
+    const passwordPage = new EnterPasswordPage(getPage(this));
+    for (let i = 0; i < count; i++) {
+      await passwordPage.enterPasswordAndContinue("wrong-password");
+      if (i < count - 1) {
+        await passwordPage.assertLoaded();
+        await passwordPage.assertInlineError();
+      }
+    }
+  }
+);
+
+/* -----------------------------------------
+   Lockout: incorrect SMS codes
+------------------------------------------ */
+
+When(
+  "I enter an incorrect phone security code {int} times",
+  async function (this: PlaywrightWorld, count: number): Promise<void> {
+    const phonePage = new CheckYourPhonePage(getPage(this));
+    for (let i = 0; i < count; i++) {
+      await phonePage.enterCodeAndContinue("999999");
+      if (i < count - 1) {
+        await phonePage.assertLoaded();
+        await phonePage.assertInlineError();
+      }
+    }
+  }
+);
+
+/* -----------------------------------------
+   Lockout: too many SMS resends
+------------------------------------------ */
+
+When(
+  "I request the phone security code a further {int} times",
+  async function (this: PlaywrightWorld, count: number): Promise<void> {
+    const page = getPage(this);
+    for (let i = 0; i < count; i++) {
+      await page.getByText(/problems with the code/i).click();
+      await page.getByRole("link", { name: /send the code again/i }).click();
+      await page.getByRole("button", { name: /get security code/i }).click();
+      if (i < count - 1) {
+        await new CheckYourPhonePage(page).assertLoaded();
+      }
+    }
+  }
+);
+
+/* -----------------------------------------
+   Lockout: incorrect auth app codes
+------------------------------------------ */
+
+When(
+  "I enter an incorrect auth app security code {int} times",
+  async function (this: PlaywrightWorld, count: number): Promise<void> {
+    const authAppPage = new EnterAuthAppCodePage(getPage(this));
+    for (let i = 0; i < count; i++) {
+      await authAppPage.enterCodeAndContinue("999999");
+      if (i < count - 1) {
+        await authAppPage.assertLoaded();
+        await authAppPage.assertInlineError();
+      }
+    }
+  }
+);
+
+/* -----------------------------------------
+   Lockout screen assertions
+------------------------------------------ */
+
+Then(
+  "the {string} lockout screen is displayed",
+  async function (this: PlaywrightWorld, title: string): Promise<void> {
+    const lockoutPage = new AccountLockedPage(getPage(this));
+    await lockoutPage.assertHeadingVisible(title);
+  }
+);
+
+Then(
+  "the lockout duration is {int} hours",
+  async function (this: PlaywrightWorld, hours: number): Promise<void> {
+    const lockoutPage = new AccountLockedPage(getPage(this));
+    await lockoutPage.assertContainsText(`${hours} hours`);
+  }
+);
+
+Then(
+  "the lockout reason is {string}",
+  async function (this: PlaywrightWorld, reason: string): Promise<void> {
+    const lockoutPage = new AccountLockedPage(getPage(this));
+    await lockoutPage.assertContainsText(`because ${reason}`);
+  }
+);
+
+Given(
+  "the lockout has not yet expired",
+  async function (this: PlaywrightWorld): Promise<void> {
+    // Intentionally empty - lockout state is maintained in Imposter stores
+  }
+);
+
+/* -----------------------------------------
+   Language switching
+------------------------------------------ */
+
+When(
+  "I switch to {string} language",
+  async function (this: PlaywrightWorld, language: string): Promise<void> {
+    const page = getPage(this);
+    if (language.toLowerCase() === "welsh") {
+      await page.locator("nav").getByRole("link", { name: "Cymraeg" }).click();
+      // The frontend sets lng cookie with Secure flag, which doesn't work over
+      // HTTP in docker. Re-set it without Secure so subsequent navigations
+      // preserve the Welsh language.
+      const url = new URL(page.url());
+      await page
+        .context()
+        .addCookies([
+          { name: "lng", value: "cy", domain: url.hostname, path: "/" },
+        ]);
+    } else {
+      await page.locator("nav").getByRole("link", { name: "English" }).click();
+    }
+  }
+);
+
+Then(
+  "I am taken to the Welsh create or sign in page",
+  async function (this: PlaywrightWorld): Promise<void> {
+    await expect(
+      getPage(this).getByRole("heading", {
+        name: /Creu eich GOV\.UK One/i,
+      })
+    ).toBeVisible();
+  }
+);
+
+Then(
+  "I am taken to the Welsh enter your email page",
+  async function (this: PlaywrightWorld): Promise<void> {
+    await expect(
+      getPage(this).getByRole("heading", {
+        name: /Rhowch eich cyfeiriad e-bost i fewngofnodi/i,
+      })
+    ).toBeVisible();
+  }
+);
+
+Then(
+  "I am prompted for my password in Welsh",
+  async function (this: PlaywrightWorld): Promise<void> {
+    const passwordPage = new EnterPasswordPage(getPage(this));
+    await passwordPage.assertLoadedWelsh();
+  }
+);
+
+When(
+  "I click link {string}",
+  async function (this: PlaywrightWorld, linkText: string): Promise<void> {
+    await getPage(this).getByRole("link", { name: linkText }).click();
+  }
+);
+
+When(
+  "I click the sign in button",
+  async function (this: PlaywrightWorld): Promise<void> {
+    await getPage(this).locator("#sign-in-button").click();
+  }
+);
+
+When(
+  "I click the continue button",
+  async function (this: PlaywrightWorld): Promise<void> {
+    await getPage(this)
+      .getByRole("button", { name: /continue/i })
+      .click();
+  }
+);

--- a/playwright-acceptance-tests/src/support/expect.ts
+++ b/playwright-acceptance-tests/src/support/expect.ts
@@ -1,0 +1,3 @@
+import { expect as baseExpect } from "@playwright/test";
+
+export const expect = baseExpect.configure({ timeout: 10_000 });

--- a/playwright-acceptance-tests/src/support/hooks.ts
+++ b/playwright-acceptance-tests/src/support/hooks.ts
@@ -4,47 +4,59 @@ import type { PlaywrightWorld } from "./world";
 import fs from "node:fs";
 import path from "node:path";
 
-const IMPOSTER_BASE_URL = process.env.IMPOSTER_URL || "http://api-stub:8080";
-const STORE_NAMES = [
-  "loginAttempts",
-  "accountLocked",
-  "verifyCodeAttempts",
-  "mfaResendCount",
-  "verifyMfaAttempts",
-  "smsCodeLocked",
-  "smsResendLocked",
-  "authAppLocked",
-];
-
 Before(async function (this: PlaywrightWorld) {
-  await resetImposterStores();
-  await this.openBrowser();
+  await this.createContext();
+
+  if (this.context) {
+    await this.context.tracing.start({ screenshots: true, snapshots: true });
+  }
+
+  // Reset Imposter stores to prevent state leaking between scenarios
+  const imposterUrl = process.env.IMPOSTER_URL || "http://api-stub:8080";
+  const storeNames = [
+    "loginAttempts",
+    "accountLocked",
+    "verifyCodeAttempts",
+    "mfaResendCount",
+    "verifyMfaAttempts",
+    "smsCodeLocked",
+    "smsResendLocked",
+    "authAppLocked",
+  ];
+  try {
+    await Promise.all(
+      storeNames.map((s) =>
+        fetch(`${imposterUrl}/system/store/${s}`, { method: "DELETE" })
+      )
+    );
+  } catch {
+    // Imposter may not be reachable in non-docker environments
+  }
 });
 
 After(async function (this: PlaywrightWorld, scenario: ITestCaseHookParameter) {
-  if (scenario.result?.status === Status.FAILED && this.page) {
-    const safeName = scenario.pickle.name.replace(/[^a-z0-9\-]+/gi, "_");
-    const screenshotsDir = path.join(process.cwd(), "reports", "screenshots");
-    fs.mkdirSync(screenshotsDir, { recursive: true });
+  const safeName = scenario.pickle.name.replace(/[^a-z0-9\-]+/gi, "_");
 
-    const filePath = path.join(screenshotsDir, `${safeName}.png`);
-    await this.page.screenshot({ path: filePath, fullPage: true });
+  if (scenario.result?.status === Status.FAILED) {
+    const reportsDir = path.join(process.cwd(), "reports");
 
-    const image = fs.readFileSync(filePath);
-    this.attach(image, "image/png");
-  }
-
-  await this.closeBrowser();
-});
-
-async function resetImposterStores(): Promise<void> {
-  for (const storeName of STORE_NAMES) {
-    try {
-      await fetch(`${IMPOSTER_BASE_URL}/system/store/${storeName}`, {
-        method: "DELETE",
-      });
-    } catch {
-      // Imposter may not be reachable in local dev - ignore
+    if (this.page) {
+      const screenshotsDir = path.join(reportsDir, "screenshots");
+      fs.mkdirSync(screenshotsDir, { recursive: true });
+      const screenshotPath = path.join(screenshotsDir, `${safeName}.png`);
+      await this.page.screenshot({ path: screenshotPath, fullPage: true });
+      this.attach(fs.readFileSync(screenshotPath), "image/png");
     }
+
+    if (this.context) {
+      const tracesDir = path.join(reportsDir, "traces");
+      fs.mkdirSync(tracesDir, { recursive: true });
+      const tracePath = path.join(tracesDir, `${safeName}.zip`);
+      await this.context.tracing.stop({ path: tracePath });
+    }
+  } else if (this.context) {
+    await this.context.tracing.stop();
   }
-}
+
+  await this.closeContext();
+});

--- a/playwright-acceptance-tests/src/support/hooks.ts
+++ b/playwright-acceptance-tests/src/support/hooks.ts
@@ -4,7 +4,20 @@ import type { PlaywrightWorld } from "./world";
 import fs from "node:fs";
 import path from "node:path";
 
+const IMPOSTER_BASE_URL = process.env.IMPOSTER_URL || "http://api-stub:8080";
+const STORE_NAMES = [
+  "loginAttempts",
+  "accountLocked",
+  "verifyCodeAttempts",
+  "mfaResendCount",
+  "verifyMfaAttempts",
+  "smsCodeLocked",
+  "smsResendLocked",
+  "authAppLocked",
+];
+
 Before(async function (this: PlaywrightWorld) {
+  await resetImposterStores();
   await this.openBrowser();
 });
 
@@ -23,3 +36,15 @@ After(async function (this: PlaywrightWorld, scenario: ITestCaseHookParameter) {
 
   await this.closeBrowser();
 });
+
+async function resetImposterStores(): Promise<void> {
+  for (const storeName of STORE_NAMES) {
+    try {
+      await fetch(`${IMPOSTER_BASE_URL}/system/store/${storeName}`, {
+        method: "DELETE",
+      });
+    } catch {
+      // Imposter may not be reachable in local dev - ignore
+    }
+  }
+}

--- a/playwright-acceptance-tests/src/support/world.ts
+++ b/playwright-acceptance-tests/src/support/world.ts
@@ -7,8 +7,24 @@ import {
 import type { Browser, BrowserContext, Page, BrowserType } from "playwright";
 import { chromium, firefox, webkit } from "playwright";
 
+let sharedBrowser: Browser | undefined;
+
+async function getBrowser(): Promise<Browser> {
+  if (!sharedBrowser) {
+    const browserName = (process.env.BROWSER || "chromium").toLowerCase();
+    const headless = (process.env.HEADLESS || "true").toLowerCase() === "true";
+    const browserType: BrowserType =
+      browserName === "firefox"
+        ? firefox
+        : browserName === "webkit"
+          ? webkit
+          : chromium;
+    sharedBrowser = await browserType.launch({ headless });
+  }
+  return sharedBrowser;
+}
+
 export class PlaywrightWorld extends World {
-  browser?: Browser;
   context?: BrowserContext;
   page?: Page;
 
@@ -16,34 +32,17 @@ export class PlaywrightWorld extends World {
     super(options);
   }
 
-  async openBrowser(): Promise<void> {
-    const browserName = (process.env.BROWSER || "chromium").toLowerCase();
-    const headless = (process.env.HEADLESS || "true").toLowerCase() === "true";
-
-    const browserType = setBrowserType(browserName);
-
-    this.browser = await browserType.launch({ headless });
-    this.context = await this.browser.newContext();
+  async createContext(): Promise<void> {
+    const browser = await getBrowser();
+    this.context = await browser.newContext();
     this.page = await this.context.newPage();
   }
 
-  async closeBrowser(): Promise<void> {
+  async closeContext(): Promise<void> {
     if (this.page) await this.page.close();
     if (this.context) await this.context.close();
-    if (this.browser) await this.browser.close();
   }
 }
 
 setWorldConstructor(PlaywrightWorld);
 setDefaultTimeout(30 * 1000);
-
-function setBrowserType(browserName: string): BrowserType {
-  switch (browserName) {
-    case "firefox":
-      return firefox;
-    case "webkit":
-      return webkit;
-    default:
-      return chromium;
-  }
-}

--- a/playwright-acceptance-tests/stubs/api-stub/login-handler.js
+++ b/playwright-acceptance-tests/stubs/api-stub/login-handler.js
@@ -1,0 +1,50 @@
+var body = JSON.parse(context.request.body);
+
+// Check if locked out from SMS/auth app (for second-visit scenarios)
+var smsCodeLocked = stores.open("smsCodeLocked").load("default");
+var smsResendLocked = stores.open("smsResendLocked").load("default");
+var authAppLocked = stores.open("authAppLocked").load("default");
+
+if (
+  smsCodeLocked === "locked" ||
+  smsResendLocked === "locked" ||
+  authAppLocked === "locked"
+) {
+  respond()
+    .withStatusCode(400)
+    .withContent('{"code":1045,"message":"Account locked"}')
+    .skipDefaultBehaviour();
+} else if (body.password === "wrong-password") {
+  var store = stores.open("loginAttempts");
+  var count = store.load("default") || 0;
+  count++;
+  store.save("default", count);
+  if (count >= 6) {
+    var lockoutStore = stores.open("accountLocked");
+    lockoutStore.save("default", "locked");
+    respond()
+      .withStatusCode(400)
+      .withContent('{"code":1028,"message":"Password attempt limit reached"}')
+      .skipDefaultBehaviour();
+  } else {
+    respond()
+      .withStatusCode(401)
+      .withContent('{"code":1028,"message":"Invalid password"}')
+      .skipDefaultBehaviour();
+  }
+} else if (body.email === "authapp@example.com") {
+  respond()
+    .withStatusCode(200)
+    .withFile("responses/login-200-auth-app.json")
+    .skipDefaultBehaviour();
+} else if (body.email === "nomfa@example.com") {
+  respond()
+    .withStatusCode(200)
+    .withFile("responses/login-200-no-mfa.json")
+    .skipDefaultBehaviour();
+} else {
+  respond()
+    .withStatusCode(200)
+    .withFile("responses/login-200.json")
+    .skipDefaultBehaviour();
+}

--- a/playwright-acceptance-tests/stubs/api-stub/mfa-handler.js
+++ b/playwright-acceptance-tests/stubs/api-stub/mfa-handler.js
@@ -1,0 +1,15 @@
+var store = stores.open("mfaResendCount");
+var count = store.load("default") || 0;
+count++;
+store.save("default", count);
+
+if (count > 5) {
+  var lockoutStore = stores.open("smsResendLocked");
+  lockoutStore.save("default", "locked");
+  respond()
+    .withStatusCode(400)
+    .withContent('{"code":1025,"message":"Too many code requests"}')
+    .skipDefaultBehaviour();
+} else {
+  respond().withStatusCode(204).withEmpty().skipDefaultBehaviour();
+}

--- a/playwright-acceptance-tests/stubs/api-stub/responses/login-200-auth-app.json
+++ b/playwright-acceptance-tests/stubs/api-stub/responses/login-200-auth-app.json
@@ -1,0 +1,14 @@
+{
+  "mfaMethodType": "AUTH_APP",
+  "latestTermsAndConditionsAccepted": true,
+  "mfaRequired": true,
+  "mfaMethodVerified": true,
+  "passwordChangeRequired": false,
+  "mfaMethods": [
+    {
+      "id": "stub-mfa-method-id",
+      "type": "AUTH_APP",
+      "priority": "DEFAULT"
+    }
+  ]
+}

--- a/playwright-acceptance-tests/stubs/api-stub/responses/login-200-no-mfa.json
+++ b/playwright-acceptance-tests/stubs/api-stub/responses/login-200-no-mfa.json
@@ -1,0 +1,8 @@
+{
+  "mfaMethodType": "SMS",
+  "latestTermsAndConditionsAccepted": true,
+  "mfaRequired": false,
+  "mfaMethodVerified": true,
+  "passwordChangeRequired": false,
+  "mfaMethods": []
+}

--- a/playwright-acceptance-tests/stubs/api-stub/responses/login-400-max-password-attempts.json
+++ b/playwright-acceptance-tests/stubs/api-stub/responses/login-400-max-password-attempts.json
@@ -1,0 +1,4 @@
+{
+  "code": 1028,
+  "message": "Max password attempts reached"
+}

--- a/playwright-acceptance-tests/stubs/api-stub/responses/mfa-400-max-codes-sent.json
+++ b/playwright-acceptance-tests/stubs/api-stub/responses/mfa-400-max-codes-sent.json
@@ -1,0 +1,4 @@
+{
+  "code": 1025,
+  "message": "Max codes sent"
+}

--- a/playwright-acceptance-tests/stubs/api-stub/responses/start-200-no-mfa.json
+++ b/playwright-acceptance-tests/stubs/api-stub/responses/start-200-no-mfa.json
@@ -6,7 +6,7 @@
     "authenticated": false,
     "mfaMethodType": "SMS",
     "isBlockedForReauth": false,
-    "mfaRequired": true
+    "mfaRequired": false
   },
   "featureFlags": {}
 }

--- a/playwright-acceptance-tests/stubs/api-stub/responses/user-exists-400-account-locked.json
+++ b/playwright-acceptance-tests/stubs/api-stub/responses/user-exists-400-account-locked.json
@@ -1,0 +1,4 @@
+{
+  "code": 1045,
+  "message": "Account locked"
+}

--- a/playwright-acceptance-tests/stubs/api-stub/responses/verify-code-400-invalid.json
+++ b/playwright-acceptance-tests/stubs/api-stub/responses/verify-code-400-invalid.json
@@ -1,0 +1,4 @@
+{
+  "code": 1035,
+  "message": "Invalid code"
+}

--- a/playwright-acceptance-tests/stubs/api-stub/responses/verify-code-400-max-attempts.json
+++ b/playwright-acceptance-tests/stubs/api-stub/responses/verify-code-400-max-attempts.json
@@ -1,0 +1,4 @@
+{
+  "code": 1034,
+  "message": "Entered invalid verify phone number code max times"
+}

--- a/playwright-acceptance-tests/stubs/api-stub/responses/verify-mfa-code-400-invalid.json
+++ b/playwright-acceptance-tests/stubs/api-stub/responses/verify-mfa-code-400-invalid.json
@@ -1,0 +1,4 @@
+{
+  "code": 1043,
+  "message": "Invalid auth app code"
+}

--- a/playwright-acceptance-tests/stubs/api-stub/responses/verify-mfa-code-400-max-attempts.json
+++ b/playwright-acceptance-tests/stubs/api-stub/responses/verify-mfa-code-400-max-attempts.json
@@ -1,0 +1,4 @@
+{
+  "code": 1042,
+  "message": "Auth app invalid code max attempts reached"
+}

--- a/playwright-acceptance-tests/stubs/api-stub/rest-plugin-config.yaml
+++ b/playwright-acceptance-tests/stubs/api-stub/rest-plugin-config.yaml
@@ -41,22 +41,19 @@ resources:
     method: POST
     contentType: "application/json"
     response:
-      statusCode: 200
-      file: responses/start-200.json
+      scriptFile: start-handler.js
 
   - path: "/user-exists"
     method: POST
     contentType: "application/json"
     response:
-      statusCode: 200
-      file: responses/user-exists-200.json
+      scriptFile: user-exists-handler.js
 
   - path: "/login"
     method: POST
     contentType: "application/json"
     response:
-      statusCode: 200
-      file: responses/login-200.json
+      scriptFile: login-handler.js
 
   - path: "/signup"
     method: POST
@@ -69,19 +66,19 @@ resources:
     method: POST
     contentType: "application/json"
     response:
-      statusCode: 204
+      scriptFile: mfa-handler.js
 
   - path: "/verify-code"
     method: POST
     contentType: "application/json"
     response:
-      statusCode: 204
+      scriptFile: verify-code-handler.js
 
   - path: "/verify-mfa-code"
     method: POST
     contentType: "application/json"
     response:
-      statusCode: 204
+      scriptFile: verify-mfa-handler.js
 
   - path: "/send-notification"
     method: POST

--- a/playwright-acceptance-tests/stubs/api-stub/start-handler.js
+++ b/playwright-acceptance-tests/stubs/api-stub/start-handler.js
@@ -1,0 +1,13 @@
+var body = JSON.parse(context.request.body);
+
+if (body.requested_credential_strength === "Cl") {
+  respond()
+    .withStatusCode(200)
+    .withFile("responses/start-200-no-mfa.json")
+    .skipDefaultBehaviour();
+} else {
+  respond()
+    .withStatusCode(200)
+    .withFile("responses/start-200.json")
+    .skipDefaultBehaviour();
+}

--- a/playwright-acceptance-tests/stubs/api-stub/user-exists-handler.js
+++ b/playwright-acceptance-tests/stubs/api-stub/user-exists-handler.js
@@ -1,0 +1,21 @@
+var accountLocked = stores.open("accountLocked").load("default");
+var smsCodeLocked = stores.open("smsCodeLocked").load("default");
+var smsResendLocked = stores.open("smsResendLocked").load("default");
+var authAppLocked = stores.open("authAppLocked").load("default");
+
+if (
+  accountLocked === "locked" ||
+  smsCodeLocked === "locked" ||
+  smsResendLocked === "locked" ||
+  authAppLocked === "locked"
+) {
+  respond()
+    .withStatusCode(400)
+    .withContent('{"code":1045,"message":"Account locked"}')
+    .skipDefaultBehaviour();
+} else {
+  respond()
+    .withStatusCode(200)
+    .withFile("responses/user-exists-200.json")
+    .skipDefaultBehaviour();
+}

--- a/playwright-acceptance-tests/stubs/api-stub/verify-code-handler.js
+++ b/playwright-acceptance-tests/stubs/api-stub/verify-code-handler.js
@@ -1,0 +1,23 @@
+var body = JSON.parse(context.request.body);
+var store = stores.open("verifyCodeAttempts");
+var count = store.load("default") || 0;
+
+if (body.code === "999999") {
+  count++;
+  store.save("default", count);
+  if (count >= 6) {
+    var lockoutStore = stores.open("smsCodeLocked");
+    lockoutStore.save("default", "locked");
+    respond()
+      .withStatusCode(400)
+      .withContent('{"code":1034,"message":"Max code attempts reached"}')
+      .skipDefaultBehaviour();
+  } else {
+    respond()
+      .withStatusCode(400)
+      .withContent('{"code":1035,"message":"Invalid code"}')
+      .skipDefaultBehaviour();
+  }
+} else {
+  respond().withStatusCode(204).withEmpty().skipDefaultBehaviour();
+}

--- a/playwright-acceptance-tests/stubs/api-stub/verify-mfa-handler.js
+++ b/playwright-acceptance-tests/stubs/api-stub/verify-mfa-handler.js
@@ -1,0 +1,23 @@
+var body = JSON.parse(context.request.body);
+var store = stores.open("verifyMfaAttempts");
+var count = store.load("default") || 0;
+
+if (body.code === "999999") {
+  count++;
+  store.save("default", count);
+  if (count >= 6) {
+    var lockoutStore = stores.open("authAppLocked");
+    lockoutStore.save("default", "locked");
+    respond()
+      .withStatusCode(400)
+      .withContent('{"code":1042,"message":"Max auth app attempts reached"}')
+      .skipDefaultBehaviour();
+  } else {
+    respond()
+      .withStatusCode(400)
+      .withContent('{"code":1043,"message":"Invalid auth app code"}')
+      .skipDefaultBehaviour();
+  }
+} else {
+  respond().withStatusCode(204).withEmpty().skipDefaultBehaviour();
+}


### PR DESCRIPTION
## What

- Migrates sign-in journey acceptance tests from Selenium (authentication-acceptance-tests) to Playwright + Cucumber (authentication-frontend/playwright-acceptance-tests)
- Implements 9 scenarios across 2 feature files: happy path sign-in (SMS, auth app, no-MFA, duplicate email, Welsh) and lockout scenarios (password, SMS code, SMS resend, auth app)
- Adds Imposter handler scripts with stateful counting for lockout flows
- Adds custom expect helper with 10s timeout for assertion resilience
- Fixes BasePage.goto to use domcontentloaded (not networkidle)
- Updates docker-compose with pinned image versions and orch-stub backend URL

## How to review

1. Code Review