### PR TITLE
AUT-5032: back button behaviour enter-password page to sign-in-passkey page

### DIFF
--- a/playwright-acceptance-tests/features/back-button-behaviour.feature
+++ b/playwright-acceptance-tests/features/back-button-behaviour.feature
@@ -1,0 +1,34 @@
+@UI
+Feature: Back Button Behaviour
+
+  Scenario: User can navigate to reset-password-check-email and navigate back through each page
+    Given a user with SMS MFA exists
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email" page
+    When the user enters their email address
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the forgotten password link
+    Then the user is taken to the "Check your email" page
+    When the user clicks the Back link
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the Back link
+    Then the user is taken to the "Enter your email" page
+    When the user clicks the Back link
+    Then the user is taken to the "Create your GOV.UK One Login or sign in" page
+
+  @PasskeyUsageEnabled
+  Scenario: User can go back to cannot sign in with a passkey page from enter-password
+    Given a user exists with a passkey
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Sign in with your face, fingerprint or passcode" page
+    When the user clicks the continue button
+    Then the user is taken to the "We could not sign you in" page
+    When the user selects radio button "Sign in with your password and a security code"
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the Back link
+    Then the user is taken to the "We could not sign you in" page
+  

--- a/playwright-acceptance-tests/features/back-button-behaviour.feature
+++ b/playwright-acceptance-tests/features/back-button-behaviour.feature
@@ -31,4 +31,16 @@ Feature: Back Button Behaviour
     Then the user is taken to the "Enter your password" page
     When the user clicks the Back link
     Then the user is taken to the "We could not sign you in" page
-  
+
+  @PasskeyUsageEnabled
+  Scenario: User can go back to sign in with a passkey from enter-password
+    Given a user exists with a passkey
+    When the user comes from the stub relying party with default options and is taken to the "Create your GOV.UK One Login or sign in" page
+    When the user selects sign in
+    Then the user is taken to the "Enter your email address" page
+    When the user enters their email address
+    Then the user is taken to the "Sign in with your face, fingerprint or passcode" page
+    When the user clicks link "Sign in another way"
+    Then the user is taken to the "Enter your password" page
+    When the user clicks the Back link
+    Then the user is taken to the "Sign in with your face, fingerprint or passcode" page

--- a/playwright-acceptance-tests/src/pages/BasePage.ts
+++ b/playwright-acceptance-tests/src/pages/BasePage.ts
@@ -36,6 +36,14 @@ export class BasePage {
     await this.page.getByRole("button", { name: /continue/i }).click();
   }
 
+  async clickBack(): Promise<void> {
+    await this.page.getByRole("link", { name: /^back$/i }).click();
+  }
+
+  async selectRadioButton(label: string | RegExp): Promise<void> {
+    await this.page.getByLabel(label).check();
+  }
+
   async goto(url: string): Promise<void> {
     await this.page.goto(url, { waitUntil: "domcontentloaded" });
   }

--- a/playwright-acceptance-tests/src/pages/EnterPasswordPage.ts
+++ b/playwright-acceptance-tests/src/pages/EnterPasswordPage.ts
@@ -20,6 +20,12 @@ export class EnterPasswordPage extends BasePage {
     await this.page.getByRole("button", { name: /continue/i }).click();
   }
 
+  async clickForgottenPasswordLink(): Promise<void> {
+    await this.page
+      .getByRole("link", { name: /forgotten my password/i })
+      .click();
+  }
+
   async enterPasswordAndContinue(password: string): Promise<void> {
     await this.enterPassword(password);
     await this.clickContinue();

--- a/playwright-acceptance-tests/src/steps/common.step.ts
+++ b/playwright-acceptance-tests/src/steps/common.step.ts
@@ -1,0 +1,20 @@
+import { When } from "@cucumber/cucumber";
+import type { PlaywrightWorld } from "../support/world";
+import { BasePage } from "../pages/BasePage";
+import { requirePage } from "../support/utils";
+
+When(
+  "the user clicks the Back link",
+  async function (this: PlaywrightWorld): Promise<void> {
+    await new BasePage(requirePage(this)).clickBack();
+  }
+);
+
+When(
+  "the user selects radio button {string}",
+  async function (this: PlaywrightWorld, label: string): Promise<void> {
+    const page = new BasePage(requirePage(this));
+    await page.selectRadioButton(label);
+    await page.clickContinue();
+  }
+);

--- a/playwright-acceptance-tests/src/steps/sign-in.steps.ts
+++ b/playwright-acceptance-tests/src/steps/sign-in.steps.ts
@@ -12,11 +12,7 @@ import { YouHaveOneLoginPage } from "../pages/YouHaveOneLoginPage";
 import { EnterAuthenticatorAppCodePage } from "../pages/EnterAuthenticatorAppCodePage";
 import { LockoutPage } from "../pages/LockoutPage";
 import { TEST_EMAIL, VALID_PASSWORD } from "../support/constants";
-
-function requirePage(world: PlaywrightWorld) {
-  if (!world.page) throw new Error("Playwright page is not initialised");
-  return world.page;
-}
+import { requirePage } from "../support/utils";
 
 /* ---- Given: user setup (no-ops with stub) ---- */
 
@@ -219,6 +215,13 @@ When(
     await new EnterPasswordPage(requirePage(this)).enterPasswordAndContinue(
       VALID_PASSWORD
     );
+  }
+);
+
+When(
+  "the user clicks the forgotten password link",
+  async function (this: PlaywrightWorld): Promise<void> {
+    await new EnterPasswordPage(requirePage(this)).clickForgottenPasswordLink();
   }
 );
 

