### PR TITLE
AUT-5674: Bug fix - couldn't sign in with passkey after validation error

### DIFF
--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-controller.ts
@@ -26,9 +26,12 @@ export function cannotSignInPasskeyGet(
     }
 
     const authenticationOptions = startPasskeyAssertionResult.data;
+    req.session.user.cannotSignInPasskeyAuthOptions = JSON.stringify(
+      authenticationOptions.publicKey
+    );
 
     res.render("cannot-sign-in-passkey/index.njk", {
-      authenticationOptions: JSON.stringify(authenticationOptions.publicKey),
+      authenticationOptions: req.session.user.cannotSignInPasskeyAuthOptions,
       is2FAJourney: req.session.user.isMfaRequired,
     });
   };

--- a/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-validation.ts
+++ b/src/components/cannot-sign-in-passkey/cannot-sign-in-passkey-validation.ts
@@ -23,6 +23,7 @@ const postValidationLocals = function locals(
   req: Request
 ): Record<string, unknown> {
   return {
+    authenticationOptions: req.session.user.cannotSignInPasskeyAuthOptions,
     is2FAJourney: req.session.user.isMfaRequired,
   };
 };

--- a/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
+++ b/src/components/cannot-sign-in-passkey/tests/cannot-sign-in-passkey-integration.test.ts
@@ -37,6 +37,7 @@ describe("Integration:: cannot sign in passkey", () => {
               commonVariables.diPersistentSessionId;
 
             req.session.user = {
+              ...req.session.user,
               journey: getPermittedJourneyForPath(
                 PATH_NAMES.CANNOT_SIGN_IN_PASSKEY
               ),
@@ -83,12 +84,10 @@ describe("Integration:: cannot sign in passkey", () => {
       const res = await request(app)
         .get(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
         .expect(200);
-      const $ = cheerio.load(res.text);
-      const options = $("#cannotSignInPasskeyForm").attr(
-        "data-authentication-options"
-      );
-      expect(options).to.equal(
-        JSON.stringify(startPasskeyAssertionResponse.publicKey)
+
+      expectDataAuthenticationOptionsToBeRendered(
+        startPasskeyAssertionResponse.publicKey,
+        res.text
       );
     });
   });
@@ -96,11 +95,18 @@ describe("Integration:: cannot sign in passkey", () => {
   describe("POST /cannot-sign-in-passkey", () => {
     let token: string;
     let cookies: string;
+    const fakeStartPasskeyAssertionOptions = {
+      publicKey: {
+        challenge: "test",
+        rpId: "localhost",
+      },
+    };
+
     before(async () => {
       nock(baseApi)
         .post(API_ENDPOINTS.START_PASSKEY_ASSERTION)
         .once()
-        .reply(200, { challenge: "test", rpId: "localhost" });
+        .reply(200, fakeStartPasskeyAssertionOptions);
 
       ({ token, cookies } = extractCsrfTokenAndCookies(
         await request(app).get(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
@@ -208,7 +214,7 @@ describe("Integration:: cannot sign in passkey", () => {
       });
 
       it("should return a validation error when no option is selected", async () => {
-        await request(app)
+        const res = await request(app)
           .post(PATH_NAMES.CANNOT_SIGN_IN_PASSKEY)
           .type("form")
           .set("Cookie", cookies)
@@ -223,7 +229,23 @@ describe("Integration:: cannot sign in passkey", () => {
             ).to.contains("Select what you would like to do");
           })
           .expect(400);
+
+        expectDataAuthenticationOptionsToBeRendered(
+          fakeStartPasskeyAssertionOptions.publicKey,
+          res.text
+        );
       });
     });
   });
 });
+
+function expectDataAuthenticationOptionsToBeRendered(
+  expectedOptions: object,
+  resText: string
+) {
+  const $ = cheerio.load(resText);
+  const options = $("#cannotSignInPasskeyForm").attr(
+    "data-authentication-options"
+  );
+  expect(options).to.equal(JSON.stringify(expectedOptions));
+}

--- a/src/components/templates/pages.ts
+++ b/src/components/templates/pages.ts
@@ -63,6 +63,7 @@ export const pages: Record<string, Page | PageVariant[]> = {
       name: "1FA journey",
       template: "cannot-sign-in-passkey/index.njk",
       options: {
+        authenticationOptions: "",
         is2FAJourney: false,
       },
     },
@@ -70,6 +71,7 @@ export const pages: Record<string, Page | PageVariant[]> = {
       name: "2FA journey",
       template: "cannot-sign-in-passkey/index.njk",
       options: {
+        authenticationOptions: "",
         is2FAJourney: true,
       },
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,7 @@ export interface UserSession {
   browserSupportsWebAuthn?: boolean;
   backendIndicatesPasskeyPromptShouldBeSkipped?: boolean;
   isInPasskeyPhasedRollout?: boolean;
+  cannotSignInPasskeyAuthOptions?: string;
 }
 
 export interface UserSessionClient {


### PR DESCRIPTION
## What

When rendering the validation error screen of the `/cannot-sign-in-passkey` page, we weren't passing in the `authenticationOptions` to the `postValidationLocals` function.

This change generates the `authenticationOptions` as before within the GET controller, but then saves it in `req.session.user.cannotSignInPasskeyAuthOptions`. This can then be used later in the validation screen.

Refreshing the page will still load new options, as before.

## How to review

1. Code Review
1. Test in authdev3 (see repro steps on [the Jira ticket](https://govukverify.atlassian.net/browse/AUT-5674))