### PR TITLE
AUT-5626: Inert after native UI

### DIFF
--- a/src/components/cannot-sign-in-passkey/index.njk
+++ b/src/components/cannot-sign-in-passkey/index.njk
@@ -88,6 +88,8 @@
         await triggerWebAuthnFlow();
       }
 
+      document.body.inert = true;
+
       cannotSignInPasskeyForm.submit();
     }
 

--- a/src/components/sign-in-with-passkey/index.njk
+++ b/src/components/sign-in-with-passkey/index.njk
@@ -66,6 +66,8 @@
         signInWithPasskeyForm.querySelector('input[name="authenticationError"]').value = `${error.name} - ${error.message}`
       }
 
+      document.body.inert = true;
+
       signInWithPasskeyForm.submit();
     }
 


### PR DESCRIPTION
## What

Makes the page inert after the user's completed that passkey native UI ceremony. This is to address an accessibility concern where the page is still clickable while the page is thinking.

## How to review

1. Code Review
2. Run locally and add a `await new Promise(r => setTimeout(r, 5000));` after the `inert=true` lines to make sure that the page is un-clickable after completing the native UI

## Checklist

- [ ] A UCD review has been performed