--- a/playwright-acceptance-tests/src/support/utils.ts
+++ b/playwright-acceptance-tests/src/support/utils.ts
@@ -1,0 +1,7 @@
+import type { PlaywrightWorld } from "./world";
+import type { Page } from "playwright";
+
+export function requirePage(world: PlaywrightWorld): Page {
+  if (!world.page) throw new Error("Playwright page is not initialised");
+  return world.page;
+}

--- a/playwright-acceptance-tests/stubs/api-stub/src/routes/static.ts
+++ b/playwright-acceptance-tests/stubs/api-stub/src/routes/static.ts
@@ -19,7 +19,18 @@ export function registerStaticRoutes(app: Express): void {
   app.post("/check-reauth-user", (_, res) => res.sendStatus(200));
 
   app.post("/reset-password-request", (_, res) =>
-    res.json({ mfaMethodType: "SMS", phoneNumberLastThree: "890" })
+    res.json({
+      mfaMethodType: "SMS",
+      phoneNumberLastThree: "890",
+      mfaMethods: [
+        {
+          id: "stub-mfa-id",
+          mfaMethodType: "SMS",
+          priority: "DEFAULT",
+          phoneNumber: "07000000000",
+        },
+      ],
+    })
   );
   app.post("/account-interventions", (_, res) =>
     res.json({

--- a/src/app.constants.ts
+++ b/src/app.constants.ts
@@ -84,6 +84,7 @@ export const PATH_NAMES = {
   SESSION_ENDED: "/session-ended",
   PASSKEY_CREATED: "/passkey-created",
   ACCOUNT_EXISTS_WITH_PASSKEY: "/account-exists",
+  JOURNEY: "/journey/:page/:event",
 };
 
 export const HREF_BACK = {

--- a/src/app.ts
+++ b/src/app.ts
@@ -113,6 +113,7 @@ import { passkeyCreatedRouter } from "./components/passkey-created/passkey-creat
 import { setGoBackHistoryMiddleware } from "./middleware/set-go-back-history-middleware.js";
 import { accountExistsWithPasskeyRouter } from "./components/account-exists-with-passkey/account-exists-with-passkey-routes.js";
 import { cannotSignInPasskeyRouter } from "./components/cannot-sign-in-passkey/cannot-sign-in-passkey-routes.js";
+import { journeyRouter } from "./components/journey/journey-routes.js";
 
 const directory_name = dirname(fileURLToPath(import.meta.url));
 
@@ -187,6 +188,7 @@ function registerRoutes(app: express.Application) {
     app.use(signInWithPasskeyRouter);
     app.use(accountExistsWithPasskeyRouter);
     app.use(cannotSignInPasskeyRouter);
+    app.use(journeyRouter);
   }
 
   // Development tools

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -51,8 +51,8 @@ export async function getNextPathAndUpdateJourney(
     nextPath: nextState.value,
     optionalPaths:
       Object.keys(nextState.meta).length > 0
-        ? nextState.meta[`${authStateMachine.id}.${nextState.value}`]
-            .optionalPaths
+        ? (nextState.meta[`${authStateMachine.id}.${nextState.value}`]
+            ?.optionalPaths ?? [])
         : [],
     goBackHistory,
   };

--- a/src/components/common/state-machine/state-machine-executor.ts
+++ b/src/components/common/state-machine/state-machine-executor.ts
@@ -15,10 +15,11 @@ import { getGoBackHistoryForTransition } from "./go-back-history.js";
 export async function getNextPathAndUpdateJourney(
   req: Request,
   res: Response,
-  event: string
+  event: string,
+  currentStateOverride?: string
 ): Promise<string> {
   const sessionId = res.locals.sessionId;
-  const currentState = req.path;
+  const currentState = currentStateOverride ? currentStateOverride : req.path;
   const sessionState = req.session.user?.journey?.nextPath;
 
   const context: AuthStateContext = {

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -364,9 +364,18 @@ const authStateMachine = createMachine<AuthStateContext>(
               target: [INTERMEDIATE_STATES.SIGN_IN_END],
             },
           ],
+          [USER_JOURNEY_EVENTS.SIGN_IN_WITHOUT_PASSKEY]: [
+            {
+              target: [PATH_NAMES.ENTER_PASSWORD],
+              meta: { reversible: true },
+            },
+          ],
         },
         meta: {
           optionalPaths: [PATH_NAMES.ENTER_PASSWORD],
+          permittedJourneyRouteEvents: [
+            USER_JOURNEY_EVENTS.SIGN_IN_WITHOUT_PASSKEY,
+          ],
         },
       },
       [PATH_NAMES.CANNOT_SIGN_IN_PASSKEY]: {

--- a/src/components/common/state-machine/state-machine.ts
+++ b/src/components/common/state-machine/state-machine.ts
@@ -372,7 +372,6 @@ const authStateMachine = createMachine<AuthStateContext>(
           ],
         },
         meta: {
-          optionalPaths: [PATH_NAMES.ENTER_PASSWORD],
           permittedJourneyRouteEvents: [
             USER_JOURNEY_EVENTS.SIGN_IN_WITHOUT_PASSKEY,
           ],

--- a/src/components/journey/journey-controller.ts
+++ b/src/components/journey/journey-controller.ts
@@ -10,11 +10,20 @@ export async function journeyGet(req: Request, res: Response): Promise<void> {
     return res.redirect(previousPageFromSession);
   }
 
+  const previousPageFromRouteParams = `/${page}`;
+
+  if (previousPageFromRouteParams !== previousPageFromSession) {
+    req.log.warn(
+      `Cannot use /journey route. Previous page in session ${previousPageFromSession} not previous page in params ${previousPageFromRouteParams}`
+    );
+    return res.redirect(previousPageFromSession);
+  }
+
   const nextPath = await getNextPathAndUpdateJourney(
     req,
     res,
     event as string,
-    `/${page}`
+    previousPageFromSession
   );
 
   return res.redirect(nextPath);

--- a/src/components/journey/journey-controller.ts
+++ b/src/components/journey/journey-controller.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from "express";
+import { authStateMachine } from "../common/state-machine/state-machine.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 
 export async function journeyGet(req: Request, res: Response): Promise<void> {
@@ -11,11 +12,21 @@ export async function journeyGet(req: Request, res: Response): Promise<void> {
   }
 
   const previousPageFromRouteParams = `/${page}`;
-
   if (previousPageFromRouteParams !== previousPageFromSession) {
     req.log.warn(
       `Cannot use /journey route. Previous page in session ${previousPageFromSession} not previous page in params ${previousPageFromRouteParams}`
     );
+    return res.redirect(previousPageFromSession);
+  }
+
+  const permittedJourneyRouteEventsForPath =
+    authStateMachine.states[previousPageFromSession].meta
+      ?.permittedJourneyRouteEvents;
+  if (
+    permittedJourneyRouteEventsForPath?.length === 0 ||
+    !permittedJourneyRouteEventsForPath?.includes(event)
+  ) {
+    req.log.error(`Event ${event} not allowed via /journey path`);
     return res.redirect(previousPageFromSession);
   }
 

--- a/src/components/journey/journey-controller.ts
+++ b/src/components/journey/journey-controller.ts
@@ -1,0 +1,15 @@
+import type { Request, Response } from "express";
+import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
+
+export async function journeyGet(req: Request, res: Response): Promise<void> {
+  const { event, page } = req.params
+
+  const nextPath = await getNextPathAndUpdateJourney(
+    req,
+    res,
+    event as string,
+    `/${page}`
+  );
+
+  return res.redirect(nextPath);
+}

--- a/src/components/journey/journey-controller.ts
+++ b/src/components/journey/journey-controller.ts
@@ -1,32 +1,17 @@
 import type { Request, Response } from "express";
 import { authStateMachine } from "../common/state-machine/state-machine.js";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
+import type { JourneyRouteParams } from "./types.js";
 
 export async function journeyGet(req: Request, res: Response): Promise<void> {
-  const { event, page } = req.params;
+  const { event, page }: JourneyRouteParams = req.params;
   const previousPageFromSession = req.session.user.journey.nextPath;
 
-  if (!event || !page) {
-    req.log.warn("Missing params");
-    return res.redirect(previousPageFromSession);
-  }
-
-  const previousPageFromRouteParams = `/${page}`;
-  if (previousPageFromRouteParams !== previousPageFromSession) {
-    req.log.warn(
-      `Cannot use /journey route. Previous page in session ${previousPageFromSession} not previous page in params ${previousPageFromRouteParams}`
-    );
-    return res.redirect(previousPageFromSession);
-  }
-
-  const permittedJourneyRouteEventsForPath =
-    authStateMachine.states[previousPageFromSession].meta
-      ?.permittedJourneyRouteEvents;
   if (
-    permittedJourneyRouteEventsForPath?.length === 0 ||
-    !permittedJourneyRouteEventsForPath?.includes(event)
+    !routeParamsDefined(req, event, page) ||
+    !routePageMatchesSessionPage(req, page, previousPageFromSession) ||
+    !eventPermittedForPage(req, previousPageFromSession, event)
   ) {
-    req.log.error(`Event ${event} not allowed via /journey path`);
     return res.redirect(previousPageFromSession);
   }
 
@@ -38,4 +23,45 @@ export async function journeyGet(req: Request, res: Response): Promise<void> {
   );
 
   return res.redirect(nextPath);
+}
+
+function routeParamsDefined(req: Request, event?: string, page?: string) {
+  if (!event || !page) {
+    req.log.warn("Missing params");
+    return false;
+  }
+  return true;
+}
+
+function routePageMatchesSessionPage(
+  req: Request,
+  page: string,
+  previousPageFromSession: string
+) {
+  const previousPageFromRouteParams = `/${page}`;
+  if (previousPageFromRouteParams !== previousPageFromSession) {
+    req.log.warn(
+      `Cannot use /journey route. Previous page in session ${previousPageFromSession} not previous page in params ${previousPageFromRouteParams}`
+    );
+    return false;
+  }
+  return true;
+}
+
+function eventPermittedForPage(
+  req: Request,
+  previousPageFromSession: string,
+  event: string
+) {
+  const permittedJourneyRouteEventsForPath =
+    authStateMachine.states[previousPageFromSession].meta
+      ?.permittedJourneyRouteEvents;
+  if (
+    permittedJourneyRouteEventsForPath?.length === 0 ||
+    !permittedJourneyRouteEventsForPath?.includes(event)
+  ) {
+    req.log.error(`Event ${event} not allowed via /journey path`);
+    return false;
+  }
+  return true;
 }

--- a/src/components/journey/journey-controller.ts
+++ b/src/components/journey/journey-controller.ts
@@ -2,7 +2,13 @@ import type { Request, Response } from "express";
 import { getNextPathAndUpdateJourney } from "../common/state-machine/state-machine-executor.js";
 
 export async function journeyGet(req: Request, res: Response): Promise<void> {
-  const { event, page } = req.params
+  const { event, page } = req.params;
+  const previousPageFromSession = req.session.user.journey.nextPath;
+
+  if (!event || !page) {
+    req.log.warn("Missing params");
+    return res.redirect(previousPageFromSession);
+  }
 
   const nextPath = await getNextPathAndUpdateJourney(
     req,

--- a/src/components/journey/journey-routes.ts
+++ b/src/components/journey/journey-routes.ts
@@ -1,5 +1,10 @@
 import * as express from "express";
+import { PATH_NAMES } from "../../app.constants.js";
+import { validateSessionMiddleware } from "../../middleware/session-middleware.js";
+import { journeyGet } from "./journey-controller.js";
 
-const router = express.Router()
+const router = express.Router();
 
-export { router as journeyRouter }
+router.get(PATH_NAMES.JOURNEY, validateSessionMiddleware, journeyGet);
+
+export { router as journeyRouter };

--- a/src/components/journey/journey-routes.ts
+++ b/src/components/journey/journey-routes.ts
@@ -1,0 +1,5 @@
+import * as express from "express";
+
+const router = express.Router()
+
+export { router as journeyRouter }

--- a/src/components/journey/tests/journey-controller-integration.test.ts
+++ b/src/components/journey/tests/journey-controller-integration.test.ts
@@ -12,7 +12,6 @@ describe("Integration::journey controller", () => {
   let capturedSession: UserSession;
 
   before(async () => {
-
     const { createApp } = await esmock(
       "../../../app.js",
       {},

--- a/src/components/journey/tests/journey-controller-integration.test.ts
+++ b/src/components/journey/tests/journey-controller-integration.test.ts
@@ -66,4 +66,13 @@ describe("Integration::journey controller", () => {
       ]);
     });
   });
+
+  describe("validation failure", () => {
+    it("should redirect to session nextPath when page in route params does not match session", async () => {
+      await request(app)
+        .get("/journey/some-other-page/A_VALID_EVENT")
+        .expect("Location", PATH_NAMES.SIGN_IN_WITH_PASSKEY)
+        .expect(302);
+    });
+  });
 });

--- a/src/components/journey/tests/journey-controller-integration.test.ts
+++ b/src/components/journey/tests/journey-controller-integration.test.ts
@@ -1,0 +1,69 @@
+import { describe } from "mocha";
+import { expect, sinon } from "../../../../test/utils/test-utils.js";
+import request from "supertest";
+import { PATH_NAMES } from "../../../app.constants.js";
+import type { NextFunction, Request, Response } from "express";
+import { getPermittedJourneyForPath } from "../../../../test/helpers/session-helper.js";
+import esmock from "esmock";
+import type { UserSession } from "../../../types.js";
+
+describe("Integration::journey controller", () => {
+  let app: any;
+  let capturedSession: UserSession;
+
+  before(async () => {
+
+    const { createApp } = await esmock(
+      "../../../app.js",
+      {},
+      {
+        "../../../middleware/session-middleware.js": {
+          validateSessionMiddleware: sinon.fake(function (
+            req: Request,
+            res: Response,
+            next: NextFunction
+          ): void {
+            res.locals.sessionId = "test-session-id";
+            res.locals.clientSessionId = "test-client-session-id";
+            res.locals.persistentSessionId = "test-persistent-session-id";
+            res.locals.supportPasskeyUsage = true;
+
+            req.session.user = {
+              email: "test@test.com",
+              journey: getPermittedJourneyForPath(
+                PATH_NAMES.SIGN_IN_WITH_PASSKEY
+              ),
+            };
+
+            capturedSession = req.session.user;
+
+            next();
+          }),
+        },
+      }
+    );
+
+    app = await createApp();
+  });
+
+  after(() => {
+    sinon.restore();
+    app = undefined;
+  });
+
+  describe("success", () => {
+    it("should redirect to /enter-password and update session when transitioning from /sign-in-passkey with SIGN_IN_WITHOUT_PASSKEY event", async () => {
+      await request(app)
+        .get("/journey/sign-in-passkey/SIGN_IN_WITHOUT_PASSKEY")
+        .expect("Location", PATH_NAMES.ENTER_PASSWORD)
+        .expect(302);
+
+      expect(capturedSession.journey.nextPath).to.equal(
+        PATH_NAMES.ENTER_PASSWORD
+      );
+      expect(capturedSession.journey.goBackHistory).to.deep.equal([
+        PATH_NAMES.SIGN_IN_WITH_PASSKEY,
+      ]);
+    });
+  });
+});

--- a/src/components/journey/tests/journey-controller.test.ts
+++ b/src/components/journey/tests/journey-controller.test.ts
@@ -43,6 +43,35 @@ describe("journey controller", () => {
         expect(res.redirect).to.have.been.calledWith(expectedNextPath);
       });
     });
+
+    describe("validation", () => {
+      [
+        { page: undefined, event: "SOME_EVENT", description: "page is missing" },
+        { page: "next-page", event: undefined, description: "event is missing" },
+        { page: undefined, event: undefined, description: "both page and event are missing" },
+      ].forEach(({ page, event, description }) => {
+        it(`should redirect to previous page when ${description}`, async () => {
+          const previousPageInSession = "/next-page";
+          const expectedNextPath = "/next-page";
+
+          req.params = { event, page };
+          req.session.user = {
+            journey: { nextPath: previousPageInSession, optionalPaths: [] },
+          };
+
+          const { journeyGet, fakeGetNextPathAndUpdateJourney } =
+            await setupStateMachineMock(
+              previousPageInSession,
+              expectedNextPath,
+              event
+            );
+
+          await journeyGet(req as Request, res as Response);
+
+          expect(fakeGetNextPathAndUpdateJourney).not.have.been.called;
+          expect(res.redirect).to.have.been.calledWith(previousPageInSession);
+        })})
+    })
   });
 
   const setupStateMachineMock = async (

--- a/src/components/journey/tests/journey-controller.test.ts
+++ b/src/components/journey/tests/journey-controller.test.ts
@@ -1,0 +1,75 @@
+import { mockResponse, type RequestOutput, type ResponseOutput } from "mock-req-res";
+import { createMockRequest } from "../../../../test/helpers/mock-request-helper.js";
+import { PATH_NAMES } from "../../../app.constants.js";
+import { expect } from "chai";
+import { describe } from "mocha";
+import { sinon } from "../../../../test/utils/test-utils.js";
+import type { Request, Response } from "express";
+import esmock from "esmock";
+
+describe("journey controller", () => {
+  let req: RequestOutput;
+  let res: ResponseOutput;
+
+  beforeEach(() => {
+    req = createMockRequest(PATH_NAMES.JOURNEY);
+    res = mockResponse();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("journeyGet", () => {
+    describe("success", () => {
+      it("should redirect to next page when validation passes", async () => {
+        const previousPage = "/previous-page";
+        const event = "EVENT_TO_GO_NEXT_PAGE";
+        const expectedNextPath = "/next-page";
+
+        req.params = { event, page: "previous-page" };
+        req.session.user = { journey: { nextPath: previousPage, optionalPaths: [] } };
+
+        const { journeyGet, fakeGetNextPathAndUpdateJourney } = await setupStateMachineMock(previousPage, expectedNextPath, event);
+
+        await journeyGet(req as Request, res as Response);
+
+        expect(fakeGetNextPathAndUpdateJourney).to.have.been.calledWith(
+          req,
+          res,
+          event,
+          previousPage
+        );
+        expect(res.redirect).to.have.been.calledWith(expectedNextPath);
+      });
+    });
+  });
+
+  const setupStateMachineMock = async (
+    previousPage: string,
+    expectedNextPath: string,
+    event?: string
+  )=> {
+    const fakeGetNextPathAndUpdateJourney =
+      sinon.fake.resolves(expectedNextPath);
+
+    const { journeyGet } = await esmock("../journey-controller.js", {
+      "../../common/state-machine/state-machine-executor.js": {
+        getNextPathAndUpdateJourney: fakeGetNextPathAndUpdateJourney,
+      },
+      "../../common/state-machine/state-machine.js": {
+        authStateMachine: {
+          states: {
+            [previousPage]: {
+              meta: {
+                allowedEventsFromJourney: event ? [event] : [],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    return { journeyGet, fakeGetNextPathAndUpdateJourney };
+  }
+});

--- a/src/components/journey/tests/journey-controller.test.ts
+++ b/src/components/journey/tests/journey-controller.test.ts
@@ -76,6 +76,64 @@ describe("journey controller", () => {
         expect(res.redirect).to.have.been.calledWith(previousPageInSession);
       });
 
+      it("should not allow the use of /journey if the event is not included in permittedJourneyRouteEvents", async () => {
+        const previousPageInSession = "/next-page";
+        const previousPageInRouteParams = "next-page";
+        const eventInRouteParams = "EVENT_TO_GO_NEXT_PAGE";
+        const expectedNextPath = "/next-page";
+
+        req.params = {
+          event: eventInRouteParams,
+          page: previousPageInRouteParams,
+        };
+        req.session.user = {
+          journey: { nextPath: previousPageInSession, optionalPaths: [] },
+        };
+
+        const { journeyGet, fakeGetNextPathAndUpdateJourney } =
+          await setupStateMachineMock(
+            previousPageInSession,
+            expectedNextPath,
+            undefined
+          );
+
+        await journeyGet(req as Request, res as Response);
+
+        expect(fakeGetNextPathAndUpdateJourney).not.have.been.called;
+        expect(res.redirect).to.have.been.calledWith(previousPageInSession);
+      });
+
+      it("should not allow the use of /journey if the state has no permittedJourneyRouteEvents defined", async () => {
+        const previousPageInSession = "/next-page";
+        const event = "SOME_EVENT";
+        const expectedNextPath = "/next-page";
+        const fakeGetNextPathAndUpdateJourney =
+          sinon.fake.resolves(expectedNextPath);
+
+        const { journeyGet } = await esmock("../journey-controller.js", {
+          "../../common/state-machine/state-machine-executor.js": {
+            getNextPathAndUpdateJourney: fakeGetNextPathAndUpdateJourney,
+          },
+          "../../common/state-machine/state-machine.js": {
+            authStateMachine: {
+              states: {
+                [previousPageInSession]: {},
+              },
+            },
+          },
+        });
+
+        req.params = { event, page: "next-page" };
+        req.session.user = {
+          journey: { nextPath: previousPageInSession, optionalPaths: [] },
+        };
+
+        await journeyGet(req as Request, res as Response);
+
+        expect(fakeGetNextPathAndUpdateJourney).not.have.been.called;
+        expect(res.redirect).to.have.been.calledWith(previousPageInSession);
+      });
+
       [
         {
           page: undefined,
@@ -135,7 +193,7 @@ describe("journey controller", () => {
           states: {
             [previousPage]: {
               meta: {
-                allowedEventsFromJourney: event ? [event] : [],
+                permittedJourneyRouteEvents: event ? [event] : [],
               },
             },
           },

--- a/src/components/journey/tests/journey-controller.test.ts
+++ b/src/components/journey/tests/journey-controller.test.ts
@@ -1,4 +1,8 @@
-import { mockResponse, type RequestOutput, type ResponseOutput } from "mock-req-res";
+import {
+  mockResponse,
+  type RequestOutput,
+  type ResponseOutput,
+} from "mock-req-res";
 import { createMockRequest } from "../../../../test/helpers/mock-request-helper.js";
 import { PATH_NAMES } from "../../../app.constants.js";
 import { expect } from "chai";
@@ -28,9 +32,12 @@ describe("journey controller", () => {
         const expectedNextPath = "/next-page";
 
         req.params = { event, page: "previous-page" };
-        req.session.user = { journey: { nextPath: previousPage, optionalPaths: [] } };
+        req.session.user = {
+          journey: { nextPath: previousPage, optionalPaths: [] },
+        };
 
-        const { journeyGet, fakeGetNextPathAndUpdateJourney } = await setupStateMachineMock(previousPage, expectedNextPath, event);
+        const { journeyGet, fakeGetNextPathAndUpdateJourney } =
+          await setupStateMachineMock(previousPage, expectedNextPath, event);
 
         await journeyGet(req as Request, res as Response);
 
@@ -45,10 +52,46 @@ describe("journey controller", () => {
     });
 
     describe("validation", () => {
+      it("should not allow the use of /journey if previous page from session doesn't match previous page in route params", async () => {
+        const previousPageInSession = "/some-page";
+        const previousPageInRouteParams = "other-page";
+        const event = "EVENT_TO_GO_NEXT_PAGE";
+        const expectedNextPath = "/next-page";
+
+        req.params = { event, page: previousPageInRouteParams };
+        req.session.user = {
+          journey: { nextPath: previousPageInSession, optionalPaths: [] },
+        };
+
+        const { journeyGet, fakeGetNextPathAndUpdateJourney } =
+          await setupStateMachineMock(
+            previousPageInRouteParams,
+            expectedNextPath,
+            event
+          );
+
+        await journeyGet(req as Request, res as Response);
+
+        expect(fakeGetNextPathAndUpdateJourney).not.have.been.called;
+        expect(res.redirect).to.have.been.calledWith(previousPageInSession);
+      });
+
       [
-        { page: undefined, event: "SOME_EVENT", description: "page is missing" },
-        { page: "next-page", event: undefined, description: "event is missing" },
-        { page: undefined, event: undefined, description: "both page and event are missing" },
+        {
+          page: undefined,
+          event: "SOME_EVENT",
+          description: "page is missing",
+        },
+        {
+          page: "next-page",
+          event: undefined,
+          description: "event is missing",
+        },
+        {
+          page: undefined,
+          event: undefined,
+          description: "both page and event are missing",
+        },
       ].forEach(({ page, event, description }) => {
         it(`should redirect to previous page when ${description}`, async () => {
           const previousPageInSession = "/next-page";
@@ -70,15 +113,16 @@ describe("journey controller", () => {
 
           expect(fakeGetNextPathAndUpdateJourney).not.have.been.called;
           expect(res.redirect).to.have.been.calledWith(previousPageInSession);
-        })})
-    })
+        });
+      });
+    });
   });
 
   const setupStateMachineMock = async (
     previousPage: string,
     expectedNextPath: string,
     event?: string
-  )=> {
+  ) => {
     const fakeGetNextPathAndUpdateJourney =
       sinon.fake.resolves(expectedNextPath);
 
@@ -100,5 +144,5 @@ describe("journey controller", () => {
     });
 
     return { journeyGet, fakeGetNextPathAndUpdateJourney };
-  }
+  };
 });

--- a/src/components/journey/types.ts
+++ b/src/components/journey/types.ts
@@ -1,0 +1,4 @@
+export type JourneyRouteParams = {
+  event?: string;
+  page?: string;
+};

--- a/src/components/sign-in-with-passkey/index.njk
+++ b/src/components/sign-in-with-passkey/index.njk
@@ -34,7 +34,7 @@
   </form>
 
   <p class="govuk-body">
-    <a href="/enter-password" class="govuk-link" rel="noreferrer noopener">{{'pages.signInWithPasskey.signInAnotherWayLinkText' | translate }}</a>
+    <a href="/journey/sign-in-passkey/SIGN_IN_WITHOUT_PASSKEY" class="govuk-link" rel="noreferrer noopener">{{'pages.signInWithPasskey.signInAnotherWayLinkText' | translate }}</a>
   </p>
 
 {% set ga4Params = { nonce: scriptNonce, englishPageTitle: pageTitleName, loggedInStatus: false, dynamic: false } %}

--- a/src/components/sign-in-with-passkey/sign-in-with-passkey-routes.ts
+++ b/src/components/sign-in-with-passkey/sign-in-with-passkey-routes.ts
@@ -6,6 +6,7 @@ import {
 } from "./sign-in-with-passkey-controller.js";
 import { validateSessionMiddleware } from "../../middleware/session-middleware.js";
 import { allowUserJourneyMiddleware } from "../../middleware/allow-user-journey-middleware.js";
+import { goBackMiddleware } from "../../middleware/go-back-middleware.js";
 
 const router = express.Router();
 
@@ -13,6 +14,7 @@ router.get(
   PATH_NAMES.SIGN_IN_WITH_PASSKEY,
   validateSessionMiddleware,
   allowUserJourneyMiddleware,
+  goBackMiddleware,
   signInWithPasskeyGet()
 );
 

--- a/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
+++ b/src/components/sign-in-with-passkey/tests/sign-in-with-passkey-integration.test.ts
@@ -81,6 +81,9 @@ describe("Integration:: sign in with passkey", () => {
       const options = $("#signInWithPasskeyForm").attr(
         "data-authentication-options"
       );
+      expect(
+        $('a[href="/journey/sign-in-passkey/SIGN_IN_WITHOUT_PASSKEY"]').length
+      ).to.equal(1);
       expect(options).to.equal(
         JSON.stringify(startPasskeyAssertionResponse.publicKey)
       );
@@ -187,5 +190,70 @@ describe("Integration:: sign in with passkey", () => {
           .expect("Location", PATH_NAMES.CANNOT_SIGN_IN_PASSKEY);
       });
     });
+  });
+});
+
+describe("Integration:: sign in with passkey - back navigation", () => {
+  let app: any;
+  let baseApi: string;
+  let capturedSession: any;
+
+  before(async () => {
+    process.env.SUPPORT_PASSKEY_USAGE = "1";
+
+    const { createApp } = await esmock(
+      "../../../app.js",
+      {},
+      {
+        "../../../middleware/session-middleware.js": {
+          validateSessionMiddleware: sinon.fake(function (
+            req: Request,
+            res: Response,
+            next: NextFunction
+          ): void {
+            res.locals.sessionId = commonVariables.sessionId;
+            res.locals.clientSessionId = commonVariables.clientSessionId;
+            res.locals.persistentSessionId =
+              commonVariables.diPersistentSessionId;
+            res.locals.supportPasskeyUsage = true;
+
+            req.session.user = {
+              journey: {
+                nextPath: PATH_NAMES.ENTER_PASSWORD,
+                optionalPaths: [],
+                goBackHistory: [PATH_NAMES.SIGN_IN_WITH_PASSKEY],
+              },
+            };
+
+            capturedSession = req.session;
+
+            next();
+          }),
+        },
+      }
+    );
+
+    baseApi = process.env.FRONTEND_API_BASE_URL as string;
+    app = await createApp();
+  });
+
+  after(() => {
+    delete process.env.SUPPORT_PASSKEY_USAGE;
+    sinon.restore();
+    app = undefined;
+  });
+
+  it("should render sign-in-passkey and pop goBackHistory when user navigates back from enter-password", async () => {
+    nock(baseApi)
+      .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
+      .once()
+      .reply(200, { publicKey: { challenge: "challenge", rpId: "localhost" } });
+
+    await request(app).get(PATH_NAMES.SIGN_IN_WITH_PASSKEY).expect(200);
+
+    expect(capturedSession.user.journey.goBackHistory).to.deep.equal([]);
+    expect(capturedSession.user.journey.nextPath).to.equal(
+      PATH_NAMES.SIGN_IN_WITH_PASSKEY
+    );
   });
 });

--- a/src/components/templates/pages.test.ts
+++ b/src/components/templates/pages.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
-import { pages } from "./pages";
-import { PATH_NAMES } from "../../app.constants";
+import { pages } from "./pages.js";
+import { PATH_NAMES } from "../../app.constants.js";
 
 // Pages that do not render a template
 // Add paths here to exclude them from being checked on the template list
@@ -26,6 +26,7 @@ const NON_TEMPLATE_PATHS = [
   PATH_NAMES.CREATE_PASSKEY_CALLBACK,
   PATH_NAMES.PRIVACY_POLICY,
   PATH_NAMES.PRIVACY_POLICY_NEW,
+  PATH_NAMES.JOURNEY,
 ];
 
 describe("template page listing", () => {


### PR DESCRIPTION
## What
<!-- Describe what you have changed and why -->

The `goBackHistory` has been added to the users frontend session already. We currently have the mechanism for tracking the users history during forward transitions and using stack to drive back navigation.

However, we have links on the site that do direct GET requests to the page in the a tag. These transitions are very difficult to track in the`goBackHistory` as they don't go via the state machine.

This PR introduces `/journey` which takes the "page the user was on" and the "event to go to the next page" as route params. It passes those into our state machine logic to get the next page the user should be on, adding the "page the user was on" to the `goBackHistory` so that we can track navigation via links in the stack.

See [this page](https://govukverify.atlassian.net/wiki/spaces/LO/pages/6574080144/Dynamic+Back+Behaviour) for more detail

<!-- Describe the steps required to review this PR.
For example:

1. Code review
2. Test the overall back button in a dev env. Enter /journey in the browser search bar with valid events for different pages and scenarios and see if anything breaks or behaves differently to how it currently does

## Checklist

<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->

- [x] A UCD review has been performed.

<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->

- [x] Any necessary changes to the [acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) have been made.

<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->

- [x] Documentation has been updated to reflect these changes.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
