### PR TITLE
BAU: Update amc action type

### DIFF
--- a/src/components/create-passkey-callback/types.ts
+++ b/src/components/create-passkey-callback/types.ts
@@ -21,7 +21,8 @@ export interface CreatePasskeyResultSuccessResponse {
 
 export interface AMCAction {
   action: AMC_SCOPE;
-  timestamp: number;
+  startedAt: number;
+  completedAt: number;
   success: boolean;
   details: AMCActionErrorDetails;
 }


### PR DESCRIPTION
Replace timestamp field with startedAt / completedAt.

This matches the latest changes in home to the journey outcome response.

We do not read the timestamp field so this does not require any other code changes: updating the object in case we want to read from any of these fields in future

## Related PRs

Home's changes to the shape of the response: https://github.com/govuk-one-login/account-components/pull/970