### PR TITLE
Aut 5529/suppress passkey setup for new accounts

### DIFF
--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -106,6 +106,8 @@ async function getExistingUserAndPopulateSessionData(
     { redactedPhoneNumber: result.data.phoneNumberLastThree }
   );
   req.session.user.hasActivePasskey = result.data.hasActivePasskey;
+  req.session.user.backendIndicatesPasskeyPromptShouldBeSkipped =
+    result.data.shouldSuppressPasskeyRegistrationPrompt;
   req.session.user.isAccountCreationJourney = !result.data.doesUserExist;
   req.session.user.needsForcedMFAReset =
     result.data.needsForcedMFAResetAfterMFACheck;

--- a/src/components/enter-email/tests/enter-email-controller.test.ts
+++ b/src/components/enter-email/tests/enter-email-controller.test.ts
@@ -501,6 +501,27 @@ describe("enter email controller", () => {
         );
       });
     });
+
+    const booleans = [true, false];
+    booleans.forEach((value) => {
+      it(`should store whether the backend indicates we should suppress the passkey registration prompt in the session when field in response is ${value}`, async () => {
+        const fakeService: EnterEmailServiceInterface = {
+          userExists: sinon.fake.returns({
+            success: true,
+            data: {
+              doesUserExist: true,
+              shouldSuppressPasskeyRegistrationPrompt: value,
+            },
+          }),
+        } as unknown as EnterEmailServiceInterface;
+
+        await enterEmailPost(fakeService)(req as Request, res as Response);
+
+        expect(
+          req.session.user.backendIndicatesPasskeyPromptShouldBeSkipped
+        ).to.eq(value);
+      });
+    });
   });
 
   describe("enterEmailCreatePost", () => {

--- a/src/components/enter-email/types.ts
+++ b/src/components/enter-email/types.ts
@@ -10,6 +10,7 @@ export interface UserExists extends DefaultApiResponse {
   lockoutInformation?: LockoutInformation[];
   hasActivePasskey: boolean | null;
   needsForcedMFAResetAfterMFACheck: boolean;
+  shouldSuppressPasskeyRegistrationPrompt: boolean;
 }
 export interface LockoutInformation {
   lockType: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,7 @@ export interface UserSession {
   hasSkippedPasskeyRegistration?: boolean;
   needsForcedMFAReset?: boolean;
   browserSupportsWebAuthn?: boolean;
+  backendIndicatesPasskeyPromptShouldBeSkipped?: boolean;
 }
 
 export interface UserSessionClient {

--- a/src/utils/passkeys-helper.test.ts
+++ b/src/utils/passkeys-helper.test.ts
@@ -15,6 +15,16 @@ describe("passkeys helper", () => {
         hasSkippedPasskeyRegistration: false,
         supportPasskeyRegistration: true,
         rpClientId: "valid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        expected: true,
+      },
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: false,
+        hasSkippedPasskeyRegistration: false,
+        supportPasskeyRegistration: true,
+        rpClientId: "valid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: null,
         expected: true,
       },
       {
@@ -23,6 +33,7 @@ describe("passkeys helper", () => {
         hasSkippedPasskeyRegistration: false,
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: false,
         expected: false,
       },
       {
@@ -31,6 +42,7 @@ describe("passkeys helper", () => {
         hasSkippedPasskeyRegistration: false,
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: false,
         expected: false,
       },
       {
@@ -39,6 +51,7 @@ describe("passkeys helper", () => {
         hasSkippedPasskeyRegistration: true,
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: false,
         expected: false,
       },
       {
@@ -47,6 +60,7 @@ describe("passkeys helper", () => {
         hasSkippedPasskeyRegistration: false,
         supportPasskeyRegistration: false,
         rpClientId: "invalid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: false,
         expected: false,
       },
       {
@@ -56,6 +70,7 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         reauthenticate: "12345",
         rpClientId: "invalid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: false,
         expected: false,
       },
       {
@@ -64,6 +79,7 @@ describe("passkeys helper", () => {
         hasSkippedPasskeyRegistration: false,
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: false,
         expected: false,
       },
       {
@@ -72,6 +88,16 @@ describe("passkeys helper", () => {
         hasSkippedPasskeyRegistration: false,
         supportPasskeyRegistration: true,
         rpClientId: "valid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        expected: false,
+      },
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: false,
+        hasSkippedPasskeyRegistration: false,
+        supportPasskeyRegistration: true,
+        rpClientId: "valid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: true,
         expected: false,
       },
     ];
@@ -84,6 +110,7 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration,
         reauthenticate,
         rpClientId,
+        backendIndicatesPasskeyPromptShouldBeSkipped,
         expected,
       }) => {
         it(`should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, hasSkippedPasskeyRegistration=${hasSkippedPasskeyRegistration}, supportPasskeyRegistration=${supportPasskeyRegistration}, reauthenticate=${reauthenticate}, rpClientId=${rpClientId}`, () => {
@@ -96,6 +123,7 @@ describe("passkeys helper", () => {
                 hasActivePasskey,
                 hasSkippedPasskeyRegistration,
                 reauthenticate,
+                backendIndicatesPasskeyPromptShouldBeSkipped,
               },
               client: {
                 rpClientId: rpClientId,

--- a/src/utils/passkeys-helper.ts
+++ b/src/utils/passkeys-helper.ts
@@ -9,6 +9,7 @@ export function shouldPromptToRegisterPasskey(
     req.session.user?.browserSupportsWebAuthn === true &&
     req.session.user?.hasActivePasskey === false &&
     req.session.user?.hasSkippedPasskeyRegistration !== true &&
+    req.session.user?.backendIndicatesPasskeyPromptShouldBeSkipped !== true &&
     !req.session.user?.reauthenticate &&
     isPromptableRPClientID(req.session.client.rpClientId) &&
     res.locals.supportPasskeyRegistration === true


### PR DESCRIPTION
## What

Read the new field returned on user exists response which indicates if the backend knows of a reason to suppress the passkey registration prompt, and use it in the prompting rules.

Together with the backend PR, this means now that if a user has an account less than two hours old, we don't show them the register passkey prompt.

In future, more rules may be added into the backend.

## How to review


* Code review
* Run locally (or currently deployed to dev) with the backend PR. Check that all works as intended with an account without a passkey.

## Related PRs

[Backend PR](https://github.com/govuk-one-login/authentication-api/pull/8503) which needs to be merged first

An acceptance test PR will follow. Currently the acceptance tests which expect the passkey registration prompt will all still pass because when the user is setup in the database, we don't add a created at timestamp, and the backend treats this as no suppression required. So this can be merged before that.