### PR TITLE
BAU: Fix deployment to subenvs

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -2580,6 +2580,6 @@ Resources:
       Type: String
       Value: !FindInMap
         - AcceptanceTestTags
-        - !Ref Environment
+        - !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
         - tags
         - DefaultValue: "unused"


### PR DESCRIPTION
When deploying to authdev1 or authdev2 we'd attempt to overwrite the dev acceptance test parameter since we were looking up based on environment not subenvironment. This caused state issues in cloudformation

