### PR TITLE
BAU: Exclude new more specific ReauthLogout tag

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -619,12 +619,12 @@ Mappings:
   AcceptanceTestTags:
     dev:
       tags: >-
-        @UI and not (@Reauth or
+        @UI and not (@ReauthMultiTabLogout or
         @AccountRecovery or @InternationalSmsSendingDisabled)
         and not (@InternationalNumbersIndefiniteLockout and @under-development)
     build:
       tags: >-
-        @UI and not (@under-development or @Reauth or
+        @UI and not (@under-development or @ReauthMultiTabLogout or
         @AcceptInternationalNumbers or @InternationalSmsSendingDisabled
         or @PasskeysEnabled or @PasskeyUsageEnabled)
     staging:


### PR DESCRIPTION
## What

- Exclude new more specific ReauthMultiTabLogout tag instead of Reauth
- Only tests that require integration with orchestration are failing in dev and build, which are now tagged with @ReauthLogout in authentication-acceptance-tests
- The other tests can run in dev and build successfully and will now run

## How to review

1. Code Review
2. Deploy to dev and see successful pipeline run
