### PR TITLE
AUT-5548: Test rollout percentages using decimals

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: eslint
         name: Run ESLint
-        language: node
+        language: system
         types_or:
           - javascript
           - ts
@@ -36,7 +36,7 @@ repos:
         pass_filenames: true
       - id: prettier
         name: Run prettier
-        language: node
+        language: system
         types_or:
           - ts
           - javascript

--- a/src/utils/passkeys-helper.test.ts
+++ b/src/utils/passkeys-helper.test.ts
@@ -456,6 +456,21 @@ describe("passkeys helper", () => {
         expected: false,
       },
       {
+        rolloutPercentage: "0.25",
+        randomValue: 0.0024,
+        expected: true,
+      },
+      {
+        rolloutPercentage: "0.25",
+        randomValue: 0.0025,
+        expected: true,
+      },
+      {
+        rolloutPercentage: "0.25",
+        randomValue: 0.0026,
+        expected: false,
+      },
+      {
         rolloutPercentage: "0",
         randomValue: 0.1,
         expected: false,


### PR DESCRIPTION

## What

Test rollout percentages using decimals

Demonstrates that fractional percentages are not rounded

Includes a fix to use 'language: system' for local pre-commit hooks as the hooks were failing.

## How to review

1. Code Review

