### PR TITLE
BAU: Refactor the shouldPromptToRegisterPasskey function

### DIFF
--- a/src/utils/passkeys-helper.ts
+++ b/src/utils/passkeys-helper.ts
@@ -9,18 +9,21 @@ export function shouldPromptToRegisterPasskey(
   req: Request,
   res: Response
 ): boolean {
-  return (
-    req.session.user?.browserSupportsWebAuthn === true &&
-    req.session.user?.hasActivePasskey === false &&
-    req.session.user?.hasSkippedPasskeyRegistration !== true &&
-    req.session.user?.backendIndicatesPasskeyPromptShouldBeSkipped !== true &&
-    !req.session.user?.reauthenticate &&
-    !userHasBeenOnPasswordResetJourney(req) &&
-    isPromptableRPClientID(req.session.client.rpClientId) &&
-    userHasLoggedInWithPasswordAnd2Fa(req) &&
-    res.locals.supportPasskeyRegistration === true &&
-    req.session.user.isInPasskeyPhasedRollout === true
-  );
+  const { user } = req.session;
+  const userHasActivePasskeyOrUnknown = user?.hasActivePasskey !== false;
+
+  if (!user?.browserSupportsWebAuthn) return false;
+  if (userHasActivePasskeyOrUnknown) return false;
+  if (user.hasSkippedPasskeyRegistration) return false;
+  if (user.backendIndicatesPasskeyPromptShouldBeSkipped) return false;
+  if (user.reauthenticate) return false;
+  if (userHasBeenOnPasswordResetJourney(req)) return false;
+  if (!isPromptableRPClientID(req.session.client.rpClientId)) return false;
+  if (!userHasLoggedInWithPasswordAnd2Fa(req)) return false;
+  if (!res.locals.supportPasskeyRegistration) return false;
+  if (!user.isInPasskeyPhasedRollout) return false;
+
+  return true;
 }
 
 export function shouldPromptToSignInWithPasskey(


### PR DESCRIPTION
## What

Previously this function boolean made up of several conditions. This was hard to follow and would get worse as we added more conditions.

Instead, use if statements and early returns to make the logic easier to read

If `hasActivePasskey` is null then the call to ADAPI failed. In this case we shouldn't show the passkey registration prompt. This meant the condition is if hasActivePasskey is null or true, then don't show the prompt. This logic is also quite hard to follow, so extract this into a variable that should make it easier to understand

Tests in dev passed: [here](https://frontend-pipeline-testreportbucket-rdhaedbpttig.s3.eu-west-2.amazonaws.com/report-2026-07-20-13-44-39/index.html?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=ASIA6GBMGN2QPZJ2JSMH%2F20260720%2Feu-west-2%2Fs3%2Faws4_request&X-Amz-Date=20260720T134729Z&X-Amz-Expires=300&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEN7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCWV1LXdlc3QtMiJHMEUCIHuUiLHYA6vZFil0yeQ8%2FIrS3kCHkta1Dn4pzfhPmL%2BhAiEA2iCugzinWnWHc6HhJfR%2BqZ9H%2B5%2Fmbxwis3RapihTVFkqigUIp%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgw5NzUwNTAyNzI0MTYiDFUj5sgs6lnELvNsjCreBG71WOqwqd5c0OXWVnvVKFse0VnesK6fTayIGZua6RxZiagFqSlEgFOOEpOPiRU4AgaVJqmYb4hIiOIvc8XwZ%2FJmd1teaThaB3%2BPc9ykddB7g1OMq7mkGMowNnA4SBJgLWXvXv%2Fb2Y1N5VlWEddxL6XLZSgRL%2BgFvNePXx7hxDZ%2FaIr32KIknNH5ox6bnFhBX5ex8MCMtzup4vDfvRuZN7wrjDyJf3H4EMvYxqAaGrOjNwYiccIZ8eXh%2FEqikzaDOTBl0M5%2B%2B2q22wa4sX48%2BOm3FISqnjnxhL5%2BQ%2FVxsGCxw0kDVqF1HpPhKCSgc8A5mKXtGiWEuo%2FvHnWZuHYdZdGjRvvrUqn4BJ4xed8gAqitdH4a3baMFYXXXawbDkPQWmceL2dureXNc7u7iGxqznJt4Fsf%2Fx9kr4vLlOgxTDo8%2FrWTmOjjP84bmCI1J7%2BrrRmIX2Such1d3DJSF5%2Bsg3uyDqbo2ZZOBDxGodPO6uEwFsBWwACuVP0Mb4uGkrqJ1ctPYeKiS3UZuJhkVhwmSnduNbnWy1UfUQuDx5akqP1ahrqIEy9GLMAKJ7CV6Pl%2BNpJNNDHj%2Fauj7Z1Or2Dr32VbsPd8s1O1zj4lbZd5gUyBxJQcocrg08uucEIC%2FPoOie5rGA%2FcIVlPTHUgU3sgLzyvxz1HXufoHqU0c4uFOrB6wZylASwVJKzSkyqJUyodAnQyqsg03WhzxRSgURaFhNFRe8UVjSqz%2BCzbdHOQPfXn7txTkFaqzcELYXuhPTuq3yAo%2BID3fV7xtVzHqX%2BpRtsk%2FtQlnL54ToG%2BEnWN8jC1xPjSBjqWAqG9Mx%2BXc42SV4noGYS%2FRd2BjtJWBQnlHgxXwgxHBar1cwSLUSDbMAvGlhStoa0NnhevO99aW2o3%2B4gZxpOTXWU%2FYvum4Z%2FFYiPsDC5U6LYxWFJjZ6qkehg7HJBx7S8hEAXiDMKjowT6hCnA2fvCgjln6l48BSYyhPyfRLwIPaHpYx6ttNVnl1axsHyADf0EILKxhGYMDOl0Eb9DyTTClexVfMBFW3Mf8uKxPUkyFNx03i5J5%2FJDO6zFAMEPhFPleEwilmVYHRHCtR2EuCthYHw4s7pyAx2uM8xppWyvlyhgr6JPkvx%2BIjDQc6xzZ6EowwCoDcy6OOioaOjAT9F9v3DIG8Do3Ajb98Eb1nki82FDTPrSaqOx&X-Amz-Signature=840d5ee5005d73f1749e99cdd4b14790457e4098695e7e5b8c45f5e1a1fdbb06&X-Amz-SignedHeaders=host&response-content-disposition=inline)

## How to review

1. Code review
2. Check if passkeys acceptance tests pass 

## Checklist

<!-- Performance analysis notice
Make sure that a performance analyst colleague in your team has been informed of any changes to the user interfaces or user journeys.

Delete this item if the PR does not change any UI or user journeys.
-->


<!-- UCD review
Changes to the user journeys, the UI or content should be reviewed by Content Design and Interaction Design before being merged.

This is to ensure:
- They have an opportunity to confirm the implementation meets expectations.
  - For example, how error screens appear and whether invalid entries can be amended.
- They can make any necessary changes to Figma designs.

It is also important that new features have a full end-to-end journey review before going live. Ensure this is done before enabling a feature flag that changes the frontend.

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

If including screenshots in the PR description, include those representing error states. Here are some examples:
- a PR that uses tables to display the screenshots https://github.com/govuk-one-login/authentication-frontend/pull/1187
- a PR that uses a dropdown to display the screenshots https://github.com/alphagov/di-infrastructure/pull/578

You can find example PRs from this repository that include screenshots through this search: https://github.com/govuk-one-login/authentication-frontend/pulls?q=is%3Apr+screenshots+is%3Aclosed+is%3Amerged

Delete this item if the PR does not change the UI.
-->


<!-- Acceptance tests have been updated
This is to avoid failures occurring after a merge. The types of changes that may impact acceptance tests might be:

- changes to user journeys
- changes to the text of page titles
- changes to the text of interactive elements (such as links).

The Test Engineers on the Authentication Team will be happy to discuss any changes if you're unsure.
-->


<!-- Associated documentation has been updated
This might include updates to the README.md, Confluence pages etc.
-->


## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one. -->

<!-- Delete this section if not needed! -->
