### PR TITLE
BAU: Evaluate isHidden on request, rather than baking into CONTACT_FORM_STRUCTURE

### DIFF
--- a/src/components/contact-us/structure/contact-us-structure-utils.ts
+++ b/src/components/contact-us/structure/contact-us-structure-utils.ts
@@ -5,7 +5,7 @@ export function getThemeRadioButtonsFromStructure(
   structure: Map<string, Theme>
 ): TemplateThemeRadioButtons[] {
   return Array.from(structure)
-    .filter(([, theme]) => !theme.isHidden)
+    .filter(([, theme]) => !theme.isHidden?.())
     .map(([themeName, theme]) => ({
       value: themeName,
       mainTextKey: theme.radio.mainTextKey,

--- a/src/components/contact-us/structure/contact-us-structure.ts
+++ b/src/components/contact-us/structure/contact-us-structure.ts
@@ -10,7 +10,7 @@ export interface Theme {
     hintTextKey?: string;
   };
   subThemes?: ContactFormStructure;
-  isHidden?: boolean;
+  isHidden?: () => boolean;
 }
 
 export const CONTACT_FORM_STRUCTURE: ContactFormStructure = new Map([
@@ -146,7 +146,7 @@ export const CONTACT_FORM_STRUCTURE: ContactFormStructure = new Map([
               hintTextKey:
                 "pages.contactUsFurtherInformation.signingIn.section1.radio8Hint",
             },
-            isHidden: !enablePasskeyContactForm(),
+            isHidden: () => !enablePasskeyContactForm(),
           },
         ],
         [

--- a/src/components/contact-us/tests/contact-us-structure-utils.test.ts
+++ b/src/components/contact-us/tests/contact-us-structure-utils.test.ts
@@ -40,6 +40,38 @@ describe("contact-us-structure-utils", () => {
     });
   });
 
+  it("should not return theme if it's hidden", () => {
+    const mockContactUsStructure: ContactFormStructure = new Map([
+      ["theme1", createTheme("nextPage1", "mainText1")],
+      [
+        "hiddenTheme1",
+        createTheme(
+          "hiddenNextPage2",
+          "hiddenMainText2",
+          undefined,
+          () => true
+        ),
+      ],
+      [
+        "shownTheme1",
+        createTheme("shownNextPage3", "shownMainText3", undefined, () => false),
+      ],
+    ]);
+
+    expect(getThemeRadioButtonsFromStructure(mockContactUsStructure)).to.eql([
+      {
+        value: "theme1",
+        mainTextKey: "mainText1",
+        hintTextKey: undefined,
+      },
+      {
+        value: "shownTheme1",
+        mainTextKey: "shownMainText3",
+        hintTextKey: undefined,
+      },
+    ]);
+  });
+
   describe("getTitleFromTheme", () => {
     it("should return the correct title", () => {
       const mockSubTheme = createTheme("theme", "nextPage", "mainText");
@@ -70,11 +102,13 @@ describe("contact-us-structure-utils", () => {
 const createTheme = (
   nextPageContent: string,
   mainText: string,
-  hintText?: string
+  hintText?: string,
+  isHidden?: () => boolean
 ): Theme => ({
   nextPageContent: nextPageContent,
   radio: {
     mainTextKey: mainText,
     hintTextKey: hintText,
   },
+  isHidden: isHidden,
 });


### PR DESCRIPTION
## What

When trying to render the journey map, we were getting errors because one of the isHidden properties in the CONTACT_FORM_STRUCTURE needed an environment variable. These envvars aren't available in the journey map.

This change makes it so that isHidden is now a function that returns a boolean, rather than a direct reference to the boolean that needs to be evaluated upon using the CONTACT_FORM_STRUCTURE in the journey map.

## How to review

1. Code Review

## Testing

I've tested setting `ENABLE_PASSKEY_CONTACT_FORM` to `0`, `1`, and not specifying it at all, to ensure the passkey contact form option was displayed/not displayed correctly.