### PR TITLE
BAU: Refactor http to have default validate status

### DIFF
--- a/src/components/check-reauth-users/check-reauth-users-service.ts
+++ b/src/components/check-reauth-users/check-reauth-users-service.ts
@@ -24,11 +24,7 @@ export function checkReauthUsersService(
     const config = getInternalRequestConfigWithSecurityHeaders(
       {
         sessionId,
-        validationStatuses: [
-          HTTP_STATUS_CODES.OK,
-          HTTP_STATUS_CODES.BAD_REQUEST,
-          HTTP_STATUS_CODES.NOT_FOUND,
-        ],
+        validationStatuses: [HTTP_STATUS_CODES.NOT_FOUND],
         clientSessionId,
         persistentSessionId,
       },

--- a/src/components/common/send-notification/send-notification-service.ts
+++ b/src/components/common/send-notification/send-notification-service.ts
@@ -49,10 +49,6 @@ export function sendNotificationService(
           sessionId: sessionId,
           clientSessionId: clientSessionId,
           persistentSessionId: persistentSessionId,
-          validationStatuses: [
-            HTTP_STATUS_CODES.NO_CONTENT,
-            HTTP_STATUS_CODES.BAD_REQUEST,
-          ],
           userLanguage: userLanguage,
         },
         req,

--- a/src/components/common/send-notification/tests/send-notification-service.test.ts
+++ b/src/components/common/send-notification/tests/send-notification-service.test.ts
@@ -67,7 +67,7 @@ describe("send notification service", () => {
       expectedPath: API_ENDPOINTS.SEND_NOTIFICATION,
       expectedHeaders,
       expectedBody: { email, notificationType },
-      validateStatus: true,
+      validateStatus: false,
     };
 
     checkApiCallMadeWithExpectedBodyAndHeaders(
@@ -105,7 +105,7 @@ describe("send notification service", () => {
         phoneNumber,
         requestNewCode,
       },
-      validateStatus: true,
+      validateStatus: false,
     };
 
     checkApiCallMadeWithExpectedBodyAndHeaders(

--- a/src/components/enter-password/enter-password-service.ts
+++ b/src/components/enter-password/enter-password-service.ts
@@ -45,11 +45,7 @@ export function enterPasswordService(
         {
           sessionId: sessionId,
           clientSessionId: clientSessionId,
-          validationStatuses: [
-            HTTP_STATUS_CODES.OK,
-            HTTP_STATUS_CODES.UNAUTHORIZED,
-            HTTP_STATUS_CODES.BAD_REQUEST,
-          ],
+          validationStatuses: [HTTP_STATUS_CODES.UNAUTHORIZED],
           persistentSessionId: persistentSessionId,
         },
         req,

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -86,7 +86,13 @@ export function getInternalRequestConfigWithSecurityHeaders(
 
   if (options.validationStatuses) {
     config.validateStatus = function (status: number) {
-      return options.validationStatuses.includes(status);
+      const isWithinDefaultValidateStatus =
+        status >= HTTP_STATUS_CODES.OK &&
+        status <= HTTP_STATUS_CODES.BAD_REQUEST;
+      return (
+        isWithinDefaultValidateStatus ||
+        options.validationStatuses.includes(status)
+      );
     };
   }
 

--- a/test/unit/utils/http.test.ts
+++ b/test/unit/utils/http.test.ts
@@ -211,7 +211,7 @@ describe("getInternalRequestConfigWithSecurityHeaders", () => {
   });
 
   it("should set the relevant validation status function", () => {
-    const validStatus = HTTP_STATUS_CODES.OK;
+    const validStatus = HTTP_STATUS_CODES.UNAUTHORIZED;
 
     const actualConfig = getInternalRequestConfigWithSecurityHeaders(
       {
@@ -223,6 +223,10 @@ describe("getInternalRequestConfigWithSecurityHeaders", () => {
 
     expect(actualConfig.validateStatus(validStatus)).to.eq(true);
     expect(actualConfig.validateStatus(HTTP_STATUS_CODES.BAD_REQUEST)).to.eq(
+      true
+    );
+    expect(actualConfig.validateStatus(HTTP_STATUS_CODES.OK)).to.eq(true);
+    expect(actualConfig.validateStatus(HTTP_STATUS_CODES.FORBIDDEN)).to.eq(
       false
     );
   });


### PR DESCRIPTION
## What

By default, axios treats any HTTP responses with status >= 200 && status < 300 as an error and throws an exception.
In http.ts, we explicitly add validateStatus where the status is between 200 and 400 (inclusive). This means, axios will not throw if the status code is 200 <= code <= 400. Instead, we handle these ourselves.

However, if you specify a validationStatuses array in the `getInternalRequestConfigWithSecurityHeaders` function, it overrides the default validateStatus specified in http.ts.
Replace this behaviour and instead add any extra status codes to the default. EG if you specify 401 as a validationStatus, axios will not throw when 200 <= code <= 400 and 401.

## How to review

1. Code review

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->


<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->


<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->


<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->


## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
