### PR TITLE
AUT-5681: Run passkeys acceptance tests in build

### DIFF
--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -517,14 +517,14 @@ Mappings:
       OrchApiBaseUrl: "https://oidc.build.account.gov.uk"
       UseRebrand: "Yes"
       SupportPasskeyUsage: "No"
-      SupportPasskeyRegistration: "No"
-      SupportNewInternationalSms: "No"
+      SupportPasskeyRegistration: "Yes"
+      SupportNewInternationalSms: "Yes"
       EnablePasskeyContactForm: "No"
       SupportSingleFactorAccountDeletion: "No"
       PasskeyPromptClientAllowList: "Ykg9fGyY76On4e8tPvFabK5BIl65EkGH"
       PasskeyPromptClientDenyList: ""
       serviceDownPageRegistry: "058264536367.dkr.ecr.eu-west-2.amazonaws.com/service-down-page-image-repository-containerrepository-5mf9vzblyt5l"
-      PasskeyRolloutPercentage: 0
+      PasskeyRolloutPercentage: 100
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       DeployServiceDownPage: "Yes"

--- a/cloudformation/deploy/template.yaml
+++ b/cloudformation/deploy/template.yaml
@@ -640,8 +640,7 @@ Mappings:
     build:
       tags: >-
         @UI and not (@under-development or @ReauthMultiTabLogout or
-        @AcceptInternationalNumbers or @InternationalSmsSendingDisabled
-        or @PasskeysEnabled or @PasskeyUsageEnabled)
+        @AcceptInternationalNumbers or @InternationalSmsSendingDisabled)
     staging:
       tags: >-
         @UI and not (@under-development or @AccountInterventions or @new-mfa-reset-with-ipv or


### PR DESCRIPTION
## What

Run passkeys acceptance tests in build

- Switch on passkeys in build and run the passkeys acceptance tests
- Proves that the tests will run green when we ship for live proving and go-live

## How to review

1. Code Review

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/3563