### PR TITLE
BAU: Enable @PasskeyUsageEnabled tests in Staging

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -629,7 +629,7 @@ Mappings:
       tags: >-
         @UI and not (@under-development or @AccountInterventions or @new-mfa-reset-with-ipv or
         @AcceptInternationalNumbers or @InternationalSmsSendingDisabled
-        or @PasskeyUsageEnabled or @EnvironmentWithAMCStubDeployed)
+        or @EnvironmentWithAMCStubDeployed)
 
 Globals:
   Function:


### PR DESCRIPTION
## What

Removes `@PasskeyUsageEnabled` from the `not` section of the acceptance test filter flags for Staging, so that these tests now run. We'll continue to keep it disabled in Build until we go-live.

## How to review

1. Code Review