### PR TITLE
Aut 5531/suppress setup prompt in pw reset

### DIFF
--- a/src/components/enter-password/enter-password-controller.ts
+++ b/src/components/enter-password/enter-password-controller.ts
@@ -181,6 +181,7 @@ export function enterPasswordPost(
     req.session.user.isLatestTermsAndConditionsAccepted =
       userLogin.data.latestTermsAndConditionsAccepted;
     req.session.user.isPasswordChangeRequired = isPasswordChangeRequired;
+    req.session.user.isCommonPasswordResetJourney = isPasswordChangeRequired;
     req.session.user.mfaMethodType = userLogin.data.mfaMethodType;
 
     const interventionRedirect = await handleAccountInterventions(

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,9 +82,10 @@ export interface UserSession {
   isAccountRecoveryJourney?: boolean;
   accountRecoveryVerifiedMfaType?: string;
   reauthenticate?: string;
-  withinForcedPasswordResetJourney?: boolean;
+  withinForcedPasswordResetJourney?: boolean; // for account interventions
+  isCommonPasswordResetJourney?: boolean; // for common passwords
+  isPasswordResetJourney?: boolean; // for user triggered password reset
   passwordResetTime?: number;
-  isPasswordResetJourney?: boolean;
   isSignInJourney?: boolean;
   isVerifyEmailCodeResendRequired?: boolean;
   channel?: string;

--- a/src/utils/passkeys-helper.test.ts
+++ b/src/utils/passkeys-helper.test.ts
@@ -16,8 +16,6 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
-        isPasswordResetJourney: false,
-        withinForcedPasswordResetJourney: false,
         expected: true,
       },
       {
@@ -27,8 +25,6 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: null,
-        isPasswordResetJourney: false,
-        withinForcedPasswordResetJourney: false,
         expected: true,
       },
       {
@@ -38,8 +34,6 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
-        isPasswordResetJourney: false,
-        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -49,8 +43,6 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
-        isPasswordResetJourney: false,
-        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -60,8 +52,6 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
-        isPasswordResetJourney: false,
-        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -71,8 +61,6 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: false,
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
-        isPasswordResetJourney: false,
-        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -83,8 +71,6 @@ describe("passkeys helper", () => {
         reauthenticate: "12345",
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
-        isPasswordResetJourney: false,
-        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -94,8 +80,6 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
-        isPasswordResetJourney: false,
-        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -105,8 +89,6 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
-        isPasswordResetJourney: false,
-        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -116,30 +98,6 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: true,
-        isPasswordResetJourney: false,
-        withinForcedPasswordResetJourney: false,
-        expected: false,
-      },
-      {
-        browserSupportsWebAuthn: true,
-        hasActivePasskey: false,
-        hasSkippedPasskeyRegistration: false,
-        supportPasskeyRegistration: true,
-        rpClientId: "valid-rp-client-id",
-        backendIndicatesPasskeyPromptShouldBeSkipped: false,
-        isPasswordResetJourney: true,
-        withinForcedPasswordResetJourney: false,
-        expected: false,
-      },
-      {
-        browserSupportsWebAuthn: true,
-        hasActivePasskey: false,
-        hasSkippedPasskeyRegistration: false,
-        supportPasskeyRegistration: true,
-        rpClientId: "valid-rp-client-id",
-        backendIndicatesPasskeyPromptShouldBeSkipped: false,
-        isPasswordResetJourney: false,
-        withinForcedPasswordResetJourney: true,
         expected: false,
       },
     ];
@@ -153,11 +111,9 @@ describe("passkeys helper", () => {
         reauthenticate,
         rpClientId,
         backendIndicatesPasskeyPromptShouldBeSkipped,
-        isPasswordResetJourney,
-        withinForcedPasswordResetJourney,
         expected,
       }) => {
-        it(`should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, hasSkippedPasskeyRegistration=${hasSkippedPasskeyRegistration}, supportPasskeyRegistration=${supportPasskeyRegistration}, reauthenticate=${reauthenticate}, rpClientId=${rpClientId}, backendIndicatesPasskeyPromptShouldBeSkipped=${backendIndicatesPasskeyPromptShouldBeSkipped}, passwordResetJourney=${isPasswordResetJourney}, withinForcedPasswordResetJourney=${withinForcedPasswordResetJourney}`, () => {
+        it(`should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, hasSkippedPasskeyRegistration=${hasSkippedPasskeyRegistration}, supportPasskeyRegistration=${supportPasskeyRegistration}, reauthenticate=${reauthenticate}, rpClientId=${rpClientId}, backendIndicatesPasskeyPromptShouldBeSkipped=${backendIndicatesPasskeyPromptShouldBeSkipped}`, () => {
           process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
 
           const req = {
@@ -168,8 +124,9 @@ describe("passkeys helper", () => {
                 hasSkippedPasskeyRegistration,
                 reauthenticate,
                 backendIndicatesPasskeyPromptShouldBeSkipped,
-                isPasswordResetJourney,
-                withinForcedPasswordResetJourney,
+                isPasswordResetJourney: false,
+                withinForcedPasswordResetJourney: false,
+                isCommonPasswordResetJourney: false,
               },
               client: {
                 rpClientId: rpClientId,
@@ -181,6 +138,77 @@ describe("passkeys helper", () => {
           } as any as Response;
 
           expect(shouldPromptToRegisterPasskey(req, res)).to.eq(expected);
+        });
+      }
+    );
+
+    const passwordResetTestCases = [
+      {
+        isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
+        isCommonPasswordResetJourney: false,
+        expectedShouldPromptToRegister: true,
+      },
+      {
+        isPasswordResetJourney: null,
+        withinForcedPasswordResetJourney: null,
+        isCommonPasswordResetJourney: null,
+        expectedShouldPromptToRegister: true,
+      },
+      {
+        isPasswordResetJourney: true,
+        withinForcedPasswordResetJourney: false,
+        isCommonPasswordResetJourney: false,
+        expectedShouldPromptToRegister: false,
+      },
+      {
+        isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: true,
+        isCommonPasswordResetJourney: false,
+        expectedShouldPromptToRegister: false,
+      },
+      {
+        isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
+        isCommonPasswordResetJourney: true,
+        expectedShouldPromptToRegister: false,
+      },
+    ];
+
+    passwordResetTestCases.forEach(
+      ({
+        isPasswordResetJourney,
+        withinForcedPasswordResetJourney,
+        isCommonPasswordResetJourney,
+        expectedShouldPromptToRegister,
+      }) => {
+        it(`should return ${expectedShouldPromptToRegister} when passwordResetJourney=${isPasswordResetJourney}, withinForcedPasswordResetJourney=${withinForcedPasswordResetJourney} and isCommonPasswordResetJourney=${isCommonPasswordResetJourney}`, () => {
+          process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
+
+          const req = {
+            session: {
+              user: {
+                browserSupportsWebAuthn: true,
+                hasActivePasskey: false,
+                hasSkippedPasskeyRegistration: false,
+                reauthenticate: false,
+                backendIndicatesPasskeyPromptShouldBeSkipped: false,
+                isPasswordResetJourney,
+                withinForcedPasswordResetJourney,
+                isCommonPasswordResetJourney,
+              },
+              client: {
+                rpClientId: "valid-rp-client-id",
+              },
+            },
+          } as any as Request;
+          const res = {
+            locals: { supportPasskeyRegistration: true },
+          } as any as Response;
+
+          expect(shouldPromptToRegisterPasskey(req, res)).to.eq(
+            expectedShouldPromptToRegister
+          );
         });
       }
     );

--- a/src/utils/passkeys-helper.test.ts
+++ b/src/utils/passkeys-helper.test.ts
@@ -17,6 +17,7 @@ describe("passkeys helper", () => {
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
         isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
         expected: true,
       },
       {
@@ -27,6 +28,7 @@ describe("passkeys helper", () => {
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: null,
         isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
         expected: true,
       },
       {
@@ -37,6 +39,7 @@ describe("passkeys helper", () => {
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
         isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -47,6 +50,7 @@ describe("passkeys helper", () => {
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
         isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -57,6 +61,7 @@ describe("passkeys helper", () => {
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
         isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -67,6 +72,7 @@ describe("passkeys helper", () => {
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
         isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -78,6 +84,7 @@ describe("passkeys helper", () => {
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
         isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -88,6 +95,7 @@ describe("passkeys helper", () => {
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
         isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -98,6 +106,7 @@ describe("passkeys helper", () => {
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
         isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -108,6 +117,7 @@ describe("passkeys helper", () => {
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: true,
         isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -118,6 +128,18 @@ describe("passkeys helper", () => {
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
         isPasswordResetJourney: true,
+        withinForcedPasswordResetJourney: false,
+        expected: false,
+      },
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: false,
+        hasSkippedPasskeyRegistration: false,
+        supportPasskeyRegistration: true,
+        rpClientId: "valid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        isPasswordResetJourney: false,
+        withinForcedPasswordResetJourney: true,
         expected: false,
       },
     ];
@@ -132,9 +154,10 @@ describe("passkeys helper", () => {
         rpClientId,
         backendIndicatesPasskeyPromptShouldBeSkipped,
         isPasswordResetJourney,
+        withinForcedPasswordResetJourney,
         expected,
       }) => {
-        it(`should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, hasSkippedPasskeyRegistration=${hasSkippedPasskeyRegistration}, supportPasskeyRegistration=${supportPasskeyRegistration}, reauthenticate=${reauthenticate}, rpClientId=${rpClientId}, backendIndicatesPasskeyPromptShouldBeSkipped=${backendIndicatesPasskeyPromptShouldBeSkipped}, passwordResetJourney=${isPasswordResetJourney}`, () => {
+        it(`should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, hasSkippedPasskeyRegistration=${hasSkippedPasskeyRegistration}, supportPasskeyRegistration=${supportPasskeyRegistration}, reauthenticate=${reauthenticate}, rpClientId=${rpClientId}, backendIndicatesPasskeyPromptShouldBeSkipped=${backendIndicatesPasskeyPromptShouldBeSkipped}, passwordResetJourney=${isPasswordResetJourney}, withinForcedPasswordResetJourney=${withinForcedPasswordResetJourney}`, () => {
           process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
 
           const req = {
@@ -146,6 +169,7 @@ describe("passkeys helper", () => {
                 reauthenticate,
                 backendIndicatesPasskeyPromptShouldBeSkipped,
                 isPasswordResetJourney,
+                withinForcedPasswordResetJourney,
               },
               client: {
                 rpClientId: rpClientId,

--- a/src/utils/passkeys-helper.test.ts
+++ b/src/utils/passkeys-helper.test.ts
@@ -16,6 +16,7 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        isPasswordResetJourney: false,
         expected: true,
       },
       {
@@ -25,6 +26,7 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: null,
+        isPasswordResetJourney: false,
         expected: true,
       },
       {
@@ -34,6 +36,7 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        isPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -43,6 +46,7 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        isPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -52,6 +56,7 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        isPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -61,6 +66,7 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: false,
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        isPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -71,6 +77,7 @@ describe("passkeys helper", () => {
         reauthenticate: "12345",
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        isPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -80,6 +87,7 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "invalid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        isPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -89,6 +97,7 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        isPasswordResetJourney: false,
         expected: false,
       },
       {
@@ -98,6 +107,17 @@ describe("passkeys helper", () => {
         supportPasskeyRegistration: true,
         rpClientId: "valid-rp-client-id",
         backendIndicatesPasskeyPromptShouldBeSkipped: true,
+        isPasswordResetJourney: false,
+        expected: false,
+      },
+      {
+        browserSupportsWebAuthn: true,
+        hasActivePasskey: false,
+        hasSkippedPasskeyRegistration: false,
+        supportPasskeyRegistration: true,
+        rpClientId: "valid-rp-client-id",
+        backendIndicatesPasskeyPromptShouldBeSkipped: false,
+        isPasswordResetJourney: true,
         expected: false,
       },
     ];
@@ -111,9 +131,10 @@ describe("passkeys helper", () => {
         reauthenticate,
         rpClientId,
         backendIndicatesPasskeyPromptShouldBeSkipped,
+        isPasswordResetJourney,
         expected,
       }) => {
-        it(`should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, hasSkippedPasskeyRegistration=${hasSkippedPasskeyRegistration}, supportPasskeyRegistration=${supportPasskeyRegistration}, reauthenticate=${reauthenticate}, rpClientId=${rpClientId}`, () => {
+        it(`should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, hasSkippedPasskeyRegistration=${hasSkippedPasskeyRegistration}, supportPasskeyRegistration=${supportPasskeyRegistration}, reauthenticate=${reauthenticate}, rpClientId=${rpClientId}, backendIndicatesPasskeyPromptShouldBeSkipped=${backendIndicatesPasskeyPromptShouldBeSkipped}, passwordResetJourney=${isPasswordResetJourney}`, () => {
           process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
 
           const req = {
@@ -124,6 +145,7 @@ describe("passkeys helper", () => {
                 hasSkippedPasskeyRegistration,
                 reauthenticate,
                 backendIndicatesPasskeyPromptShouldBeSkipped,
+                isPasswordResetJourney,
               },
               client: {
                 rpClientId: rpClientId,

--- a/src/utils/passkeys-helper.ts
+++ b/src/utils/passkeys-helper.ts
@@ -11,7 +11,7 @@ export function shouldPromptToRegisterPasskey(
     req.session.user?.hasSkippedPasskeyRegistration !== true &&
     req.session.user?.backendIndicatesPasskeyPromptShouldBeSkipped !== true &&
     !req.session.user?.reauthenticate &&
-    !req.session.user?.isPasswordResetJourney &&
+    !userHasBeenOnPasswordResetJourney(req) &&
     isPromptableRPClientID(req.session.client.rpClientId) &&
     res.locals.supportPasskeyRegistration === true
   );
@@ -30,4 +30,11 @@ export function shouldPromptToSignInWithPasskey(
 
 function isPromptableRPClientID(rpClientId: string) {
   return getPasskeyPromptClientAllowList().includes(rpClientId);
+}
+
+function userHasBeenOnPasswordResetJourney(req: Request) {
+  return (
+    req.session.user?.isPasswordResetJourney ||
+    req.session.user?.withinForcedPasswordResetJourney
+  );
 }

--- a/src/utils/passkeys-helper.ts
+++ b/src/utils/passkeys-helper.ts
@@ -35,6 +35,7 @@ function isPromptableRPClientID(rpClientId: string) {
 function userHasBeenOnPasswordResetJourney(req: Request) {
   return (
     req.session.user?.isPasswordResetJourney ||
-    req.session.user?.withinForcedPasswordResetJourney
+    req.session.user?.withinForcedPasswordResetJourney ||
+    req.session.user?.isCommonPasswordResetJourney
   );
 }

--- a/src/utils/passkeys-helper.ts
+++ b/src/utils/passkeys-helper.ts
@@ -11,6 +11,7 @@ export function shouldPromptToRegisterPasskey(
     req.session.user?.hasSkippedPasskeyRegistration !== true &&
     req.session.user?.backendIndicatesPasskeyPromptShouldBeSkipped !== true &&
     !req.session.user?.reauthenticate &&
+    !req.session.user?.isPasswordResetJourney &&
     isPromptableRPClientID(req.session.client.rpClientId) &&
     res.locals.supportPasskeyRegistration === true
   );


### PR DESCRIPTION
## What

Do not prompt a user to set up a passkey if they have been through any kind of password reset journey:

* voluntary password reset
* forced password reset via an account intervention
* forced password reset via having a common password

This is to reduce prompt fatigue when a user has gone through a more complicated sign in journey.

## Related PRs

[Related acceptance test change](https://github.com/govuk-one-login/authentication-acceptance-tests/pull/942) (this frontend PR can be merged first as the registration step is currently optional so will not fail if removed from these journeys, but this test PR prevents regression)