### PR TITLE
AUT-5556: Pass supportPasskeyUsage to check-user-exists API

### DIFF
--- a/src/components/enter-email/enter-email-controller.ts
+++ b/src/components/enter-email/enter-email-controller.ts
@@ -83,7 +83,8 @@ async function getExistingUserAndPopulateSessionData(
     email,
     clientSessionId,
     persistentSessionId,
-    req
+    req,
+    res.locals.supportPasskeyUsage === true
   );
 
   if (!result.success) {

--- a/src/components/enter-email/enter-email-service.ts
+++ b/src/components/enter-email/enter-email-service.ts
@@ -17,12 +17,14 @@ export function enterEmailService(
     emailAddress: string,
     clientSessionId: string,
     persistentSessionId: string,
-    req: Request
+    req: Request,
+    supportPasskeyUsage: boolean = false
   ): Promise<ApiResponseResult<UserExists>> {
     const response = await axios.client.post<UserExists>(
       API_ENDPOINTS.USER_EXISTS,
       {
         email: emailAddress.toLowerCase(),
+        supportPasskeyUsage,
       },
       getInternalRequestConfigWithSecurityHeaders(
         {

--- a/src/components/enter-email/tests/enter-email-service.test.ts
+++ b/src/components/enter-email/tests/enter-email-service.test.ts
@@ -49,7 +49,7 @@ describe("enter email service", () => {
     const expectedApiCallDetails = {
       expectedPath: API_ENDPOINTS.USER_EXISTS,
       expectedHeaders: expectedHeadersFromCommonVarsWithSecurityHeaders,
-      expectedBody: { email },
+      expectedBody: { email, supportPasskeyUsage: false },
     };
 
     const result = await service.userExists(

--- a/src/components/enter-email/types.ts
+++ b/src/components/enter-email/types.ts
@@ -25,6 +25,7 @@ export interface EnterEmailServiceInterface {
     emailAddress: string,
     clientSessionId: string,
     persistentSessionId: string,
-    req: Request
+    req: Request,
+    supportPasskeyUsage?: boolean
   ) => Promise<ApiResponseResult<UserExists>>;
 }


### PR DESCRIPTION
## What

Pass supportPasskeyUsage to check-user-exists API

PR no 1 of [2](https://github.com/govuk-one-login/authentication-api/pull/8638) to remove the [backend passkeys switch](https://github.com/govuk-one-login/authentication-api/blob/8b47cf38e93b8527715a8cfa72144a75da78eb81/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java#L808).

Instead of having a switch on the backend to switch signing-in with a passkey on, drive the behaviour from the [equivalent frontend switch](https://github.com/govuk-one-login/authentication-frontend/blob/1465e139b579e669c3acce5a27c7a13c1472dff1/src/config.ts#L194) by passing its value to the check-user-exists API.  This means that both switched-on and off states of the handler can be tested before go-live.  The switched-on state must be tested to prove that the calls to the data api for passkeys are configured correctly.  An error at this place would block all user journeys.

This PR will be merged before the backend version.

## How to review

1. Code Review
1. Deploy to a dev environment using the [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-frontend/actions/workflows/build-deploy-frontend-dev.yml)
1. Ensure that calls to check-user-exists work correctly

Tested in authdev1

## Checklist

- [x] Local running `./startup -L` still works.

## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/8638
