### PR TITLE
BAU: Ensure 401 errors are correctly handled in passkey sign in

### DIFF
--- a/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
+++ b/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
@@ -167,11 +167,31 @@ describe("Integration:: cannot sign in passkey", () => {
           .expect(403);
       });
 
-      it("should redirect to cannot-sign-in-passkey when finishPasskeyAssertion fails", async () => {
+      it("should redirect to cannot-sign-in-passkey when parsing pkc error", async () => {
         nock(baseApi)
           .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
           .once()
           .reply(400, { success: false, code: 0 });
+
+        await request(app)
+          .post(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            _csrf: token,
+            authenticationResponse: commonVariables.passkeyAssertionResponse,
+            "cannot-sign-in-passkey-action":
+              CANNOT_SIGN_IN_PASSKEY_ACTION.RETRY_PASSKEY,
+          })
+          .expect(302)
+          .expect("Location", PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);
+      });
+
+      it("should redirect to cannot-sign-in-passkey when finish assertion fails", async () => {
+        nock(baseApi)
+          .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
+          .once()
+          .reply(401, { success: false, code: 0 });
 
         await request(app)
           .post(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)

--- a/src/components/common/passkey/passkey-service.ts
+++ b/src/components/common/passkey/passkey-service.ts
@@ -9,7 +9,7 @@ import type {
   StartPasskeyAssertionResponse,
 } from "./types.js";
 import type { ApiResponseResult, DefaultApiResponse } from "../../../types.js";
-import { API_ENDPOINTS } from "../../../app.constants.js";
+import { API_ENDPOINTS, HTTP_STATUS_CODES } from "../../../app.constants.js";
 import type { Request } from "express";
 import type { AuthenticationResponseJSON } from "@simplewebauthn/browser";
 
@@ -52,6 +52,11 @@ export function passkeyService(axios: Http = http): PasskeyServiceInterface {
           sessionId: sessionId,
           clientSessionId: clientSessionId,
           persistentSessionId: persistentSessionId,
+          validationStatuses: [
+            HTTP_STATUS_CODES.UNAUTHORIZED,
+            HTTP_STATUS_CODES.OK,
+            HTTP_STATUS_CODES.BAD_REQUEST,
+          ],
         },
         req,
         API_ENDPOINTS.FINISH_PASSKEY_ASSERTION

--- a/src/components/common/passkey/tests/passkey-service.test.ts
+++ b/src/components/common/passkey/tests/passkey-service.test.ts
@@ -139,6 +139,7 @@ describe("passkey service", () => {
         expectedPath: API_ENDPOINTS.FINISH_PASSKEY_ASSERTION,
         expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
         expectedBody: { pkc: startAuthenticationWebauthnResponse },
+        validateStatus: true,
       };
       checkApiCallMadeWithExpectedBodyAndHeaders(
         result,
@@ -176,6 +177,7 @@ describe("passkey service", () => {
         expectedPath: API_ENDPOINTS.FINISH_PASSKEY_ASSERTION,
         expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
         expectedBody: { pkc: startAuthenticationWebauthnResponse },
+        validateStatus: true,
       };
       checkApiCallMadeWithExpectedBodyAndHeaders(
         result,

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
@@ -151,11 +151,29 @@ describe("Integration:: sign in with passkey", () => {
           .expect("Location", PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);
       });
 
-      it("should redirect to cannot sign in passkey when finish assertion fails", async () => {
+      it("should redirect to cannot sign in passkey when parsing pkc error", async () => {
         nock(baseApi)
           .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
           .once()
           .reply(400, { message: "Assertion failed", code: 1000 });
+
+        await request(app)
+          .post(PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+          .type("form")
+          .set("Cookie", cookies)
+          .send({
+            _csrf: token,
+            authenticationResponse: commonVariables.passkeyAssertionResponse,
+          })
+          .expect(302)
+          .expect("Location", PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);
+      });
+
+      it("should redirect to cannot sign in passkey when finish assertion fails", async () => {
+        nock(baseApi)
+          .post(API_ENDPOINTS.FINISH_PASSKEY_ASSERTION)
+          .once()
+          .reply(401, { message: "Assertion failed", code: 1000 });
 
         await request(app)
           .post(PATH_NAMES.SIGN_IN_WITH_PASSKEY)


### PR DESCRIPTION
## What

By default axios will throw if the status code in the response is status >= 200 && status < 300. We override this in http.ts, so if the status code is between 200 and 400 inclusive, we handle this ourselves.

For sign in with passkey, the FinishAssertionHandler can return a 401, which we want to handle and display the cannot-sign-in-passkey page. This was not being correctly handled before.

## How to review

1. code review

## Checklist
