### PR TITLE
AUT-5549: PASSKEYS GO LIVE: Remove use of allowlist when deciding whether to show passkey prompt

### DIFF
--- a/src/utils/passkeys-helper.test.ts
+++ b/src/utils/passkeys-helper.test.ts
@@ -172,7 +172,7 @@ describe("passkeys helper", () => {
 
     testCases.forEach(({ conditions, expected }, index) => {
       it(`[${index}] should return ${expected} when conditions=${JSON.stringify(conditions)}`, () => {
-        process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
+        process.env.PASSKEY_PROMPT_CLIENT_DENY_LIST = "invalid-rp-client-id";
 
         const req = createMockRequest("", {
           session: {
@@ -208,52 +208,32 @@ describe("passkeys helper", () => {
       });
     });
 
-    describe("shouldPromptToRegisterPasskeyDependingOnAllowlistAndDenylist", () => {
+    describe("shouldPromptToRegisterPasskeyDependingOnDenylist", () => {
       const testCases = [
         {
-          description:
-            "rpClientId is on the deny list even if on the allow list",
-          allowList: "valid-rp-client-id",
-          denyList: "valid-rp-client-id",
+          description: "rpClientId is on the deny list",
+          denyList: "an-rp-client-id",
           expected: false,
         },
         {
-          description:
-            "rpClientId is on the deny list even if on the allow list with multiple entries",
-          allowList: "other-client-id,valid-rp-client-id,another-client-id",
-          denyList: "valid-rp-client-id",
+          description: "rpClientId is on the deny list with multiple entries",
+          denyList: "other-client-id,an-rp-client-id,another-client-id",
           expected: false,
         },
         {
-          description:
-            "rpClientId is on the allow list but not on the deny list",
-          allowList: "other-client-id,valid-rp-client-id,another-client-id",
+          description: "rpClientId is not on the deny list",
           denyList: "some-other-client-id",
           expected: true,
-        },
-        {
-          description: "allowList is empty",
-          allowList: "",
-          denyList: "some-other-client-id",
-          expected: false,
         },
         {
           description: "denyList is empty",
-          allowList: "valid-rp-client-id",
           denyList: "",
           expected: true,
         },
-        {
-          description: "both allowList and denyList are empty",
-          allowList: "",
-          denyList: "",
-          expected: false,
-        },
       ];
 
-      testCases.forEach(({ description, allowList, denyList, expected }, index) => {
+      testCases.forEach(({ description, denyList, expected }, index) => {
         it(`[${index}] should return ${expected} when ${description}`, () => {
-          process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = allowList;
           process.env.PASSKEY_PROMPT_CLIENT_DENY_LIST = denyList;
 
           const req = createMockRequest("", {
@@ -272,7 +252,7 @@ describe("passkeys helper", () => {
                 isCommonPasswordResetJourney: false,
               },
               client: {
-                rpClientId: "valid-rp-client-id",
+                rpClientId: "an-rp-client-id",
               },
             },
           });
@@ -319,12 +299,15 @@ describe("passkeys helper", () => {
     ];
 
     passwordResetTestCases.forEach(
-      ({
-        isPasswordResetJourney,
-        withinForcedPasswordResetJourney,
-        isCommonPasswordResetJourney,
-        expectedShouldPromptToRegister,
-      }, index) => {
+      (
+        {
+          isPasswordResetJourney,
+          withinForcedPasswordResetJourney,
+          isCommonPasswordResetJourney,
+          expectedShouldPromptToRegister,
+        },
+        index
+      ) => {
         it(`[${index}] should return ${expectedShouldPromptToRegister} when passwordResetJourney=${isPasswordResetJourney}, withinForcedPasswordResetJourney=${withinForcedPasswordResetJourney} and isCommonPasswordResetJourney=${isCommonPasswordResetJourney}`, () => {
           process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
 
@@ -378,7 +361,10 @@ describe("passkeys helper", () => {
       },
     ];
     mfaVariantTestCases.forEach(
-      ({ isMfaRequired, isUpliftRequired, expectedShouldPromptToRegister }, index) => {
+      (
+        { isMfaRequired, isUpliftRequired, expectedShouldPromptToRegister },
+        index
+      ) => {
         it(`[${index}] should return ${expectedShouldPromptToRegister} when isMfaRequired=${isMfaRequired} and isUpliftRequired=${isUpliftRequired}`, () => {
           process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
 
@@ -449,12 +435,15 @@ describe("passkeys helper", () => {
     ];
 
     testCases.forEach(
-      ({
-        browserSupportsWebAuthn,
-        hasActivePasskey,
-        supportPasskeyUsage,
-        expected,
-      }, index) => {
+      (
+        {
+          browserSupportsWebAuthn,
+          hasActivePasskey,
+          supportPasskeyUsage,
+          expected,
+        },
+        index
+      ) => {
         it(`[${index}] should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, supportPasskeyUsage=${supportPasskeyUsage}`, () => {
           const req = {
             session: { user: { browserSupportsWebAuthn, hasActivePasskey } },

--- a/src/utils/passkeys-helper.test.ts
+++ b/src/utils/passkeys-helper.test.ts
@@ -170,8 +170,8 @@ describe("passkeys helper", () => {
       },
     ];
 
-    testCases.forEach(({ conditions, expected }) => {
-      it(`should return ${expected} when conditions=${JSON.stringify(conditions)}`, () => {
+    testCases.forEach(({ conditions, expected }, index) => {
+      it(`[${index}] should return ${expected} when conditions=${JSON.stringify(conditions)}`, () => {
         process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
 
         const req = createMockRequest("", {
@@ -251,8 +251,8 @@ describe("passkeys helper", () => {
         },
       ];
 
-      testCases.forEach(({ description, allowList, denyList, expected }) => {
-        it(`should return ${expected} when ${description}`, () => {
+      testCases.forEach(({ description, allowList, denyList, expected }, index) => {
+        it(`[${index}] should return ${expected} when ${description}`, () => {
           process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = allowList;
           process.env.PASSKEY_PROMPT_CLIENT_DENY_LIST = denyList;
 
@@ -324,8 +324,8 @@ describe("passkeys helper", () => {
         withinForcedPasswordResetJourney,
         isCommonPasswordResetJourney,
         expectedShouldPromptToRegister,
-      }) => {
-        it(`should return ${expectedShouldPromptToRegister} when passwordResetJourney=${isPasswordResetJourney}, withinForcedPasswordResetJourney=${withinForcedPasswordResetJourney} and isCommonPasswordResetJourney=${isCommonPasswordResetJourney}`, () => {
+      }, index) => {
+        it(`[${index}] should return ${expectedShouldPromptToRegister} when passwordResetJourney=${isPasswordResetJourney}, withinForcedPasswordResetJourney=${withinForcedPasswordResetJourney} and isCommonPasswordResetJourney=${isCommonPasswordResetJourney}`, () => {
           process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
 
           const req = createMockRequest("", {
@@ -378,8 +378,8 @@ describe("passkeys helper", () => {
       },
     ];
     mfaVariantTestCases.forEach(
-      ({ isMfaRequired, isUpliftRequired, expectedShouldPromptToRegister }) => {
-        it(`should return ${expectedShouldPromptToRegister} when isMfaRequired=${isMfaRequired} and isUpliftRequired=${isUpliftRequired}`, () => {
+      ({ isMfaRequired, isUpliftRequired, expectedShouldPromptToRegister }, index) => {
+        it(`[${index}] should return ${expectedShouldPromptToRegister} when isMfaRequired=${isMfaRequired} and isUpliftRequired=${isUpliftRequired}`, () => {
           process.env.PASSKEY_PROMPT_CLIENT_ALLOW_LIST = "valid-rp-client-id";
 
           const req = createMockRequest("", {
@@ -454,8 +454,8 @@ describe("passkeys helper", () => {
         hasActivePasskey,
         supportPasskeyUsage,
         expected,
-      }) => {
-        it(`should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, supportPasskeyUsage=${supportPasskeyUsage}`, () => {
+      }, index) => {
+        it(`[${index}] should return ${expected} when browserSupportsWebAuthn=${browserSupportsWebAuthn}, hasActivePasskey=${hasActivePasskey}, supportPasskeyUsage=${supportPasskeyUsage}`, () => {
           const req = {
             session: { user: { browserSupportsWebAuthn, hasActivePasskey } },
           } as any as Request;
@@ -530,8 +530,8 @@ describe("passkeys helper", () => {
       },
     ];
 
-    testCases.forEach(({ rolloutPercentage, randomValue, expected }) => {
-      it(`should return ${expected} when PASSKEY_ROLLOUT_PERCENTAGE is ${rolloutPercentage} and Math.random returns ${randomValue}`, () => {
+    testCases.forEach(({ rolloutPercentage, randomValue, expected }, index) => {
+      it(`[${index}] should return ${expected} when PASSKEY_ROLLOUT_PERCENTAGE is ${rolloutPercentage} and Math.random returns ${randomValue}`, () => {
         process.env.PASSKEY_ROLLOUT_PERCENTAGE = rolloutPercentage;
         mathRandomStub = sinon.stub(Math, "random").returns(randomValue);
 

--- a/src/utils/passkeys-helper.ts
+++ b/src/utils/passkeys-helper.ts
@@ -1,6 +1,5 @@
 import type { Request, Response } from "express";
 import {
-  getPasskeyPromptClientAllowList,
   getPasskeyRolloutPercentage,
   getPasskeyPromptClientDenyList,
 } from "../config.js";
@@ -59,10 +58,7 @@ export function isInPasskeyPhasedRollout(): boolean {
 }
 
 function isPromptableRPClientID(rpClientId: string) {
-  return (
-    getPasskeyPromptClientAllowList().includes(rpClientId) &&
-    !getPasskeyPromptClientDenyList().includes(rpClientId)
-  );
+  return !getPasskeyPromptClientDenyList().includes(rpClientId);
 }
 
 function userHasBeenOnPasswordResetJourney(req: Request) {


### PR DESCRIPTION
## What

Remove use of allowlist when deciding whether to show passkey prompt

- Only the denylist remains and is taken into account
- Allowlist infrastructure will be removed in a separate PR to avoid canary related deployment issues

The PR is part of the Passkeys Implementation Go Live steps: https://govukverify.atlassian.net/wiki/spaces/LO/pages/6710690976/DCP-4931+Passkeys+-+Implementation+Plan+-+Jul+2026#Go-Live-steps

**This change makes passkeys generally available to all clients depending on whether the other feature switches have been enabled too.  It should only be merged as part of the Passkeys Go Live**

## How to review

1. Code Review
1. Deploy to a dev environment using the [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-frontend/actions/workflows/build-deploy-frontend-dev.yml) with a test client on the denylist
1. Verify that prompts are not shown for this client, and that prompts are shown for other clients

## Checklist

- [ ] Local running `./startup -L` still works.

## Related PRs

