### PR TITLE
AUT 5532 & 5533: suppress passkey prompt in no 2fa variants

### DIFF
--- a/src/utils/passkeys-helper.test.ts
+++ b/src/utils/passkeys-helper.test.ts
@@ -127,6 +127,7 @@ describe("passkeys helper", () => {
                 isPasswordResetJourney: false,
                 withinForcedPasswordResetJourney: false,
                 isCommonPasswordResetJourney: false,
+                isMfaRequired: true,
               },
               client: {
                 rpClientId: rpClientId,
@@ -193,9 +194,54 @@ describe("passkeys helper", () => {
                 hasSkippedPasskeyRegistration: false,
                 reauthenticate: false,
                 backendIndicatesPasskeyPromptShouldBeSkipped: false,
+                isMfaRequired: true,
                 isPasswordResetJourney,
                 withinForcedPasswordResetJourney,
                 isCommonPasswordResetJourney,
+              },
+              client: {
+                rpClientId: "valid-rp-client-id",
+              },
+            },
+          } as any as Request;
+          const res = {
+            locals: { supportPasskeyRegistration: true },
+          } as any as Response;
+
+          expect(shouldPromptToRegisterPasskey(req, res)).to.eq(
+            expectedShouldPromptToRegister
+          );
+        });
+      }
+    );
+
+    const mfaVariantTestCases = [
+      {
+        isMfaRequired: true,
+        expectedShouldPromptToRegister: true,
+      },
+      {
+        isMfaRequired: false,
+        expectedShouldPromptToRegister: false,
+      },
+    ];
+    mfaVariantTestCases.forEach(
+      ({ isMfaRequired, expectedShouldPromptToRegister }) => {
+        it(`should return ${expectedShouldPromptToRegister} when isMfaRequired=${isMfaRequired}`, () => {
+          process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
+
+          const req = {
+            session: {
+              user: {
+                isMfaRequired: isMfaRequired,
+                browserSupportsWebAuthn: true,
+                hasActivePasskey: false,
+                hasSkippedPasskeyRegistration: false,
+                reauthenticate: false,
+                backendIndicatesPasskeyPromptShouldBeSkipped: false,
+                isPasswordResetJourney: false,
+                withinForcedPasswordResetJourney: false,
+                isCommonPasswordResetJourney: false,
               },
               client: {
                 rpClientId: "valid-rp-client-id",

--- a/src/utils/passkeys-helper.test.ts
+++ b/src/utils/passkeys-helper.test.ts
@@ -128,6 +128,7 @@ describe("passkeys helper", () => {
                 withinForcedPasswordResetJourney: false,
                 isCommonPasswordResetJourney: false,
                 isMfaRequired: true,
+                isUpliftRequired: false,
               },
               client: {
                 rpClientId: rpClientId,
@@ -195,6 +196,7 @@ describe("passkeys helper", () => {
                 reauthenticate: false,
                 backendIndicatesPasskeyPromptShouldBeSkipped: false,
                 isMfaRequired: true,
+                isUpliftRequired: false,
                 isPasswordResetJourney,
                 withinForcedPasswordResetJourney,
                 isCommonPasswordResetJourney,
@@ -218,22 +220,30 @@ describe("passkeys helper", () => {
     const mfaVariantTestCases = [
       {
         isMfaRequired: true,
+        isUpliftRequired: false,
         expectedShouldPromptToRegister: true,
       },
       {
         isMfaRequired: false,
+        isUpliftRequired: false,
+        expectedShouldPromptToRegister: false,
+      },
+      {
+        isMfaRequired: true,
+        isUpliftRequired: true,
         expectedShouldPromptToRegister: false,
       },
     ];
     mfaVariantTestCases.forEach(
-      ({ isMfaRequired, expectedShouldPromptToRegister }) => {
-        it(`should return ${expectedShouldPromptToRegister} when isMfaRequired=${isMfaRequired}`, () => {
+      ({ isMfaRequired, isUpliftRequired, expectedShouldPromptToRegister }) => {
+        it(`should return ${expectedShouldPromptToRegister} when isMfaRequired=${isMfaRequired} and isUpliftRequired=${isUpliftRequired}`, () => {
           process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
 
           const req = {
             session: {
               user: {
                 isMfaRequired: isMfaRequired,
+                isUpliftRequired: isUpliftRequired,
                 browserSupportsWebAuthn: true,
                 hasActivePasskey: false,
                 hasSkippedPasskeyRegistration: false,

--- a/src/utils/passkeys-helper.ts
+++ b/src/utils/passkeys-helper.ts
@@ -13,6 +13,7 @@ export function shouldPromptToRegisterPasskey(
     !req.session.user?.reauthenticate &&
     !userHasBeenOnPasswordResetJourney(req) &&
     isPromptableRPClientID(req.session.client.rpClientId) &&
+    userIsOn2FaJourney(req) &&
     res.locals.supportPasskeyRegistration === true
   );
 }
@@ -38,4 +39,8 @@ function userHasBeenOnPasswordResetJourney(req: Request) {
     req.session.user?.withinForcedPasswordResetJourney ||
     req.session.user?.isCommonPasswordResetJourney
   );
+}
+
+function userIsOn2FaJourney(req: Request) {
+  return req.session.user?.isMfaRequired;
 }

--- a/src/utils/passkeys-helper.ts
+++ b/src/utils/passkeys-helper.ts
@@ -13,7 +13,7 @@ export function shouldPromptToRegisterPasskey(
     !req.session.user?.reauthenticate &&
     !userHasBeenOnPasswordResetJourney(req) &&
     isPromptableRPClientID(req.session.client.rpClientId) &&
-    userIsOn2FaJourney(req) &&
+    userHasLoggedInWithPasswordAnd2Fa(req) &&
     res.locals.supportPasskeyRegistration === true
   );
 }
@@ -41,6 +41,6 @@ function userHasBeenOnPasswordResetJourney(req: Request) {
   );
 }
 
-function userIsOn2FaJourney(req: Request) {
-  return req.session.user?.isMfaRequired;
+function userHasLoggedInWithPasswordAnd2Fa(req: Request) {
+  return req.session.user?.isMfaRequired && !req.session.user?.isUpliftRequired;
 }


### PR DESCRIPTION
## What

Amend prompting rules to suppress passkey setup prompts in:

* 1fa journeys and
* Uplift journeys

We don't want to prompt in the case of 1fa journeys as they do not meet our security requirements to set up a passkey. In the case of uplift journeys, we do not want to add additional prompts.

## Related PRs

[Acceptance test PR](https://github.com/govuk-one-login/authentication-acceptance-tests/pull/949) (must be merged after this)
[Backend PR](https://github.com/govuk-one-login/authentication-api/pull/8564) which ensures that an authorisation for amc for passkey create is not requested if we do not think a 2fa journey has happened (must be merged after this)
