### PR TITLE
BAU: Enable Passkeys prompt in staging for mobile

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -549,7 +549,7 @@ Mappings:
       SupportNewInternationalSms: "No"
       EnablePasskeyContactForm: "Yes"
       SupportSingleFactorAccountDeletion: "No"
-      PasskeyPromptClientAllowList: "nsR2wZ7EebJ2VOzE1LUa9iAVadunWQP3,EMGmY82k-92QSakDl_9keKDFmZY" # perf-test client, home client
+      PasskeyPromptClientAllowList: "EB2EC91OpyzuhI7C2nw1aiEK2q8,3NKFv679oYlMdyrhKErrTGbzBy2h8rrd,nsR2wZ7EebJ2VOzE1LUa9iAVadunWQP3,EMGmY82k-92QSakDl_9keKDFmZY" # mobile sts, rp-stub, perf-test client, home client
       serviceDownPageRegistry: "058264536367.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository-containerrepository-5mf9vzblyt5l"
     integration:
       DeployServiceDownPage: "Yes"


### PR DESCRIPTION
## What

Enable Passkeys prompt in staging for mobile

As per the implementation plan the prompt should be enabled permanently in advance of go-live: https://govukverify.atlassian.net/wiki/spaces/LO/pages/6710690976/DCP-4931+Passkeys+-+Implementation+Plan+-+Jul+2026#Pre-live-tasks

Will receive confirmation from mobile once testing is complete on whether this can remain permanent.

This is a revert and has been tested before

## Related

Reverts govuk-one-login/authentication-frontend#3512

